### PR TITLE
[nrf fromlist] drivers/flash/soc_flash_nrf: FTPAN-242 workaround

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -15,6 +15,7 @@
 #include <drivers/flash.h>
 #include <string.h>
 #include <nrfx_nvmc.h>
+#include <nrf_erratas.h>
 
 #include "soc_flash_nrf.h"
 
@@ -80,6 +81,17 @@ static struct k_sem sem_lock;
 #define SYNC_UNLOCK()
 #endif
 
+#if NRF52_ERRATA_242_PRESENT
+#include <hal/nrf_power.h>
+static int suspend_pofwarn(void);
+static void restore_pofwarn(void);
+
+#define SUSPEND_POFWARN() suspend_pofwarn()
+#define RESUME_POFWARN()  restore_pofwarn()
+#else
+#define SUSPEND_POFWARN() 0
+#define RESUME_POFWARN()
+#endif /* NRF52_ERRATA_242_PRESENT */
 
 static int write(off_t addr, const void *data, size_t len);
 static int erase(uint32_t addr, uint32_t size);
@@ -357,12 +369,20 @@ static int erase_op(void *context)
 
 #ifdef CONFIG_SOC_FLASH_NRF_UICR
 	if (e_ctx->flash_addr == (off_t)NRF_UICR) {
+		if (SUSPEND_POFWARN()) {
+			return -ECANCELED;
+		}
+
 		(void)nrfx_nvmc_uicr_erase();
+		RESUME_POFWARN();
 		return FLASH_OP_DONE;
 	}
 #endif
 
 	do {
+		if (SUSPEND_POFWARN()) {
+			return -ECANCELED;
+		}
 
 #if defined(CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE)
 		if (e_ctx->flash_addr == e_ctx->flash_addr_next) {
@@ -380,6 +400,8 @@ static int erase_op(void *context)
 		e_ctx->len -= pg_size;
 		e_ctx->flash_addr += pg_size;
 #endif /* CONFIG_SOC_FLASH_NRF_PARTIAL_ERASE */
+
+		RESUME_POFWARN();
 
 #ifndef CONFIG_SOC_FLASH_NRF_RADIO_SYNC_NONE
 		i++;
@@ -424,10 +446,15 @@ static int write_op(void *context)
 			count = w_ctx->len;
 		}
 
+		if (SUSPEND_POFWARN()) {
+			return -ECANCELED;
+		}
+
 		nrfx_nvmc_bytes_write(w_ctx->flash_addr,
 				      (const void *)w_ctx->data_addr,
 				      count);
 
+		RESUME_POFWARN();
 		shift_write_context(count, w_ctx);
 
 #ifndef CONFIG_SOC_FLASH_NRF_RADIO_SYNC_NONE
@@ -442,9 +469,13 @@ static int write_op(void *context)
 #endif /* CONFIG_SOC_FLASH_NRF_EMULATE_ONE_BYTE_WRITE_ACCESS */
 	/* Write all the 4-byte aligned data */
 	while (w_ctx->len >= sizeof(uint32_t)) {
+		if (SUSPEND_POFWARN()) {
+			return -ECANCELED;
+		}
+
 		nrfx_nvmc_word_write(w_ctx->flash_addr,
 				     UNALIGNED_GET((uint32_t *)w_ctx->data_addr));
-
+		RESUME_POFWARN();
 		shift_write_context(sizeof(uint32_t), w_ctx);
 
 #ifndef CONFIG_SOC_FLASH_NRF_RADIO_SYNC_NONE
@@ -461,10 +492,14 @@ static int write_op(void *context)
 #if IS_ENABLED(CONFIG_SOC_FLASH_NRF_EMULATE_ONE_BYTE_WRITE_ACCESS)
 	/* Write remaining unaligned data */
 	if (w_ctx->len) {
+		if (SUSPEND_POFWARN()) {
+			return -ECANCELED;
+		}
+
 		nrfx_nvmc_bytes_write(w_ctx->flash_addr,
 				      (const void *)w_ctx->data_addr,
 				      w_ctx->len);
-
+		RESUME_POFWARN();
 		shift_write_context(w_ctx->len, w_ctx);
 	}
 #endif /* CONFIG_SOC_FLASH_NRF_EMULATE_ONE_BYTE_WRITE_ACCESS */
@@ -502,3 +537,50 @@ static int write(off_t addr, const void *data, size_t len)
 
 	return write_op(&context);
 }
+
+#if NRF52_ERRATA_242_PRESENT
+/* Disable POFWARN by writing POFCON before a write or erase operation.
+ * Do not attempt to write or erase if EVENTS_POFWARN is already asserted.
+ */
+static bool pofcon_enabled;
+
+static int suspend_pofwarn(void)
+{
+	if (!nrf52_errata_242()) {
+		return 0;
+	}
+
+	bool enabled;
+	nrf_power_pof_thr_t pof_thr;
+
+	pof_thr = nrf_power_pofcon_get(NRF_POWER, &enabled);
+
+	if (enabled) {
+		nrf_power_pofcon_set(NRF_POWER, false, pof_thr);
+
+		/* This check need to be reworked once POFWARN event will be
+		 * served by zephyr.
+		 */
+		if (nrf_power_event_check(NRF_POWER, NRF_POWER_EVENT_POFWARN)) {
+			nrf_power_pofcon_set(NRF_POWER, true, pof_thr);
+			return -ECANCELED;
+		}
+
+		pofcon_enabled = enabled;
+	}
+
+	return 0;
+}
+
+static void restore_pofwarn(void)
+{
+	nrf_power_pof_thr_t pof_thr;
+
+	if (pofcon_enabled) {
+		pof_thr = nrf_power_pofcon_get(NRF_POWER, NULL);
+
+		nrf_power_pofcon_set(NRF_POWER, true, pof_thr);
+		pofcon_enabled = false;
+	}
+}
+#endif  /* NRF52_ERRATA_242_PRESENT */

--- a/drivers/flash/soc_flash_nrf.h
+++ b/drivers/flash/soc_flash_nrf.h
@@ -10,7 +10,7 @@
 #include <kernel.h>
 
 #define FLASH_OP_DONE    (0) /* 0 for compliance with the driver API. */
-#define FLASH_OP_ONGOING (-1)
+#define FLASH_OP_ONGOING  1
 
 struct flash_context {
 	uint32_t data_addr;  /* Address of data to write. */
@@ -53,7 +53,8 @@ struct flash_context {
  *
  * @param context pointer to flash_context structure.
  * @retval @ref FLASH_OP_DONE once operation was done, @ref FLASH_OP_ONGOING if
- *         operation needs more time for execution.
+ *         operation needs more time for execution and a negative error code if
+ *         operation was aborted.
  */
 typedef int (*flash_op_handler_t) (void *context);
 
@@ -92,12 +93,13 @@ bool nrf_flash_sync_is_required(void);
  * to timing settings requested by nrf_flash_sync_set_context().
  * This routine need to be called the handler as many time as it returns
  * FLASH_OP_ONGOING, howewer an operation timeot should be implemented.
- * When the handler() returns FLASH_OP_DONE, no further execution windows are
- * needed so function should return as the handler() finished its operation.
+ * When the handler() returns FLASH_OP_DONE or an error code, no further
+ * execution windows are needed so function should return as the handler()
+ * finished its operation.
  *
- * @retval 0 if op_desc->handler() was executed and
- * finished its operation. Otherwise (timeout, couldn't schedule execution...)
- * a negative error code.
+ * @retval 0 if op_desc->handler() was executed and finished its operation
+ * successfully. Otherwise (handler returned error, timeout, couldn't schedule
+ * execution...) a negative error code.
  *
  *                              execution window
  *            Driver task           task

--- a/drivers/flash/soc_flash_nrf_ticker.c
+++ b/drivers/flash/soc_flash_nrf_ticker.c
@@ -58,18 +58,20 @@ static void time_slot_callback_work(uint32_t ticks_at_expire,
 	struct flash_op_desc *op_desc;
 	uint8_t instance_index;
 	uint8_t ticker_id;
+	int rc;
 
 	__ASSERT(ll_radio_state_is_idle(),
 		 "Radio is on during flash operation.\n");
 
 	op_desc = context;
-	if (op_desc->handler(op_desc->context) == FLASH_OP_DONE) {
+	rc = op_desc->handler(op_desc->context);
+	if (rc != FLASH_OP_ONGOING) {
 		ll_timeslice_ticker_id_get(&instance_index, &ticker_id);
 
 		/* Stop the time slot ticker */
 		_ticker_stop(instance_index, 0, ticker_id);
 
-		_ticker_sync_context.result = 0;
+		_ticker_sync_context.result = (rc == FLASH_OP_DONE) ? 0 : rc;
 
 		/* notify thread that data is available */
 		k_sem_give(&sem_sync);


### PR DESCRIPTION
- Introduce support for situation when synchronization back-end aborts operation before it is done. synchronization API will transfer operation return code to the driver shim back.

- Disable POFWARN by writing POFCON before a write or erase operation. Do not attempt to write or erase if EVENTS_POFWARN is already asserted.

This is upstream PR copy https://github.com/zephyrproject-rtos/zephyr/pull/31759