### PR TITLE
[nrf noup] include: net: new socket options for NRF91

### DIFF
--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -753,13 +753,19 @@ static inline char *inet_ntop(sa_family_t family, const void *src, char *dst,
 #define SOL_SOCKET 1
 
 /* Socket options for SOL_SOCKET level */
-/** sockopt: Enable server address reuse (ignored, for compatibility) */
+/** sockopt: Enable server address reuse */
 #define SO_REUSEADDR 2
 /** sockopt: Async error (ignored, for compatibility) */
 #define SO_ERROR 4
 #define SO_RCVTIMEO 20
 #define SO_SNDTIMEO 21
 #define SO_BINDTODEVICE 25
+/** sockopt: disable all replies to unexpected traffics */
+#define SO_SILENCE_ALL 30
+/** sockopt: disable IPv4 ICMP replies */
+#define SO_IP_ECHO_REPLY 31
+/** sockopt: disable IPv6 ICMP replies */
+#define SO_IPV6_ECHO_REPLY 32
 
 /** sockopt: Timestamp TX packets */
 #define SO_TIMESTAMPING 37


### PR DESCRIPTION
New NRF91 socket options added:
- SO_SILENCE_ALL to disable/enable all replies to unexpected traffics
- SO_IP_ECHO_REPLY to disable/enable replies to IPv4 ICMPs
- SO_IPV6_ECHO_REPLY to disable/enable replies to IPv6 ICMPs

SO_REUSEADDR comment cleanup since it will be supported by NRF91.

Signed-off-by: Petri Honkala <petri.honkala@nordicsemi.no>


sdk-nrf PR: https://github.com/nrfconnect/sdk-nrf/pull/2540
sdk-zephyr PR: https://github.com/nrfconnect/sdk-zephyr/pull/325