### PR TITLE
[nrf noup] bluetooth: hci_driver: Do not enable BT_QUIRK_NO_AUTO_DLE

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -138,7 +138,7 @@ endif # BT_RPMSG_NRF53
 config BT_DRIVER_QUIRK_NO_AUTO_DLE
 	bool "Host auto-initiated Data Length Update quirk"
 	depends on BT_AUTO_DATA_LEN_UPDATE
-	default y if BT_RPMSG_NRF53
+	default y if BT_LL_SW_SPLIT
 	help
 	  Enable the quirk wherein BT Host stack will auto-initiate Data Length
 	  Update procedure for new connections for controllers that do not


### PR DESCRIPTION
This quirk is only needed for the zephyr controller. This controller
does not follow the spec recommendation of initiating a DLE procedure
after connection establishment.

By changing the default value of this quirk, the throughput sample
will perform better on nrf53, as there is no longer a second DLE
procedure after connection establishment.

In a split build, there is no way the host can know if the controller
has this quirk or not. Our best assumption is therefore that the spec
recommended behavior is followed.

Therefore applications built for nrf53 with the zephyr LL will have
a lower maximum throughput.

See also:
https://github.com/zephyrproject-rtos/zephyr/pull/26277
https://github.com/zephyrproject-rtos/zephyr/pull/28239

ref: NCSDK-7247

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>