### PR TITLE
West runners dependencies in sync with CMake runners target 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1353,7 +1353,7 @@ if(HEX_FILES_TO_MERGE)
     )
 
   add_custom_target(mergehex ALL DEPENDS ${MERGED_HEX_NAME})
-  list(APPEND FLASH_DEPS mergehex)
+  list(APPEND RUNNERS_DEPS mergehex)
 
   message(VERBOSE "Merging hex files: ${HEX_FILES_TO_MERGE}")
 endif()

--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -199,6 +199,7 @@ foreach(target flash debug debugserver attach)
       ${target}
       --skip-rebuild
       DEPENDS ${FLASH_DEPS}
+              $<TARGET_PROPERTY:zephyr_property_target,FLASH_DEPENDENCIES>
       WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
       )
 

--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -179,8 +179,9 @@ foreach(target flash debug debugserver attach)
   elseif(target STREQUAL attach)
     set(comment "Debugging ${BOARD}")
   endif()
+  string(TOUPPER ${target} TARGET_UPPER)
 
-  list(APPEND FLASH_DEPS ${logical_target_for_zephyr_elf})
+  list(APPEND RUNNERS_DEPS ${logical_target_for_zephyr_elf})
 
   # Enable verbose output, if requested.
   if(CMAKE_VERBOSE_MAKEFILE)
@@ -198,8 +199,8 @@ foreach(target flash debug debugserver attach)
       ${RUNNER_VERBOSE}
       ${target}
       --skip-rebuild
-      DEPENDS ${FLASH_DEPS}
-              $<TARGET_PROPERTY:zephyr_property_target,FLASH_DEPENDENCIES>
+      DEPENDS ${RUNNERS_DEPS}
+              $<TARGET_PROPERTY:zephyr_property_target,${TARGET_UPPER}_DEPENDENCIES>
       WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
       )
 

--- a/cmake/flash/CMakeLists.txt
+++ b/cmake/flash/CMakeLists.txt
@@ -211,6 +211,16 @@ foreach(target flash debug debugserver attach)
       ${comment}
       USES_TERMINAL
       )
+
+    # This is an artificial target to allow west to ensure all dependencies of
+    # target is build before carrying out the actual command.
+    # This allows `west` to run just the dependencies before flashing.
+    add_custom_target(west_${target}_depends
+      COMMAND ${CMAKE_COMMAND} -E echo ""
+      DEPENDS ${RUNNERS_DEPS}
+              $<TARGET_PROPERTY:zephyr_property_target,${TARGET_UPPER}_DEPENDENCIES>
+      USES_TERMINAL
+      )
   else()
     add_custom_target(${target}
       COMMAND ${CMAKE_COMMAND} -E echo \"West was not found in path. To support

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -259,8 +259,9 @@ def load_cmake_cache(build_dir, args):
 
 def rebuild(command, build_dir, args):
     _banner(f'west {command.name}: rebuilding')
+    extra_args = ['--target', 'west_' + command.name + '_depends']
     try:
-        zcmake.run_build(build_dir)
+        zcmake.run_build(build_dir, extra_args=extra_args)
     except CalledProcessError:
         if args.build_dir:
             log.die(f're-build in {args.build_dir} failed')


### PR DESCRIPTION
This commit creates a phony west_flash_target target with identical
dependencies as CMake flash target (and the same for debug, debugserver,
etc. targets).

ninja flash correctly ensures dependencies are taken into
consideration before calling west flash.

Unfortunately, calling west flash directly would not re-run the flash
dependencies, cause west flash would only build the default CMake
target.

Now, west flash calls the phony west_flash_depends target, ensuring
all deps are up-to-date before flashing (unless --skip-rebuild is given)

--------

Manifest: https://github.com/nrfconnect/sdk-nrf/pull/2499
