### PR TITLE
[nrf fromlist] runners: mdb: fix imports

### DIFF
--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -5,12 +5,18 @@
 '''Runners for Synopsys Metaware Debugger(mdb).'''
 
 
-import time
 import shutil
-import psutil
+import time
 import os
 from os import path
+
 from runners.core import ZephyrBinaryRunner, RunnerCaps
+
+try:
+    import psutil
+    MISSING_REQUIREMENTS = False
+except ImportError:
+    MISSING_REQUIREMENTS = True
 
 # normally we should create class with common functionality inherited from
 # ZephyrBinaryRunner and inherit MdbNsimBinaryRunner and MdbHwBinaryRunner
@@ -205,4 +211,9 @@ class MdbHwBinaryRunner(ZephyrBinaryRunner):
             dig_device=args.dig_device)
 
     def do_run(self, command, **kwargs):
+        if MISSING_REQUIREMENTS:
+            raise RuntimeError('one or more Python dependencies were missing; '
+                               "see the getting started guide for details on "
+                               "how to fix")
+
         mdb_do_run(self, command)


### PR DESCRIPTION
Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/30661/

Runner implementations are only allowed to unconditionally import
modules in the python standard library. They are not allowed to import
anything that comes from pip or other third party sources unless they
catch the ImportError and gracefully do nothing.

Fix the imports in the mdb runner accordingly, sorting the imports
into sections to make it clearer what's stdlib, what's runners, and
what's third party while we're here.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>