### PR TITLE
Init message when receiving bootstrap finish

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -3317,7 +3317,8 @@ static int handle_request(struct coap_packet *request,
 	} else if ((code & COAP_REQUEST_MASK) == COAP_METHOD_POST && r == 1 && \
 		   strncmp(options[0].value, "bs", options[0].len) == 0) {
 		engine_bootstrap_finish();
-		return 0;
+		msg->code = COAP_RESPONSE_CODE_CHANGED;
+		return lwm2m_init_message(msg);
 #endif
 	} else {
 		r = coap_options_to_path(options, r, &msg->path);


### PR DESCRIPTION
After receiving the bootstrap finish message, the client must follow the
step 3: Clean-up after successful Bootstrapping

> [...] Successful Bootstrapping means that the Bootstrap-Finish operation has
> been received by the LwM2M Client and the loaded configuration is considered
> consistent by the LwM2M Client. In this case the Bootstrap-Finish response code
> sent to the LwM2M Bootstrap-Server is 2.04 (Changed).
>
> If Bootstrapping was unsuccessful, the Bootstrap-Server Account MUST retain the
> values it had before the unsuccessful Bootstrapping sequence started and further
> statements