### PR TITLE
[nrf fromlist] soc: arm: Kconfig: Add more nrf flash protection block sizes

### DIFF
--- a/soc/arm/Kconfig
+++ b/soc/arm/Kconfig
@@ -57,6 +57,30 @@ config NRF_SPU_RAM_REGION_SIZE
 	  RAM region size for the NRF_SPU peripheral
 endif
 
+if HAS_HW_NRF_MPU
+config NRF_MPU_FLASH_REGION_SIZE
+	hex
+	default 0x1000
+	help
+	  FLASH region size for the NRF_MPU peripheral (nRF51).
+endif
+
+if HAS_HW_NRF_BPROT
+config NRF_BPROT_FLASH_REGION_SIZE
+	hex
+	default $(dt_node_int_prop_hex,$(DT_CHOSEN_ZEPHYR_FLASH),erase-block-size)
+	help
+	  FLASH region size for the NRF_BPROT peripheral (nRF52).
+endif
+
+if HAS_HW_NRF_ACL
+config NRF_ACL_FLASH_REGION_SIZE
+	hex
+	default $(dt_node_int_prop_hex,$(DT_CHOSEN_ZEPHYR_FLASH),erase-block-size)
+	help
+	  FLASH region size for the NRF_ACL peripheral.
+endif
+
 config HAS_SWO
 	bool
 	help


### PR DESCRIPTION
Add
- NRF_MPU_FLASH_REGION_SIZE
- NRF_BPROT_FLASH_REGION_SIZE
- NRF_ACL_FLASH_REGION_SIZE

NRF_SPU_FLASH_REGION_SIZE is already available.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/26335

NRF PR: https://github.com/nrfconnect/sdk-nrf/pull/2515