### PR TITLE
west: Provide path hint for manifest project

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -188,9 +188,9 @@ def main():
         # West is imported here, as it is optional (and thus maybe not installed)
         # if user is providing a specific modules list.
         from west.manifest import Manifest
-        from west.util import WestNotFound
+        from west.util import WestNotFound, west_topdir
         try:
-            manifest = Manifest.from_file()
+            manifest = Manifest.from_file(topdir=west_topdir())
             projects = [p.posixpath for p in manifest.get_projects([])]
         except WestNotFound:
             # Only accept WestNotFound, meaning we are not in a west


### PR DESCRIPTION
If the Manifest object is created without providing the `topdir` argument and the manifest file does not set `self.path`, the resulting `ManifestProject` has path set to None.
As a result, all commands defined in `zephyr_module.py` fail.

Signed-off-by: Tomasz Chyrowicz <tomasz.chyrowicz@nordicsemi.no>