### PR TITLE
[nrf fromlist] kconfig: add config for cpuapp domain board

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig
@@ -67,4 +67,13 @@ config BT_CTLR
 config BT_ECC
 	default y if BT
 
+config DOMAIN_CPUAPP_BOARD
+	string
+	default "nrf5340pdk_nrf5340_cpuapp" if BOARD_NRF5340PDK_NRF5340_CPUNET
+	default "nrf5340dk_nrf5340_cpuapp" if BOARD_NRF5340DK_NRF5340_CPUNET
+	help
+	  The board which will be used for CPUAPP domain when creating a multi
+	  image application where one or more images should be located on
+	  another board.
+
 endif # BOARD_NRF5340PDK_NRF5340_CPUNET || BOARD_NRF5340DK_NRF5340_CPUNET


### PR DESCRIPTION
This is needed for when network core image is parent.

Upstream PR https://github.com/zephyrproject-rtos/zephyr/pull/28988

Ref: NCSDK-6542

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>