### PR TITLE
[nrf fromlist] samples: net: lwm2m_client: Remove nrf52dk_nrf52832 from the allowlist

### DIFF
--- a/samples/net/lwm2m_client/sample.yaml
+++ b/samples/net/lwm2m_client/sample.yaml
@@ -16,7 +16,7 @@ tests:
   sample.net.lwm2m_client.bt:
     harness: net
     extra_args: OVERLAY_CONFIG=overlay-bt.conf
-    platform_allow: nrf52dk_nrf52832 nrf52840dk_nrf52840 disco_l475_iot1
+    platform_allow: nrf52840dk_nrf52840 disco_l475_iot1
     tags: net lwm2m
   sample.net.lwm2m_client.queue_mode:
     harness: net


### PR DESCRIPTION
BLE and LwM2M grew in terms of RAM usage so that the sample does not
fit into nRF52832 anymore in the default configuration. This cause
twister to report an error when overflows errors are enabled.

Upstream PR 31350

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>