### PR TITLE
 [nrf temphack] drivers: ieee802154: nrf5: Remove TX modes when not supported

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -195,6 +195,7 @@ static enum ieee802154_hw_caps nrf5_get_capabilities(const struct device *dev)
 #if !defined(CONFIG_NRF_802154_SL_OPENSOURCE) && \
     !defined(CONFIG_NRF_802154_SER_HOST)
 	       IEEE802154_HW_CSMA |
+	       IEEE802154_HW_TXTIME |
 #endif
 	       IEEE802154_HW_2_4_GHZ |
 	       IEEE802154_HW_TX_RX_ACK |
@@ -412,6 +413,8 @@ static int nrf5_tx(const struct device *dev,
 	case IEEE802154_TX_MODE_CCA:
 		ret = nrf_802154_transmit_raw(nrf5_radio->tx_psdu, true);
 		break;
+#if !defined(CONFIG_NRF_802154_SL_OPENSOURCE) && \
+    !defined(CONFIG_NRF_802154_SER_HOST)
 	case IEEE802154_TX_MODE_CSMA_CA:
 		nrf_802154_transmit_csma_ca_raw(nrf5_radio->tx_psdu);
 		break;
@@ -435,6 +438,7 @@ static int nrf5_tx(const struct device *dev,
 		}
 		break;
 	}
+#endif
 	default:
 		NET_ERR("TX mode %d not supported", mode);
 		return -ENOTSUP;


### PR DESCRIPTION
This commit depends on commit:
16786a8
drivers: ieee802154: nrf5: Add support for tx in the future

and should be reverted when
zephyrproject-rtos/zephyr#29123
is upmerged.

Remove TXTIME, TXTIME_CCA, CSMA_CA capabilities and their calls when
they are not supported by selected drivers. Add TXTIME flag in
get_capabilites function.

This commit induces code style warnings. Warnings are related to macro
alignment. Fixing them renders macros less readable. As consulted with
reviewers, in this case it is acceptable.

Signed-off-by: Pawel Kwiek <pawel.kwiek@nordicsemi.no>