### PR TITLE
[nrf fromtree] net: openthread: Make radio workqueue stack size ...

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -137,6 +137,10 @@ config OPENTHREAD_PKT_LIST_SIZE
 	int "List size for IPv6 packet buffering"
 	default 10
 
+config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
+	int "OpenThread radio transmit workqueue stack size"
+	default 512
+
 endmenu # "Zephyr optimizations"
 
 config OPENTHREAD_SHELL

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -44,8 +44,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 #define FRAME_TYPE_MASK 0x07
 #define FRAME_TYPE_ACK 0x02
 
-#define OT_WORKER_STACK_SIZE 512
-
 #if IS_ENABLED(CONFIG_NET_TC_THREAD_COOPERATIVE)
 #define OT_WORKER_PRIORITY   K_PRIO_COOP(CONFIG_OPENTHREAD_THREAD_PRIORITY)
 #else
@@ -88,7 +86,8 @@ static uint8_t  energy_detection_channel;
 static int16_t energy_detected_value;
 
 ATOMIC_DEFINE(pending_events, PENDING_EVENT_COUNT);
-K_KERNEL_STACK_DEFINE(ot_task_stack, OT_WORKER_STACK_SIZE);
+K_KERNEL_STACK_DEFINE(ot_task_stack,
+		      CONFIG_OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE);
 static struct k_work_q ot_work_q;
 static otError tx_rx_result;
 

--- a/tests/subsys/openthread/radio_stub.c
+++ b/tests/subsys/openthread/radio_stub.c
@@ -17,6 +17,7 @@
 #define CONFIG_OPENTHREAD_THREAD_PRIORITY 5
 #define OT_WORKER_PRIORITY K_PRIO_COOP(CONFIG_OPENTHREAD_THREAD_PRIORITY)
 #define CONFIG_NET_L2_OPENTHREAD 1
+#define CONFIG_OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE 512
 
 /* needed for stubbing device driver */
 const struct device *device_get_binding_stub(const char *name);


### PR DESCRIPTION
Add Kconfig option for configuring OpenThread radio transmit workqueue
stack size.

(cherry picked from commit ad360c4)

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>