### PR TITLE
drivers: ieee802154: nrf5: Remove nrf_802154_tx_started callback

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -53,9 +53,6 @@ struct nrf5_802154_data {
 	/* CCA result. Holds information whether channel is free or not. */
 	bool channel_free;
 
-	/* TX synchronization semaphore. Unlocked when transmission starts. */
-	struct k_sem tx_started;
-
 	/* TX synchronization semaphore. Unlocked when frame has been
 	 * sent or send procedure failed.
 	 */


### PR DESCRIPTION
Remove the implementation of nrf_802154_tx_started
radio driver callback. Remove the semaphore dedicated
to this callback.

PR updating the manifest:
https://github.com/nrfconnect/sdk-nrf/pull/3108

Jira: KRKNWK-7789