### PR TITLE
[nrf toup] drivers: Adding cryptocell as chosen entropy for nRF5340

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -28,6 +28,7 @@
 	};
 
 	chosen {
+		zephyr,entropy = &cryptocell;
 		zephyr,flash-controller = &flash_controller;
 	};
 


### PR DESCRIPTION
-Adding cryptocell as zephyr,entropy for nRF5340 in dts

ref: NCSDK-4638

Used by (dependent on):
manifest PR: https://github.com/nrfconnect/sdk-nrf/pull/2758
nrfxlib PR: https://github.com/nrfconnect/sdk-nrfxlib/pull/242

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>