### PR TITLE
[nrf fromtree] scripts: ensuring posix path on module defined roots.

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -154,7 +154,7 @@ def process_settings(module, meta):
             setting = build_settings.get(root+'_root', None)
             if setting is not None:
                 root_path = PurePath(module) / setting
-                out_text += f'"{root.upper()}_ROOT":"{root_path}"\n'
+                out_text += f'"{root.upper()}_ROOT":"{root_path.as_posix()}"\n'
 
     return out_text
 


### PR DESCRIPTION
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/29235

This commit ensures that roots are being converted to posix paths.
This fixes the issue where windows style path (containing `\`) would
result in DTS dependency file to contain mixed style path separator and
thus causing Ninja to re-invoke CMake in an endless loop.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

------
Manifest PR: https://github.com/nrfconnect/sdk-nrf/pull/3150