### PR TITLE
[nrf fromtree] usb: mass: Fix main thread stack size overflow.

### DIFF
--- a/samples/subsys/usb/mass/prj.conf
+++ b/samples/subsys/usb/mass/prj.conf
@@ -14,3 +14,4 @@ CONFIG_USB_MASS_STORAGE_LOG_LEVEL_ERR=y
 # If the target's code needs to do file operations, enable target's
 # FAT FS code. (Without this only the host can access the fs contents)
 #CONFIG_FILE_SYSTEM=y
+CONFIG_MAIN_STACK_SIZE=1536


### PR DESCRIPTION
After HW stack protection option was globally enabled for
nRF SoCs turned out main stack size is too small for
USB mass storage sample. Increase to avoid overflow.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>

Recent upmerge included zephyr v2.4.0 however this patch was added after the relase.
There is a need to include it in the ncs-v1.4.0.
Original [upstream PR](https://github.com/zephyrproject-rtos/zephyr/pull/28724). Already merged.