### PR TITLE
[nrf fromlist] openthread: logging: Fix platform log linking in NCP

### DIFF
--- a/subsys/net/lib/openthread/platform/CMakeLists.txt
+++ b/subsys/net/lib/openthread/platform/CMakeLists.txt
@@ -14,6 +14,6 @@ zephyr_library_sources(
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_DIAG diag.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_NCP uart.c)
 zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_SHELL shell.c)
-zephyr_library_sources_ifndef(CONFIG_LOG_BACKEND_SPINEL logging.c)
+zephyr_library_sources_ifdef(CONFIG_OPENTHREAD_DEBUG logging.c)
 
 zephyr_include_directories(.)


### PR DESCRIPTION
This PR ensures that `otPlatLog` is compiled in always when `CONFIG_OPENTHREAD_DEBUG` is set.
It fixes the NCP sample linking.

Upstream PR:
https://github.com/zephyrproject-rtos/zephyr/pull/29266

Signed-off-by: Piotr Szkotak <piotr.szkotak@nordicsemi.no>