### PR TITLE
[nrf fromlist] cmake: remove call to cmake and use ${CMAKE_COMMAND}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1114,7 +1114,7 @@ set(post_build_byproducts "")
 list(APPEND
   post_build_commands
   COMMAND
-  cmake -E rename ${logical_target_for_zephyr_elf}.map ${KERNEL_MAP_NAME}
+  ${CMAKE_COMMAND} -E rename ${logical_target_for_zephyr_elf}.map ${KERNEL_MAP_NAME}
 )
 
 if(NOT CONFIG_BUILD_NO_GAP_FILL)


### PR DESCRIPTION
This commit removes an occurence of `cmake` and instead uses the correct
form ${CMAKE_COMMAND}.

This fixes issues where CMake is invoked without being present in the
system PATH.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

----- 
Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/26114

---- 
Fixes: NCSIDB-107