### PR TITLE
[nrf fromtree] net: config: Fix IPv6 setup when DAD is unused and...

### DIFF
--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -250,7 +250,7 @@ static void setup_ipv6(struct net_if *iface, uint32_t flags)
 
 	if (sizeof(CONFIG_NET_CONFIG_MY_IPV6_ADDR) == 1) {
 		/* Empty address, skip setting ANY address in this case */
-		return;
+		goto exit;
 	}
 
 	if (net_addr_pton(AF_INET6, CONFIG_NET_CONFIG_MY_IPV6_ADDR, &laddr)) {
@@ -281,6 +281,8 @@ static void setup_ipv6(struct net_if *iface, uint32_t flags)
 				CONFIG_NET_CONFIG_MY_IPV6_ADDR);
 		}
 	}
+
+exit:
 
 #if !defined(CONFIG_NET_IPV6_DAD)
 	services_notify_ready(NET_CONFIG_NEED_IPV6);


### PR DESCRIPTION
Cherry picked from https://github.com/zephyrproject-rtos/zephyr/commit/6edf5bde11680fff5708caadd3bd317381334991 .
It didn't make it on the "upmerge" time. It help fixes part of https://projecttools.nordicsemi.no/jira/browse/KRKNWK-6681 which was reported based on https://devzone.nordicsemi.com/support-private/support/251619 .