### PR TITLE
nRF5340 multiprotocol fixes

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -210,8 +210,7 @@ static enum ieee802154_hw_caps nrf5_get_capabilities(const struct device *dev)
 {
 	return IEEE802154_HW_FCS |
 	       IEEE802154_HW_FILTER |
-#if !defined(CONFIG_NRF_802154_SL_OPENSOURCE) && \
-    !defined(CONFIG_NRF_802154_SER_HOST)
+#if !defined(CONFIG_NRF_802154_SL_OPENSOURCE)
 	       IEEE802154_HW_CSMA |
 #ifdef CONFIG_IEEE802154_NRF5_PKT_TXTIME
 	       IEEE802154_HW_TXTIME |
@@ -451,8 +450,7 @@ static int nrf5_tx(const struct device *dev,
 	case IEEE802154_TX_MODE_CCA:
 		ret = nrf_802154_transmit_raw(nrf5_radio->tx_psdu, true);
 		break;
-#if !defined(CONFIG_NRF_802154_SL_OPENSOURCE) && \
-    !defined(CONFIG_NRF_802154_SER_HOST)
+#if !defined(CONFIG_NRF_802154_SL_OPENSOURCE)
 	case IEEE802154_TX_MODE_CSMA_CA:
 		nrf_802154_transmit_csma_ca_raw(nrf5_radio->tx_psdu);
 		break;

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -104,7 +104,7 @@ static void nrf5_get_eui64(uint8_t *mac)
 				   sizeof(factoryAddress));
 #endif
 	if (ret != 0) {
-		LOG_ERR("Unable to read EUI64 from the secure zone.")
+		LOG_ERR("Unable to read EUI64 from the secure zone.");
 		LOG_ERR("Setting EUI64 to 0");
 		factoryAddress = 0ULL;
 	}

--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -129,7 +129,7 @@ if NRF_802154_SER_RADIO
 
 config NRF_802154_SER_RADIO_INIT_PRIO
 	int "nRF52 IEEE 802.15.4 serialization initialization priority"
-	default 81
+	default 47
 	help
 	  Set the initialization priority number. Do not mess with it unless
 	  you know what you are doing.

--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -217,17 +217,25 @@ void nrfx_busy_wait(uint32_t usec_to_wait);
 //------------------------------------------------------------------------------
 
 /** @brief Bitmask that defines DPPI channels that are reserved for use outside of the nrfx library. */
-#define NRFX_DPPI_CHANNELS_USED   NRFX_PPI_CHANNELS_USED_BY_BT_CTLR
+#define NRFX_DPPI_CHANNELS_USED   (NRFX_PPI_CHANNELS_USED_BY_BT_CTLR |    \
+				   NRFX_PPI_CHANNELS_USED_BY_802154_DRV | \
+				   NRFX_PPI_CHANNELS_USED_BY_MPSL)
 
 /** @brief Bitmask that defines DPPI groups that are reserved for use outside of the nrfx library. */
-#define NRFX_DPPI_GROUPS_USED     NRFX_PPI_GROUPS_USED_BY_BT_CTLR
+#define NRFX_DPPI_GROUPS_USED     (NRFX_PPI_GROUPS_USED_BY_BT_CTLR |    \
+				   NRFX_PPI_GROUPS_USED_BY_802154_DRV | \
+				   NRFX_PPI_GROUPS_USED_BY_MPSL)
 
 /** @brief Bitmask that defines PPI channels that are reserved for use outside of the nrfx library. */
-#define NRFX_PPI_CHANNELS_USED    (NRFX_PPI_CHANNELS_USED_BY_BT_CTLR | \
-                                   NRFX_PPI_CHANNELS_USED_BY_PWM_SW)
+#define NRFX_PPI_CHANNELS_USED    (NRFX_PPI_CHANNELS_USED_BY_BT_CTLR |    \
+				   NRFX_PPI_CHANNELS_USED_BY_802154_DRV | \
+				   NRFX_PPI_CHANNELS_USED_BY_MPSL |       \
+				   NRFX_PPI_CHANNELS_USED_BY_PWM_SW)
 
 /** @brief Bitmask that defines PPI groups that are reserved for use outside of the nrfx library. */
-#define NRFX_PPI_GROUPS_USED      NRFX_PPI_GROUPS_USED_BY_BT_CTLR
+#define NRFX_PPI_GROUPS_USED      (NRFX_PPI_GROUPS_USED_BY_BT_CTLR |    \
+				   NRFX_PPI_GROUPS_USED_BY_802154_DRV | \
+				   NRFX_PPI_GROUPS_USED_BY_MPSL)
 
 /** @brief Bitmask that defines GPIOTE channels that are reserved for use outside of the nrfx library. */
 #define NRFX_GPIOTE_CHANNELS_USED NRFX_GPIOTE_CHANNELS_USED_BY_PWM_SW
@@ -240,6 +248,27 @@ extern const uint32_t z_bt_ctlr_used_nrf_ppi_groups;
 #else
 #define NRFX_PPI_CHANNELS_USED_BY_BT_CTLR   0
 #define NRFX_PPI_GROUPS_USED_BY_BT_CTLR     0
+#endif
+
+#if defined(CONFIG_NRF_802154_RADIO_DRIVER)
+extern const uint32_t g_nrf_802154_used_nrf_ppi_channels;
+extern const uint32_t g_nrf_802154_used_nrf_ppi_groups;
+#define NRFX_PPI_CHANNELS_USED_BY_802154_DRV   g_nrf_802154_used_nrf_ppi_channels
+#define NRFX_PPI_GROUPS_USED_BY_802154_DRV     g_nrf_802154_used_nrf_ppi_groups
+#else
+#define NRFX_PPI_CHANNELS_USED_BY_802154_DRV   0
+#define NRFX_PPI_GROUPS_USED_BY_802154_DRV     0
+#endif
+
+#if defined(CONFIG_NRF_802154_RADIO_DRIVER) && \
+	!defined(CONFIG_NRF_802154_SL_OPENSOURCE)
+extern const uint32_t z_mpsl_used_nrf_ppi_channels;
+extern const uint32_t z_mpsl_used_nrf_ppi_groups;
+#define NRFX_PPI_CHANNELS_USED_BY_MPSL   z_mpsl_used_nrf_ppi_channels
+#define NRFX_PPI_GROUPS_USED_BY_MPSL     z_mpsl_used_nrf_ppi_groups
+#else
+#define NRFX_PPI_CHANNELS_USED_BY_MPSL   0
+#define NRFX_PPI_GROUPS_USED_BY_MPSL     0
 #endif
 
 #if defined(CONFIG_PWM_NRF5_SW)

--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: e34f5d9bc0ac4aa4f65e466ed6103f279d7124d6
+      revision: a2e3b69da9b836ef08a86ffcd750e2d76a04335e
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262

--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: f0d54d8449acbee49b3cebcef0e3e56640c50277
+      revision: e34f5d9bc0ac4aa4f65e466ed6103f279d7124d6
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
The cherry-picked commits originate from zephyrproject-rtos/zephyr#31474

This PR suppresses #439 and #435