### PR TITLE
Bluetooth: controller: Fix qualification issues

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2920,6 +2920,7 @@ void hci_disconn_complete_encode(struct pdu_data *pdu_data, u16_t handle,
 
 	ep->status = 0x00;
 	ep->handle = sys_cpu_to_le16(handle);
+	ep->reason = *((u8_t *)pdu_data);
 }
 
 void hci_disconn_complete_process(u16_t handle)

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LL_VERSION_NUMBER BT_HCI_VERSION_5_2
+#define LL_VERSION_NUMBER BT_HCI_VERSION_5_1
 
 int ll_init(struct k_sem *sem_rx);
 void ll_reset(void);


### PR DESCRIPTION
Fix regression in the disconnect complete event encoding where the
disconnect reason was accidentally deleted.

Regression introduced during conflict resolution of uint8_t and u8_t
differences in cherry-pick of:
736b79c

Change the LL version back to 5.1, to be able to re-use existing
Bluetooth conformance qualification.