### PR TITLE
west.yml: Update hal_nordic revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -56,7 +56,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: 7430036d4f18cdf1f49158e97e5d57aacb44fb92
+      revision: pull/77/head
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
The manifest update introduces one commit for the 802.15.4 radio driver in hal_nordic repository.

* drivers: nrf_radio_802154: Add callout for custom initialization part
This commit introduces nrf_802154_custom_part_of_radio_init callout.
Application can override weak empty implementation to provide some additional
operations to be performed at the beginning of each new timeslot.
