### PR TITLE
[nrf fromtree] kernel/timeout: revert to signed dticks for timeout storage

### DIFF
--- a/include/kernel_structs.h
+++ b/include/kernel_structs.h
@@ -223,9 +223,9 @@ struct _timeout {
 	_timeout_func_t fn;
 #ifdef CONFIG_TIMEOUT_64BIT
 	/* Can't use k_ticks_t for header dependency reasons */
-	uint64_t dticks;
+	int64_t dticks;
 #else
-	uint32_t dticks;
+	int32_t dticks;
 #endif
 };
 


### PR DESCRIPTION
The fix to handle long duration timeouts in 150e18de6e1806942 also
changed the duration value from signed to unsigned.  This can cause
delays in processing alarms when timer handlers run longer than a tick
(either due to delays or if there are many of them).  Revert to a
signed representation.

sdk-nrf PR: https://github.com/nrfconnect/sdk-nrf/pull/2913