### PR TITLE
drivers: serial: nrfx_uarte: Add low power TX only mode

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -21,6 +21,14 @@ if UART_NRFX
 DT_COMPAT_NORDIC_NRF_UART  := nordic,nrf-uart
 DT_COMPAT_NORDIC_NRF_UARTE := nordic,nrf-uarte
 
+config UART_NRFX_LP_TX_ONLY
+	bool "LP TX only modes"
+	default n
+	help
+	  Enable low power mode that disables the peripheral after
+	  each transmission. To be used in modes where only TX
+	  is used. I.e logging.
+
 # ----------------- port 0 -----------------
 config UART_0_NRF_UART
 	def_bool $(dt_nodelabel_has_compat,uart0,$(DT_COMPAT_NORDIC_NRF_UART))

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1040,7 +1040,12 @@ static int uarte_nrfx_poll_in(const struct device *dev, unsigned char *c)
  */
 static void uarte_nrfx_poll_out(const struct device *dev, unsigned char c)
 {
+
+
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
+#if defined(CONFIG_UART_NRFX_LP_TX_ONLY)
+	nrf_uarte_enable(uarte);
+#endif
 	struct uarte_nrfx_data *data = get_dev_data(dev);
 	atomic_t *lock;
 
@@ -1102,6 +1107,9 @@ static void uarte_nrfx_poll_out(const struct device *dev, unsigned char c)
 
 	/* Release the lock. */
 	*lock = 0;
+#if defined(CONFIG_UART_NRFX_LP_TX_ONLY)
+	nrf_uarte_disable(uarte);
+#endif
 }
 #ifdef UARTE_INTERRUPT_DRIVEN
 /** Interrupt driven FIFO fill function */


### PR DESCRIPTION
Add mode that enables and disables the UARTE peripheral after each
use to use minmal power when not actively using it.
Useful for logging.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>