### PR TITLE
[nrf noup] subsys/fs: move FS partition to the end back

### DIFF
--- a/subsys/fs/pm.yml
+++ b/subsys/fs/pm.yml
@@ -2,6 +2,6 @@
 
 #ifdef CONFIG_FILE_SYSTEM_LITTLEFS
 littlefs_storage:
-  placement: {after: [mcuboot_storage, app]}
+  placement: {before: [end]}
   size: CONFIG_PM_PARTITION_SIZE_LITTLEFS
 #endif

--- a/subsys/settings/pm.yml
+++ b/subsys/settings/pm.yml
@@ -1,5 +1,5 @@
 #include <autoconf.h>
 
 settings_storage:
-  placement: {after: [mcuboot_storage, app]}
+  placement: {before: [end]}
   size: CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE


### PR DESCRIPTION
In case of the DFU capability enabled:
Up to NCS v1.1.0 any storage partition lands at the end of the flash memory.
Since v1.2.0 any storage partition lands right after
the executable application.
So it is impossible to build proper update application out-of-the box.

This patch moves storage partitions at the flash end back.
User needs only to correct the partition size (via Kconfig) to
the same as in previous release for ensure proper upgrade build.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>