### PR TITLE
[nrf noup] arch: arm: add IRQ relay mechanism to ARMv7-M

### DIFF
--- a/arch/arm/core/aarch32/CMakeLists.txt
+++ b/arch/arm/core/aarch32/CMakeLists.txt
@@ -21,7 +21,7 @@ zephyr_library_sources(
 zephyr_library_sources_ifdef(CONFIG_GEN_SW_ISR_TABLE isr_wrapper.S)
 zephyr_library_sources_ifdef(CONFIG_CPLUSPLUS __aeabi_atexit.c)
 zephyr_library_sources_ifdef(CONFIG_IRQ_OFFLOAD irq_offload.c)
-zephyr_library_sources_ifdef(CONFIG_CPU_CORTEX_M0 irq_relay.S)
+zephyr_library_sources_ifdef(CONFIG_SW_VECTOR_RELAY irq_relay.S)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S)
 
 add_subdirectory_ifdef(CONFIG_CPU_CORTEX_M cortex_m)

--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -268,7 +268,6 @@ config DYNAMIC_DIRECT_INTERRUPTS
 config SW_VECTOR_RELAY
 	bool "Enable Software Vector Relay"
 	default y if BOOTLOADER_MCUBOOT
-	depends on ARMV6_M_ARMV8_M_BASELINE && !(CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP || CPU_CORTEX_M_HAS_VTOR)
 	help
 	  Add Vector Table relay handler and relay vector table, to
 	  relay interrupts based on a vector table pointer. This is only

--- a/arch/arm/core/aarch32/irq_relay.S
+++ b/arch/arm/core/aarch32/irq_relay.S
@@ -104,5 +104,87 @@ SECTION_FUNC(vector_relay_table, __vector_relay_table)
 	.word __vector_relay_handler
 	.word __vector_relay_handler
 	.word __vector_relay_handler
+#ifdef CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+	.word __vector_relay_handler
+#endif
 
 #endif

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -37,7 +37,7 @@
 
 #include <string.h>
 
-#ifdef CONFIG_CPU_CORTEX_M_HAS_VTOR
+#if defined(CONFIG_CPU_CORTEX_M_HAS_VTOR) && !defined(CONFIG_SW_VECTOR_RELAY)
 
 #ifdef CONFIG_XIP
 #define VECTOR_ADDRESS ((uintptr_t)_vector_start)


### PR DESCRIPTION
This commit allows the `SW_VECTOR_RELAY` to be
enabled on the ARMv7-M architectures and covers
all additional interrupt vectors.

Signed-off-by: Rafał Kuźnia <rafal.kuznia@nordicsemi.no>