### PR TITLE
Update out of tree dt helper name

### DIFF
--- a/scripts/dts/edtlib.py
+++ b/scripts/dts/edtlib.py
@@ -102,10 +102,6 @@ class EDT:
     nodes:
       A list of Node objects for the nodes that appear in the devicetree
 
-    alias2node:
-      A collections.OrderedDict that maps an /aliases property to the node
-      pointed to by that alias.
-
     compat2enabled:
       A collections.defaultdict that maps each 'compatible' string that appears
       on some enabled Node to a list of enabled Nodes.
@@ -552,19 +548,14 @@ class EDT:
             node._init_pinctrls()
 
     def _init_luts(self):
-        # Initialize alias2node, compat2enabled, and label2node
-        # lookup tables (LUTs).
+        # Initialize node lookup tables (LUTs).
 
-        self.alias2node = OrderedDict()
         self.label2node = OrderedDict()
         self.compat2enabled = defaultdict(list)
         self.compat2nodes = defaultdict(list)
         self.compat2okay = defaultdict(list)
 
         for node in self.nodes:
-            for alias in node.aliases:
-                self.alias2node[alias] = node
-
             for label in node.labels:
                 self.label2node[label] = node
 

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -107,20 +107,6 @@ def dt_nodelabel_enabled(kconf, _, label):
     return "y" if node and node.enabled else "n"
 
 
-def dt_alias_enabled(kconf, _, alias):
-    """
-    This function takes an /aliases property 'alias' and returns "y" if we find
-    that alias is defined and points to an "enabled" node in the EDT;
-    otherwise, we return "n"
-    """
-    if doc_mode or edt is None:
-        return "n"
-
-    node = edt.alias2node.get(alias)
-
-    return "y" if node and node.enabled else "n"
-
-
 def _node_reg_addr(node, index, unit):
     if not node:
         return 0
@@ -411,7 +397,6 @@ functions = {
         "dt_chosen_enabled": (dt_chosen_enabled, 1, 1),
         "dt_chosen_path": (dt_chosen_path, 1, 1),
         "dt_nodelabel_enabled": (dt_nodelabel_enabled, 1, 1),
-        "dt_alias_enabled": (dt_alias_enabled, 1, 1),
         "dt_chosen_reg_addr_int": (dt_chosen_reg, 1, 3),
         "dt_chosen_reg_addr_hex": (dt_chosen_reg, 1, 3),
         "dt_chosen_reg_size_int": (dt_chosen_reg, 1, 3),

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -94,10 +94,30 @@ def dt_chosen_path(kconf, _, chosen):
     return node.path if node else ""
 
 
+def dt_node_enabled(kconf, _, node):
+    """
+    This function returns "y" if 'node' refers to a status "okay" node
+    in the EDT. Otherwise, it returns "n". The 'node' argument can be
+    either a full path (starting with /) or an alias.
+    """
+
+    if doc_mode or edt is None:
+        return "n"
+
+    try:
+        node = edt.get_node(node)
+    except edtlib.EDTError:
+        return "n"
+
+    return "y" if node and node.enabled else "n"
+
+
 def dt_nodelabel_enabled(kconf, _, label):
     """
-    This function takes a 'label' and returns "y" if we find an "enabled"
-    node that has a 'nodelabel' of 'label' in the EDT otherwise we return "n"
+    This function is like dt_node_enabled(), but the 'label' argument
+    should be a node label, like "foo" is here:
+
+       foo: some-node { ... };
     """
     if doc_mode or edt is None:
         return "n"
@@ -396,6 +416,7 @@ functions = {
         "dt_chosen_label": (dt_chosen_label, 1, 1),
         "dt_chosen_enabled": (dt_chosen_enabled, 1, 1),
         "dt_chosen_path": (dt_chosen_path, 1, 1),
+        "dt_node_enabled": (dt_node_enabled, 1, 1),
         "dt_nodelabel_enabled": (dt_nodelabel_enabled, 1, 1),
         "dt_chosen_reg_addr_int": (dt_chosen_reg, 1, 3),
         "dt_chosen_reg_addr_hex": (dt_chosen_reg, 1, 3),


### PR DESCRIPTION
The dt_alias_enabled kconfigfunction was proposed for upstream in https://github.com/zephyrproject-rtos/zephyr/pull/24794, but it was rejected there. Replace it with a new version named dt_node_enabled in response to review.