### PR TITLE
[nrf noup] drivers: flash: No spm_request_read when no secure services

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -141,7 +141,8 @@ static int flash_nrf_read(const struct device *dev, off_t addr,
 		return 0;
 	}
 
-#if CONFIG_ARM_NONSECURE_FIRMWARE && CONFIG_SPM && USE_PARTITION_MANAGER
+#if CONFIG_ARM_NONSECURE_FIRMWARE && CONFIG_SPM && USE_PARTITION_MANAGER \
+	&& CONFIG_SPM_SECURE_SERVICES
 	if (addr < PM_APP_ADDRESS) {
 		return spm_request_read(data, addr, len);
 	}


### PR DESCRIPTION
Will not call spm_request_read when secure services are disabled.

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>