### PR TITLE
[nrf toup] module: hal_nordic: Remove NRF_802154_SL_CHOICE

### DIFF
--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -20,18 +20,6 @@ menuconfig NRF_802154_RADIO_DRIVER
 
 if NRF_802154_RADIO_DRIVER
 
-choice NRF_802154_SL_CHOICE
-	prompt "nRF 802.15.4 Service Layer selection"
-	help
-		Select implementation of nRF 802.15.4 Service Layer.
-
-config NRF_802154_SL_OPENSOURCE
-	bool "Open source nRF 802.15.4 Service Layer."
-	help
-		Use open source implementation of nRF 802.15.4 Service Layer.
-
-endchoice # NRF_802154_SL_CHOICE
-
 choice NRF_802154_CCA_MODE
 	prompt "nRF IEEE 802.15.4 CCA mode"
 	default NRF_802154_CCA_MODE_ED

--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: 742d8fb839406951ef7f95d0132bfa8c2635343f
+      revision: c84263d8ecc7767b25d9abab9502c9e748d045e9
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 3b54187649cc9b37161d49918f1ad28ff7c7f830


### PR DESCRIPTION
This reverts commit 3bdcae3d69ea6652b9e566d1376ab3d085c1b832.
As other 802.15.4 commits in hal_nordic repo are also reverted,
this patch updates the hal_nordic commit hash in west.yml,
so that those commits can be reverted safely.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>