### PR TITLE
[nrf fromtree] Bluetooth: GATT: Fix regression in lazy loading of CCCs

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4339,11 +4339,6 @@ next:
 static int ccc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		   void *cb_arg)
 {
-	if (IS_ENABLED(CONFIG_BT_SETTINGS_CCC_LAZY_LOADING)) {
-		/* Only load CCCs on demand */
-		return 0;
-	}
-
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		struct ccc_store ccc_store[CCC_STORE_MAX];
 		struct ccc_load load;
@@ -4401,7 +4396,18 @@ static int ccc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 	return 0;
 }
 
-SETTINGS_STATIC_HANDLER_DEFINE(bt_ccc, "bt/ccc", NULL, ccc_set, NULL, NULL);
+static int ccc_set_cb(const char *name, size_t len_rd, settings_read_cb read_cb,
+		      void *cb_arg)
+{
+	if (IS_ENABLED(CONFIG_BT_SETTINGS_CCC_LAZY_LOADING)) {
+		/* Only load CCCs on demand */
+		return 0;
+	}
+
+	return ccc_set(name, len_rd, read_cb, cb_arg);
+}
+
+SETTINGS_STATIC_HANDLER_DEFINE(bt_ccc, "bt/ccc", NULL, ccc_set_cb, NULL, NULL);
 
 static int ccc_set_direct(const char *key, size_t len, settings_read_cb read_cb,
 			  void *cb_arg, void *param)


### PR DESCRIPTION
Fix regression in lazy loading handling of GATT CCCs.
Bug introduced by: 00d370b09aa5dd1dc56986989989df6d4dd53bcf
The commit failed to account for ccc_set_direct calling ccc_set.

Fixes: #29150

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>
(cherry picked from commit 34cf1c74c21b10acfbc6504cd9bc212317c726d0)
Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>