### PR TITLE
[nrf noup] linker: use partition manager to set RAM

### DIFF
--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -34,6 +34,7 @@
 #endif
 
 #if USE_PARTITION_MANAGER
+
 #include <pm_config.h>
 
 #ifdef LINK_INTO_s1
@@ -56,7 +57,11 @@ _image_1_primary_slot_id = PM_S1_ID;
 #define ROM_ADDR PM_ADDRESS
 #endif /* LINK_MCUBOOT_INTO_s1 */
 #define ROM_SIZE PM_SIZE
-#else
+
+#define RAM_SIZE PM_SRAM_SIZE
+#define RAM_ADDR PM_SRAM_ADDRESS
+
+#else /* ! USE_PARTITION_MANAGER */
 
 #if !defined(CONFIG_XIP) && (CONFIG_FLASH_SIZE == 0)
 #define ROM_ADDR RAM_ADDR
@@ -76,7 +81,6 @@ _image_1_primary_slot_id = PM_S1_ID;
 #define ROM_SIZE (CONFIG_FLASH_SIZE*1K - CONFIG_FLASH_LOAD_OFFSET)
 #endif /* CONFIG_FLASH_LOAD_SIZE > 0 */
 #endif /* CONFIG_HAS_TI_CCFG */
-#endif /* USE_PARTITION_MANAGER */
 
 #if defined(CONFIG_XIP)
 #if defined(CONFIG_IS_BOOTLOADER)
@@ -91,6 +95,8 @@ _image_1_primary_slot_id = PM_S1_ID;
 #define RAM_SIZE (CONFIG_SRAM_SIZE * 1K - CONFIG_BOOTLOADER_SRAM_SIZE * 1K)
 #define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
 #endif
+
+#endif /* USE_PARTITION_MANAGER */
 
 #if defined(CONFIG_CUSTOM_SECTION_ALIGN)
 _region_min_align = CONFIG_CUSTOM_SECTION_MIN_ALIGN_SIZE;


### PR DESCRIPTION
Partition manager now supports partitioning RAM as well as FLASH.

Use the RAM_ADDR and RAM_SIZE as defined by the partition manager.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>