### PR TITLE
[nrf temphack] soc: use PM when configuring MPU regions

### DIFF
--- a/soc/arm/common/cortex_m/arm_mpu_regions.c
+++ b/soc/arm/common/cortex_m/arm_mpu_regions.c
@@ -8,6 +8,9 @@
 #include <arch/arm/aarch32/cortex_m/mpu/arm_mpu.h>
 
 #include "arm_mpu_mem_cfg.h"
+#if USE_PARTITION_MANAGER
+#include <pm_config.h>
+#endif
 
 static const struct arm_mpu_region mpu_regions[] = {
 	/* Region 0 */
@@ -21,6 +24,14 @@ static const struct arm_mpu_region mpu_regions[] = {
 #endif
 	/* Region 1 */
 	MPU_REGION_ENTRY("SRAM_0",
+#if USE_PARTITION_MANAGER
+			 PM_SRAM_ADDRESS,
+#if defined(CONFIG_ARMV8_M_BASELINE) || defined(CONFIG_ARMV8_M_MAINLINE)
+			 REGION_RAM_ATTR(PM_SRAM_ADDRESS, PM_SRAM_SIZE)),
+#else
+			 REGION_RAM_ATTR(REGION_SRAM_SIZE)),
+#endif
+#else
 			 CONFIG_SRAM_BASE_ADDRESS,
 #if defined(CONFIG_ARMV8_M_BASELINE) || defined(CONFIG_ARMV8_M_MAINLINE)
 			 REGION_RAM_ATTR(CONFIG_SRAM_BASE_ADDRESS, \
@@ -28,6 +39,9 @@ static const struct arm_mpu_region mpu_regions[] = {
 #else
 			 REGION_RAM_ATTR(REGION_SRAM_SIZE)),
 #endif
+
+#endif /* USE_PARTITION_MANAGER */
+
 };
 
 const struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
Temporary solution for using partition manager defines when configuring
the MPU regions.

This fixes assert seen when configuring dynamic regions.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>