### PR TITLE
Add socket option for TLS session cache

### DIFF
--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -354,6 +354,9 @@ struct mqtt_sec_config {
 	 *  May be NULL to skip hostname verification.
 	 */
 	const char *hostname;
+
+	/** Indicates the preference for enabling TLS session caching. */
+	int session_cache;
 };
 
 /** @brief MQTT transport type. */

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -119,6 +119,11 @@ struct zsock_pollfd {
  *    - 1 - server
  */
 #define TLS_DTLS_ROLE 6
+/** Socket option to control TLS session caching. Accepted values:
+ *  - 0 - Disabled.
+ *  - 1 - Enabled.
+ */
+#define TLS_SESSION_CACHE 7
 
 /** @} */
 
@@ -130,6 +135,10 @@ struct zsock_pollfd {
 /* Valid values for TLS_DTLS_ROLE option */
 #define TLS_DTLS_ROLE_CLIENT 0 /**< Client role in a DTLS session. */
 #define TLS_DTLS_ROLE_SERVER 1 /**< Server role in a DTLS session. */
+
+/* Valid values for TLS_SESSION_CACHE option */
+#define TLS_SESSION_CACHE_DISABLED 0 /**< Disable TLS session caching. */
+#define TLS_SESSION_CACHE_ENABLED 1 /**< Enable TLS session caching. */
 
 struct zsock_addrinfo {
 	struct zsock_addrinfo *ai_next;

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -78,6 +78,16 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 		}
 	}
 
+	if (tls_config->session_cache == TLS_SESSION_CACHE_ENABLED) {
+		ret = setsockopt(client->transport.tls.sock, SOL_TLS,
+				 TLS_SESSION_CACHE,
+				 &tls_config->session_cache,
+				 sizeof(tls_config->session_cache));
+		if (ret < 0) {
+			goto error;
+		}
+	}
+
 	size_t peer_addr_size = sizeof(struct sockaddr_in6);
 
 	if (broker->sa_family == AF_INET) {


### PR DESCRIPTION
[nrf noup] net: socket: Add TLS_SESSION_CACHE option

Add socket opption for TLS session caching.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>

---

[nrf noup] net: lib: mqtt: Provide option to enable TLS ession caching

Provides an option to enable TLS session caching for an MQTT
client's secure socket.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>