### PR TITLE
[nrf fromlist] settings: fix possible unaligned write while a line coping

### DIFF
--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -295,7 +295,14 @@ int settings_line_entry_copy(void *dst_ctx, off_t dst_off, void *src_ctx,
 			break;
 		}
 
-		rc = settings_io_cb.write_cb(dst_ctx, dst_off, buf, chunk_size);
+		size_t write_size = chunk_size;
+
+		if (chunk_size % settings_io_cb.rwbs) {
+			write_size += settings_io_cb.rwbs -
+				      chunk_size % settings_io_cb.rwbs;
+		}
+
+		rc = settings_io_cb.write_cb(dst_ctx, dst_off, buf, write_size);
 		if (rc) {
 			break;
 		}


### PR DESCRIPTION
It was possible that settings_line_entry_copy() did unaligned
flash write.
This patch introduce respecting the flash write-block-size.

upstream patch:
zephyrproject-rtos/zephyr#30421

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>