### PR TITLE
[nrf fromtree] west.yml: Update hal_nordic revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: 665cfbbb969f31d3514af0a5a1088dc424ae334d
+      revision: 7430036d4f18cdf1f49158e97e5d57aacb44fb92
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
This PR updates the used hal_nordic revision to the latest one.

(below is the description of the last cherry-picked commit)

This commit brings in a fix for a typo in hal_nordic repo.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>
(cherry picked from commit c284a72b45645549479e7b19f8403caf6c293415)
Signed-off-by: Czeslaw Makarski <Czeslaw.Makarski@nordicsemi.no>