### PR TITLE
[nrf fromtree] drivers: gpio_nrfx: Allocate GPIOTE channels with nrfx

### DIFF
--- a/drivers/gpio/Kconfig.nrfx
+++ b/drivers/gpio/Kconfig.nrfx
@@ -5,6 +5,7 @@ menuconfig GPIO_NRFX
 	bool "nRF GPIO driver"
 	default y
 	depends on SOC_FAMILY_NRF
+	select NRFX_GPIOTE
 	help
 	  Enable GPIO driver for nRF line of MCUs.
 


### PR DESCRIPTION
The GPIO driver uses a proprietary GPIOTE channel allocator.
This commit makes it use the allocation mechanism provided by nrfx.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>

This PR cherry-picks commit introduced to upstream in https://github.com/zephyrproject-rtos/zephyr/pull/31606 in order to unblock https://github.com/nrfconnect/sdk-nrf/pull/3770 and https://github.com/nrfconnect/sdk-nrf/pull/3750.