### PR TITLE
[nrf fromtree] Bluetooth: controller: Fix latency cancel on LLCP initiation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -52,12 +52,6 @@ inline void ull_conn_upd_curr_reset(void);
 
 static int init_reset(void);
 
-#if defined(CONFIG_BT_PERIPHERAL)
-static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
-					       void *params);
-static void peripheral_latency_cancel(struct ll_conn *conn, uint16_t handle);
-#endif /* CONFIG_BT_PERIPHERAL */
-
 static void ticker_update_conn_op_cb(uint32_t status, void *param);
 static void ticker_stop_conn_op_cb(uint32_t status, void *param);
 static void ticker_start_conn_op_cb(uint32_t status, void *param);
@@ -237,7 +231,7 @@ int ll_tx_mem_enqueue(uint16_t handle, void *tx)
 	MFIFO_ENQUEUE(conn_tx, idx);
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
-		peripheral_latency_cancel(conn, handle);
+		ull_slave_latency_cancel(conn, handle);
 	}
 
 	return 0;
@@ -316,7 +310,7 @@ uint8_t ll_conn_update(uint16_t handle, uint8_t cmd, uint8_t status, uint16_t in
 
 			if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
 			    conn->lll.role) {
-				peripheral_latency_cancel(conn, handle);
+				ull_slave_latency_cancel(conn, handle);
 			}
 		}
 
@@ -364,7 +358,7 @@ uint8_t ll_terminate_ind_send(uint16_t handle, uint8_t reason)
 	conn->llcp_terminate.req++;
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
-		peripheral_latency_cancel(conn, handle);
+		ull_slave_latency_cancel(conn, handle);
 	}
 
 	return 0;
@@ -388,7 +382,7 @@ uint8_t ll_feature_req_send(uint16_t handle)
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
 	    IS_ENABLED(CONFIG_BT_CTLR_SLAVE_FEAT_REQ) &&
 	    conn->lll.role) {
-		peripheral_latency_cancel(conn, handle);
+		ull_slave_latency_cancel(conn, handle);
 	}
 
 	return 0;
@@ -410,7 +404,7 @@ uint8_t ll_version_ind_send(uint16_t handle)
 	conn->llcp_version.req++;
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
-		peripheral_latency_cancel(conn, handle);
+		ull_slave_latency_cancel(conn, handle);
 	}
 
 	return 0;
@@ -463,7 +457,7 @@ uint32_t ll_length_req_send(uint16_t handle, uint16_t tx_octets, uint16_t tx_tim
 	conn->llcp_length.req++;
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
-		peripheral_latency_cancel(conn, handle);
+		ull_slave_latency_cancel(conn, handle);
 	}
 
 	return 0;
@@ -558,7 +552,7 @@ uint8_t ll_phy_req_send(uint16_t handle, uint8_t tx, uint8_t flags, uint8_t rx)
 	conn->llcp_phy.req++;
 
 	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
-		peripheral_latency_cancel(conn, handle);
+		ull_slave_latency_cancel(conn, handle);
 	}
 
 	return 0;
@@ -1610,38 +1604,6 @@ static int init_reset(void)
 
 	return 0;
 }
-
-#if defined(CONFIG_BT_PERIPHERAL)
-static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
-					       void *params)
-{
-	struct ll_conn *conn = params;
-
-	LL_ASSERT(ticker_status == TICKER_STATUS_SUCCESS);
-
-	conn->slave.latency_cancel = 0U;
-}
-
-static void peripheral_latency_cancel(struct ll_conn *conn, uint16_t handle)
-{
-	/* break peripheral latency */
-	if (conn->lll.latency_event && !conn->slave.latency_cancel) {
-		uint32_t ticker_status;
-
-		conn->slave.latency_cancel = 1U;
-
-		ticker_status =
-			ticker_update(TICKER_INSTANCE_ID_CTLR,
-				      TICKER_USER_ID_THREAD,
-				      (TICKER_ID_CONN_BASE + handle),
-				      0, 0, 0, 0, 1, 0,
-				      ticker_update_latency_cancel_op_cb,
-				      (void *)conn);
-		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
-			  (ticker_status == TICKER_STATUS_BUSY));
-	}
-}
-#endif /* CONFIG_BT_PERIPHERAL */
 
 static void ticker_update_conn_op_cb(uint32_t status, void *param)
 {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -55,6 +55,7 @@ static int init_reset(void);
 #if defined(CONFIG_BT_PERIPHERAL)
 static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
 					       void *params);
+static void peripheral_latency_cancel(struct ll_conn *conn, uint16_t handle);
 #endif /* CONFIG_BT_PERIPHERAL */
 
 static void ticker_update_conn_op_cb(uint32_t status, void *param);
@@ -235,25 +236,9 @@ int ll_tx_mem_enqueue(uint16_t handle, void *tx)
 
 	MFIFO_ENQUEUE(conn_tx, idx);
 
-#if defined(CONFIG_BT_PERIPHERAL)
-	/* break slave latency */
-	if (conn->lll.role && conn->lll.latency_event &&
-	    !conn->slave.latency_cancel) {
-		uint32_t ticker_status;
-
-		conn->slave.latency_cancel = 1U;
-
-		ticker_status =
-			ticker_update(TICKER_INSTANCE_ID_CTLR,
-				      TICKER_USER_ID_THREAD,
-				      (TICKER_ID_CONN_BASE + handle),
-				      0, 0, 0, 0, 1, 0,
-				      ticker_update_latency_cancel_op_cb,
-				      (void *)conn);
-		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
-			  (ticker_status == TICKER_STATUS_BUSY));
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
 	}
-#endif /* CONFIG_BT_PERIPHERAL */
 
 	return 0;
 }
@@ -328,6 +313,11 @@ uint8_t ll_conn_update(uint16_t handle, uint8_t cmd, uint8_t status, uint16_t in
 			conn->llcp_conn_param.state = cmd;
 			conn->llcp_conn_param.cmd = 1U;
 			conn->llcp_conn_param.req++;
+
+			if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
+			    conn->lll.role) {
+				peripheral_latency_cancel(conn, handle);
+			}
 		}
 
 #else /* !CONFIG_BT_CTLR_CONN_PARAM_REQ */
@@ -373,6 +363,10 @@ uint8_t ll_terminate_ind_send(uint16_t handle, uint8_t reason)
 
 	conn->llcp_terminate.req++;
 
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
+	}
+
 	return 0;
 }
 
@@ -391,6 +385,12 @@ uint8_t ll_feature_req_send(uint16_t handle)
 
 	conn->llcp_feature.req++;
 
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) &&
+	    IS_ENABLED(CONFIG_BT_CTLR_SLAVE_FEAT_REQ) &&
+	    conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
+	}
+
 	return 0;
 }
 
@@ -408,6 +408,10 @@ uint8_t ll_version_ind_send(uint16_t handle)
 	}
 
 	conn->llcp_version.req++;
+
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
+	}
 
 	return 0;
 }
@@ -457,6 +461,10 @@ uint32_t ll_length_req_send(uint16_t handle, uint16_t tx_octets, uint16_t tx_tim
 #endif /* CONFIG_BT_CTLR_PHY */
 
 	conn->llcp_length.req++;
+
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
+	}
 
 	return 0;
 }
@@ -548,6 +556,10 @@ uint8_t ll_phy_req_send(uint16_t handle, uint8_t tx, uint8_t flags, uint8_t rx)
 	conn->llcp_phy.flags = flags;
 	conn->llcp_phy.rx = rx;
 	conn->llcp_phy.req++;
+
+	if (IS_ENABLED(CONFIG_BT_PERIPHERAL) && conn->lll.role) {
+		peripheral_latency_cancel(conn, handle);
+	}
 
 	return 0;
 }
@@ -1608,6 +1620,26 @@ static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
 	LL_ASSERT(ticker_status == TICKER_STATUS_SUCCESS);
 
 	conn->slave.latency_cancel = 0U;
+}
+
+static void peripheral_latency_cancel(struct ll_conn *conn, uint16_t handle)
+{
+	/* break peripheral latency */
+	if (conn->lll.latency_event && !conn->slave.latency_cancel) {
+		uint32_t ticker_status;
+
+		conn->slave.latency_cancel = 1U;
+
+		ticker_status =
+			ticker_update(TICKER_INSTANCE_ID_CTLR,
+				      TICKER_USER_ID_THREAD,
+				      (TICKER_ID_CONN_BASE + handle),
+				      0, 0, 0, 0, 1, 0,
+				      ticker_update_latency_cancel_op_cb,
+				      (void *)conn);
+		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
+			  (ticker_status == TICKER_STATUS_BUSY));
+	}
 }
 #endif /* CONFIG_BT_PERIPHERAL */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_slave.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave.c
@@ -46,6 +46,8 @@
 
 static void ticker_op_stop_adv_cb(uint32_t status, void *param);
 static void ticker_op_cb(uint32_t status, void *param);
+static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
+					       void *params);
 
 void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		     struct node_rx_ftr *ftr, struct lll_conn *lll)
@@ -368,6 +370,26 @@ void ull_slave_done(struct node_rx_event_done *done, uint32_t *ticks_drift_plus,
 	}
 }
 
+void ull_slave_latency_cancel(struct ll_conn *conn, uint16_t handle)
+{
+	/* break peripheral latency */
+	if (conn->lll.latency_event && !conn->slave.latency_cancel) {
+		uint32_t ticker_status;
+
+		conn->slave.latency_cancel = 1U;
+
+		ticker_status =
+			ticker_update(TICKER_INSTANCE_ID_CTLR,
+				      TICKER_USER_ID_THREAD,
+				      (TICKER_ID_CONN_BASE + handle),
+				      0, 0, 0, 0, 1, 0,
+				      ticker_update_latency_cancel_op_cb,
+				      (void *)conn);
+		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
+			  (ticker_status == TICKER_STATUS_BUSY));
+	}
+}
+
 void ull_slave_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder,
 			 uint16_t lazy, void *param)
 {
@@ -477,4 +499,14 @@ static void ticker_op_cb(uint32_t status, void *param)
 	ARG_UNUSED(param);
 
 	LL_ASSERT(status == TICKER_STATUS_SUCCESS);
+}
+
+static void ticker_update_latency_cancel_op_cb(uint32_t ticker_status,
+					       void *params)
+{
+	struct ll_conn *conn = params;
+
+	LL_ASSERT(ticker_status == TICKER_STATUS_SUCCESS);
+
+	conn->slave.latency_cancel = 0U;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_slave_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_slave_internal.h
@@ -8,5 +8,6 @@ void ull_slave_setup(memq_link_t *link, struct node_rx_hdr *rx,
 		     struct node_rx_ftr *ftr, struct lll_conn *lll);
 void ull_slave_done(struct node_rx_event_done *done, uint32_t *ticks_drift_plus,
 		    uint32_t *ticks_drift_minus);
+void ull_slave_latency_cancel(struct ll_conn *conn, uint16_t handle);
 void ull_slave_ticker_cb(uint32_t ticks_at_expire, uint32_t remainder, uint16_t lazy,
 			 void *param);


### PR DESCRIPTION
Fix controller implementation to cancel peripheral latency
when initiating new control procedures.

Fixes #28699.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>