### PR TITLE
drivers: ieee802154: load EUI64 from UICR

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -52,4 +52,28 @@ config IEEE802154_NRF5_PKT_TXTIME
 	  Enable TX time support. This is needed when upper layers want
 	  to set the exact time when the packet should be sent.
 
+config IEEE802154_NRF5_UICR_EUI64_ENABLE
+	bool "Enables using EUI64 value stored in UICR registers"
+	depends on !IEEE802154_VENDOR_OUI_ENABLE
+	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF53X
+	help
+	  This option enables setting custom vendor EUI64 value
+	  stored in User information configuration registers (UICR).
+	  Notice that this disables the default setting of EUI64
+	  value from Factory information configuration registers
+	  (FICR).
+
+if IEEE802154_NRF5_UICR_EUI64_ENABLE
+
+config IEEE802154_NRF5_UICR_EUI64_REG
+	int "UICR base register for the EUI64 value"
+	range 0 30 if SOC_SERIES_NRF52X
+	range 0 190 if SOC_SERIES_NRF53X
+	default 0
+	help
+	  Base of the two consecutive registers from the UICR customer
+	  section in which custom EUI64 is stored.
+
+endif # IEEE802154_NRF5_UICR_EUI64_ENABLE
+
 endif

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -65,13 +65,21 @@ static struct nrf5_802154_data nrf5_data;
 
 #if defined(CONFIG_IEEE802154_NRF5_UICR_EUI64_ENABLE)
 #if defined(CONFIG_SOC_NRF5340_CPUAPP)
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+#define EUI64_ADDR (NRF_UICR_S->OTP)
+#else
 #define EUI64_ADDR (NRF_UICR->OTP)
+#endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
 #else
 #define EUI64_ADDR (NRF_UICR->CUSTOMER)
 #endif /* CONFIG_SOC_NRF5340_CPUAPP */
 #else
 #if defined(CONFIG_SOC_NRF5340_CPUAPP) || defined(CONFIG_SOC_NRF5340_CPUNET)
+#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+#define EUI64_ADDR (NRF_FICR_S->INFO.DEVICEID)
+#else
 #define EUI64_ADDR (NRF_FICR->INFO.DEVICEID)
+#endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
 #else
 #define EUI64_ADDR (NRF_FICR->DEVICEID)
 #endif /* CONFIG_SOC_NRF5340_CPUAPP || CONFIG_SOC_NRF5340_CPUNET */
@@ -114,8 +122,9 @@ static void nrf5_get_eui64(uint8_t *mac)
 	defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	int ret = -EPERM;
 #if defined(CONFIG_SPM)
-	ret = spm_request_read(&factoryAddress, (uint32_t)EUI64_ADDR,
-				   sizeof(factoryAddress));
+	ret = spm_request_read(&factoryAddress,
+			       (uint32_t)&EUI64_ADDR[EUI64_ADDR_HIGH],
+			       sizeof(factoryAddress));
 #endif
 	if (ret != 0) {
 		LOG_ERR("Unable to read EUI64 from the secure zone.");

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -63,15 +63,27 @@ static struct nrf5_802154_data nrf5_data;
 #define FRAME_PENDING_BIT (1 << 4)
 #define TXTIME_OFFSET_US  (5 * USEC_PER_MSEC)
 
-#if defined(CONFIG_SOC_NRF5340_CPUAPP) || defined(CONFIG_SOC_NRF5340_CPUNET)
-#if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
-#define EUI64_ADDR (NRF_FICR_S->INFO.DEVICEID)
+#if defined(CONFIG_IEEE802154_NRF5_UICR_EUI64_ENABLE)
+#if defined(CONFIG_SOC_NRF5340_CPUAPP)
+#define EUI64_ADDR (NRF_UICR->OTP)
 #else
+#define EUI64_ADDR (NRF_UICR->CUSTOMER)
+#endif /* CONFIG_SOC_NRF5340_CPUAPP */
+#else
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) || defined(CONFIG_SOC_NRF5340_CPUNET)
 #define EUI64_ADDR (NRF_FICR->INFO.DEVICEID)
-#endif
 #else
 #define EUI64_ADDR (NRF_FICR->DEVICEID)
-#endif
+#endif /* CONFIG_SOC_NRF5340_CPUAPP || CONFIG_SOC_NRF5340_CPUNET */
+#endif /* CONFIG_IEEE802154_NRF5_UICR_EUI64_ENABLE */
+
+#if defined(CONFIG_IEEE802154_UICR_EUI64_ENABLE)
+#define EUI64_ADDR_HIGH CONFIG_IEEE802154_NRF5_UICR_EUI64_REG
+#define EUI64_ADDR_LOW (CONFIG_IEEE802154_NRF5_UICR_EUI64_REG + 1)
+#else
+#define EUI64_ADDR_HIGH 0
+#define EUI64_ADDR_LOW 1
+#endif /* CONFIG_IEEE802154_NRF5_UICR_EUI64_ENABLE */
 
 /* Convenience defines for RADIO */
 #define NRF5_802154_DATA(dev) \
@@ -91,10 +103,12 @@ static void nrf5_get_eui64(uint8_t *mac)
 	uint64_t factoryAddress;
 	uint32_t index = 0;
 
+#if !defined(CONFIG_IEEE802154_NRF5_UICR_EUI64_ENABLE)
 	/* Set the MAC Address Block Larger (MA-L) formerly called OUI. */
 	mac[index++] = (IEEE802154_NRF5_VENDOR_OUI >> 16) & 0xff;
 	mac[index++] = (IEEE802154_NRF5_VENDOR_OUI >> 8) & 0xff;
 	mac[index++] = IEEE802154_NRF5_VENDOR_OUI & 0xff;
+#endif
 
 #if defined(CONFIG_SOC_NRF5340_CPUAPP) && \
 	defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
@@ -110,8 +124,8 @@ static void nrf5_get_eui64(uint8_t *mac)
 	}
 #else
 	/* Use device identifier assigned during the production. */
-	factoryAddress = (uint64_t)EUI64_ADDR[0] << 32;
-	factoryAddress |= EUI64_ADDR[1];
+	factoryAddress = (uint64_t)EUI64_ADDR[EUI64_ADDR_HIGH] << 32;
+	factoryAddress |= EUI64_ADDR[EUI64_ADDR_LOW];
 #endif
 	memcpy(mac + index, &factoryAddress, sizeof(factoryAddress) - index);
 }


### PR DESCRIPTION
Add `IEEE802154_NRF5_UICR_EUI64_ENABLE` option to allow loading EUI64 from UICR registers.

KRKNWK-8932