### PR TITLE
[nrf fromlist] boards: add domain board to nrf53 network

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig
@@ -43,6 +43,17 @@ config BOARD_ENABLE_CPUNET
 	  may already have started the Network MCU.
 	default y if (BT || NET_L2_IEEE802154)
 
+config DOMAIN_CPUNET_BOARD
+	string
+	default "nrf5340pdk_nrf5340_cpunet" if BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340PDK_NRF5340_CPUAPPNS
+	default "nrf5340dk_nrf5340_cpunet" if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPPNS
+	depends on BOARD_ENABLE_CPUNET
+	help
+	  The board which will be used for CPUNET domain when creating a multi
+	  image application where one or more images should be located on
+	  another board. For example hci_rpmsg on the nRF5340_cpunet for
+	  Bluetooth applications.
+
 endif # BOARD_NRF5340PDK_NRF5340_CPUAPP || BOARD_NRF5340PDK_NRF5340_CPUAPPNS || BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPPNS
 
 if BOARD_NRF5340PDK_NRF5340_CPUNET || BOARD_NRF5340DK_NRF5340_CPUNET


### PR DESCRIPTION
Boards does not map well to a domain.
Disassociate domains from boards.

NRF PR https://github.com/nrfconnect/sdk-nrf/pull/2527

Upstream PR https://github.com/zephyrproject-rtos/zephyr/pull/26439

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>