### PR TITLE
[nrf fromtree] drivers: uart: Prevent spurious UART_RX_BUF_REQUEST

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -594,6 +594,7 @@ static int uarte_nrfx_rx_disable(struct device *dev)
 	}
 	if (data->async->rx_next_buf != NULL) {
 		nrf_uarte_shorts_disable(uarte, NRF_UARTE_SHORT_ENDRX_STARTRX);
+		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_RXSTARTED);
 	}
 
 	k_timer_stop(&data->async->rx_timeout_timer);


### PR DESCRIPTION
This is a follow-up to commit cf7dd4981fbd1490041cc4367d5d5aaf865b5dd0.

When disabling RX, it is necessary to clear the RXSTARTED event after
the ENDRX_STARTRX shortcut is deactivated, as the event might already
have been generated at this point. If the event is not cleared and
the disabling of RX is done from the user handler called in the context
of the ENDRX interrupt, a spurious UART_RX_BUF_REQUEST event will be
generated (although RX is already disabled) for which a corresponding
call to uart_rx_buf_rsp() would fail, as the second buffer is already
set. Depending on the application implementation, this can result in
other unexpected problems.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>
(cherry picked from commit 49627feb0380cb121e06bdb0710989d5828a5624)