### PR TITLE
[nrf toup] module: hal_nordic: Add NRF_802154_SL_CHOICE

### DIFF
--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -20,6 +20,18 @@ menuconfig NRF_802154_RADIO_DRIVER
 
 if NRF_802154_RADIO_DRIVER
 
+choice NRF_802154_SL_CHOICE
+	prompt "nRF 802.15.4 Service Layer selection"
+	help
+		Select implementation of nRF 802.15.4 Service Layer.
+
+config NRF_802154_SL_OPENSOURCE
+	bool "Open source nRF 802.15.4 Service Layer."
+	help
+		Use open source implementation of nRF 802.15.4 Service Layer.
+
+endchoice # NRF_802154_SL_CHOICE
+
 choice NRF_802154_CCA_MODE
 	prompt "nRF IEEE 802.15.4 CCA mode"
 	default NRF_802154_CCA_MODE_ED


### PR DESCRIPTION
NRF_802154_RADIO_DRIVER will be split into 'Radio Driver' part and
'Service Layer' (SL) library. SL will be selectable. To make this possible NRF_802154_SL_CHOICE is added.

Signed-off-by: Andrzej Kuros <andrzej.kuros@nordicsemi.no>