### PR TITLE
[nrf fromlist] drivers: serial: nrfx_uarte: Fix power management

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1538,6 +1538,9 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 	if (new_state == DEVICE_PM_ACTIVE_STATE) {
 		uarte_nrfx_pins_enable(dev, true);
 		nrf_uarte_enable(uarte);
+
+		data->pm_state = new_state;
+
 #ifdef CONFIG_UART_ASYNC_API
 		if (hw_rx_counting_enabled(get_dev_data(dev))) {
 			nrfx_timer_enable(&get_dev_config(dev)->timer);
@@ -1559,8 +1562,6 @@ static void uarte_nrfx_set_power_state(const struct device *dev,
 			}
 #endif
 		}
-
-		data->pm_state = new_state;
 	} else {
 		__ASSERT_NO_MSG(new_state == DEVICE_PM_LOW_POWER_STATE ||
 				new_state == DEVICE_PM_SUSPEND_STATE ||


### PR DESCRIPTION
Power consumption was still high after putting uarte device into off
state. It was caused by ENDRX interrupt that was triggered after
calling STOPRX. ENDRX event was called with 0 amount but interrupt
got triggered and fifo_read was starting RX again.

Added disabling RX interrupt before disabling UARTE and reenabling at
device activation.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>