### PR TITLE
[nrf fromtree] api: remove unnecessary parentheses in DEVICE_NAME_GET.

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -43,7 +43,7 @@ extern "C" {
  *
  * @return The expanded name of the device object created by DEVICE_DEFINE()
  */
-#define DEVICE_NAME_GET(name) (_CONCAT(__device_, name))
+#define DEVICE_NAME_GET(name) _CONCAT(__device_, name)
 
 /**
  * @def SYS_DEVICE_DEFINE


### PR DESCRIPTION
Get rid of compilation warnings caused by additional parentheses (visible only when using C++ compilator - e.g. in CHIP).

Upstream merged PR: https://github.com/zephyrproject-rtos/zephyr/pull/31471