### PR TITLE
[nrf fromlist] lib/os/work_q: sanity check work_q handler prior to calling it

### DIFF
--- a/lib/os/work_q.c
+++ b/lib/os/work_q.c
@@ -25,6 +25,7 @@ void z_work_q_main(void *work_q_ptr, void *p2, void *p3)
 		}
 
 		handler = work->handler;
+		__ASSERT(handler != NULL, "handler must be provided");
 
 		/* Reset pending state so it can be resubmitted by handler */
 		if (atomic_test_and_clear_bit(work->flags,


### PR DESCRIPTION
Just as NULL pointers should not be dereferenced, they should
not be called either.

Fixes 26723

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>