### PR TITLE
[nrf fromlist] Bluetooth: hci: Depend on SOC not BOARD

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -106,7 +106,7 @@ config BT_STM32_IPM_RX_STACK_SIZE
 
 config BT_RPMSG_NRF53
 	bool "nRF53 configuration of RPMsg"
-	default y if (BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340PDK_NRF5340_CPUAPPNS)
+	default y if SOC_NRF5340_CPUAPP
 	depends on BT_RPMSG
 	select IPM
 	select IPM_NRFX


### PR DESCRIPTION
The CONFIG_BT_RPMSG_NRF53 should depend on the SOC, not the BOARD
definition. Otherwise this will break for custom boards.

Signed-off-by: Thomas Stenersen <thomas.stenersen@nordicsemi.no>

---
Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/26215
