### PR TITLE
[nrf noup] Bluetoooth: Add experimental for non-qualified options

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -74,7 +74,7 @@ choice BT_LL_CHOICE
 	  Select the Bluetooth Link Layer to compile.
 
 config BT_LL_SW_SPLIT
-	bool "Software-based BLE Link Layer"
+	bool "Software-based BLE Link Layer [EXPERIMENTAL]"
 	select BT_RECV_IS_RX_THREAD
 	select ENTROPY_GENERATOR
 	help

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BT_MESH
-	bool "Bluetooth Mesh support"
+	bool "Bluetooth Mesh support [EXPERIMENTAL]"
 	select TINYCRYPT
 	select TINYCRYPT_AES
 	select TINYCRYPT_AES_CMAC


### PR DESCRIPTION
Zephyr controller does not yet have a qualification for this release.
Bluetooth Mesh does not yet have a qualification for this release.

Manifest PR: https://github.com/nrfconnect/sdk-nrf/pull/3370

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>