### PR TITLE
[nrf fromtree]: settings: Handle unhandled error

### DIFF
--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -213,6 +213,9 @@ static int settings_nvs_save(struct settings_store *cs, const char *name,
 	/* write the value */
 	rc = nvs_write(&cf->cf_nvs, write_name_id + NVS_NAME_ID_OFFSET,
 		       value, val_len);
+	if (rc < 0) {
+		return rc;
+	}
 
 	/* write the name if required */
 	if (write_name) {


### PR DESCRIPTION
Upstream commit: 563c24f

There was a case when the return code was ignored. This commit fixes it.
