### PR TITLE
net: http_client: Fix payload issue on HTTP upload

### DIFF
--- a/include/net/http_client.h
+++ b/include/net/http_client.h
@@ -238,7 +238,9 @@ struct http_request {
 	/** Payload, may be NULL */
 	const char *payload;
 
-	/** Payload length, may be 0. Only used if payload field is not NULL */
+	/** Payload length is used to calculate Content-Length. Set to 0
+	 * for chunked transfers.
+	 */
 	size_t payload_len;
 
 	/** User supplied callback function to call when optional headers need

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -563,9 +563,27 @@ int http_client_req(int sock, struct http_request *req,
 		total_sent += ret;
 	}
 
-	if (req->payload_cb) {
-		ret = http_send_data(sock, send_buf, send_buf_max_len,
+	if (req->payload || req->payload_cb) {
+		if (req->payload_len) {
+			char content_len_str[HTTP_CONTENT_LEN_SIZE];
+
+			ret = snprintk(content_len_str, HTTP_CONTENT_LEN_SIZE,
+				       "%zd", req->payload_len);
+			if (ret <= 0 || ret >= HTTP_CONTENT_LEN_SIZE) {
+				ret = -ENOMEM;
+				goto out;
+			}
+
+			ret = http_send_data(sock, send_buf, send_buf_max_len,
+					     &send_buf_pos,
+					     "Content-Length", ": ",
+					     content_len_str, HTTP_CRLF,
+					     HTTP_CRLF, NULL);
+		} else {
+			ret = http_send_data(sock, send_buf, send_buf_max_len,
 				     &send_buf_pos, HTTP_CRLF, NULL);
+		}
+
 		if (ret < 0) {
 			goto out;
 		}
@@ -580,39 +598,29 @@ int http_client_req(int sock, struct http_request *req,
 		send_buf_pos = 0;
 		total_sent += ret;
 
-		ret = req->payload_cb(sock, req, user_data);
-		if (ret < 0) {
-			goto out;
+		if (req->payload_cb) {
+			ret = req->payload_cb(sock, req, user_data);
+			if (ret < 0) {
+				goto out;
+			}
+
+			total_sent += ret;
+		} else {
+			u32_t length;
+
+			if (req->payload_len == 0) {
+				length = strlen(req->payload);
+			} else {
+				length = req->payload_len;
+			}
+
+			ret = sendall(sock, req->payload, length);
+			if (ret < 0) {
+				goto out;
+			}
+
+			total_sent += length;
 		}
-
-		total_sent += ret;
-	} else if (req->payload) {
-		char content_len_str[HTTP_CONTENT_LEN_SIZE];
-
-		ret = snprintk(content_len_str, HTTP_CONTENT_LEN_SIZE,
-			       "%zd", req->payload_len);
-		if (ret <= 0 || ret >= HTTP_CONTENT_LEN_SIZE) {
-			ret = -ENOMEM;
-			goto out;
-		}
-
-		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, "Content-Length", ": ",
-				     content_len_str, HTTP_CRLF,
-				     HTTP_CRLF, NULL);
-		if (ret < 0) {
-			goto out;
-		}
-
-		total_sent += ret;
-
-		ret = http_send_data(sock, send_buf, send_buf_max_len,
-				     &send_buf_pos, req->payload, NULL);
-		if (ret < 0) {
-			goto out;
-		}
-
-		total_sent += ret;
 	} else {
 		ret = http_send_data(sock, send_buf, send_buf_max_len,
 				     &send_buf_pos, HTTP_CRLF, NULL);


### PR DESCRIPTION
This PR is a backport of a bug fix in the Zephyr HTTP client that causes request payloads to fail ([relevant issue](https://github.com/zephyrproject-rtos/zephyr/issues/24431)). The changes have already been approved for merge in the main Zephyr repo (see [PR](https://github.com/zephyrproject-rtos/zephyr/pull/24432)).

I am submitting this backport to be merged early, instead of the next Zephyr release, because the bug cripples upload functionality in the HTTP client for binary payloads and should be resolved as soon as possible for nRF SDK users.