### PR TITLE
[nrf fromlist] Bluetooth: shell: Fix shell build with out-of-tree ...

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2863,6 +2863,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 #if defined(CONFIG_BT_HCI_MESH_EXT)
 	SHELL_CMD(mesh_adv, NULL, "<on, off>", cmd_mesh_adv),
 #endif /* CONFIG_BT_HCI_MESH_EXT */
+
+#if defined(CONFIG_BT_LL_SW_SPLIT)
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_BROADCASTER)
 	SHELL_CMD_ARG(advx, NULL,
@@ -2881,6 +2883,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(bt_cmds,
 		      4, 0),
 	SHELL_CMD_ARG(test_end, NULL, HELP_NONE, cmd_test_end, 1, 0),
 #endif /* CONFIG_BT_CTLR_DTM */
+#endif /* CONFIG_BT_LL_SW_SPLIT */
+
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
controller

Fix shell build errors when building with combined host and controller
but the selected controller is not the in-tree zephyr controller, i.e
CONFIG_BT_CTLR=y, CONFIG_BT_LL_SW_SPLIT=n and cmd_scanx and others
are not defined.

Manifest PR: https://github.com/nrfconnect/sdk-nrf/pull/3201