### PR TITLE
[nrf noup] samples: smp_svr: Increase stack size for overlay-bt.conf

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
@@ -14,3 +14,6 @@ CONFIG_FILE_SYSTEM_LITTLEFS=y
 
 # Enable file system commands
 CONFIG_MCUMGR_CMD_FS_MGMT=y
+
+# Increase stack size to work around known issue NCSDK-6832
+CONFIG_MAIN_STACK_SIZE=2048


### PR DESCRIPTION
The known issue NCSDK-6832 regards the softdevice using  more stack than
what is allocated by default, causing a stackoverflow after booting the
app. Increasing the stack resolves the issue on nRF52 devices, as well
as compiling with CONFIG_BT_LL_SW_SPLIT=y.

Ref: NCSDK-6855
Signed-off-by: Stephen Stauts <stephen.stauts@nordicsemi.no>