### PR TITLE
[nrf fromtree] doc: fix parsing directive inside literal

### DIFF
--- a/doc/scripts/extract_content.py
+++ b/doc/scripts/extract_content.py
@@ -83,7 +83,7 @@ def src_deps(zephyr_base, src_file, dest, src_root):
     # argument, which is a (relative) path to the additional
     # dependency file.
     directives = "|".join(DIRECTIVES)
-    pattern = re.compile(r"\.\.\s+(?P<directive>%s)::\s+(?P<dep_rel>[^\s]+)" %
+    pattern = re.compile(r"\.\.\s+(?P<directive>%s)::\s+(?P<dep_rel>[^\s`]+)" %
                          directives)
     deps = []
     for m in pattern.finditer(content):


### PR DESCRIPTION
This expands the current directive matching regex to also allow "`" as an ending character along with spaces; it fixes issues when directives are added inside a literal ("``").

Technically this is not correct, a directive must always end in space-like characters,  but a proper parser would know that it is inside a literal and accept the contents without interpretation; short of implementing a proper rST parser this should work with no side-effects.

JIRA: NCSDK-7485