### PR TITLE
Bluetooth: Post-upmerge bugfixes for v1.5

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -161,6 +161,7 @@ int lll_adv_data_init(struct lll_adv_pdu *pdu)
 		return -ENOMEM;
 	}
 
+	p->len = 0U;
 	pdu->pdu[0] = (void *)p;
 
 	return 0;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll_adv.c
@@ -150,6 +150,7 @@ int lll_adv_data_init(struct lll_adv_pdu *pdu)
 		return -ENOMEM;
 	}
 
+	p->len = 0U;
 	pdu->pdu[0] = (void *)p;
 
 	return 0;

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -350,7 +350,12 @@ static int unseg_app_sdu_unpack(struct bt_mesh_friend *frnd,
 				struct unseg_app_sdu_meta *meta)
 {
 	uint16_t app_idx = FRIEND_ADV(buf)->app_idx;
-	struct bt_mesh_net_rx net;
+	struct bt_mesh_net_rx net = {
+		.ctx = {
+			.app_idx = app_idx,
+			.net_idx = frnd->subnet->net_idx,
+		},
+	};
 	int err;
 
 	meta->subnet = frnd->subnet;
@@ -426,6 +431,8 @@ static int unseg_app_sdu_prepare(struct bt_mesh_friend *frnd,
 	if (meta.crypto.seq_num == bt_mesh.seq) {
 		return 0;
 	}
+
+	BT_DBG("Re-encrypting friend pdu");
 
 	err = unseg_app_sdu_decrypt(frnd, buf, &meta);
 	if (err) {

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -432,13 +432,16 @@ static int unseg_app_sdu_prepare(struct bt_mesh_friend *frnd,
 		return 0;
 	}
 
-	BT_DBG("Re-encrypting friend pdu");
+	BT_DBG("Re-encrypting friend pdu (SeqNum %06x -> %06x)",
+	       meta.crypto.seq_num, bt_mesh.seq);
 
 	err = unseg_app_sdu_decrypt(frnd, buf, &meta);
 	if (err) {
 		BT_WARN("Decryption failed! %d", err);
 		return err;
 	}
+
+	meta.crypto.seq_num = bt_mesh.seq;
 
 	err = unseg_app_sdu_encrypt(frnd, buf, &meta);
 	if (err) {

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -134,6 +134,10 @@ int bt_mesh_provision(const uint8_t net_key[16], uint16_t net_idx,
 		bt_mesh_lpn_group_add(BT_MESH_ADDR_ALL_NODES);
 	}
 
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_mesh_net_pending_net_store();
+	}
+
 	bt_mesh_start();
 
 	return 0;

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -39,14 +39,6 @@
 #include "prov.h"
 #include "cfg.h"
 
-/* Minimum valid Mesh Network PDU length. The Network headers
- * themselves take up 9 bytes. After that there is a minimum of 1 byte
- * payload for both CTL=1 and CTL=0 PDUs (smallest OpCode is 1 byte). CTL=1
- * PDUs must use a 64-bit (8 byte) NetMIC, whereas CTL=0 PDUs have at least
- * a 32-bit (4 byte) NetMIC and AppMIC giving again a total of 8 bytes.
- */
-#define BT_MESH_NET_MIN_PDU_LEN (BT_MESH_NET_HDR_LEN + 1 + 8)
-
 #define LOOPBACK_MAX_PDU_LEN (BT_MESH_NET_HDR_LEN + 16)
 #define LOOPBACK_USER_DATA_SIZE sizeof(struct bt_mesh_subnet *)
 #define LOOPBACK_BUF_SUB(buf) (*(struct bt_mesh_subnet **)net_buf_user_data(buf))
@@ -747,6 +739,11 @@ int bt_mesh_net_decode(struct net_buf_simple *in, enum bt_mesh_net_if net_if,
 		return -EINVAL;
 	}
 
+	if (in->len > BT_MESH_NET_MAX_PDU_LEN) {
+		BT_WARN("Dropping too long mesh packet (len %u)", in->len);
+		return -EINVAL;
+	}
+
 	if (net_if == BT_MESH_NET_IF_ADV && check_dup(in)) {
 		return -EINVAL;
 	}
@@ -796,7 +793,7 @@ int bt_mesh_net_decode(struct net_buf_simple *in, enum bt_mesh_net_if net_if,
 void bt_mesh_net_recv(struct net_buf_simple *data, int8_t rssi,
 		      enum bt_mesh_net_if net_if)
 {
-	NET_BUF_SIMPLE_DEFINE(buf, 29);
+	NET_BUF_SIMPLE_DEFINE(buf, BT_MESH_NET_MAX_PDU_LEN);
 	struct bt_mesh_net_rx rx = { .ctx.recv_rssi = rssi };
 	struct net_buf_simple_state state;
 

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -138,11 +138,6 @@ static void msg_cache_add(struct bt_mesh_net_rx *rx)
 	msg_cache_next %= ARRAY_SIZE(msg_cache);
 }
 
-static void store_net(void)
-{
-	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_NET_PENDING);
-}
-
 static void store_iv(bool only_duration)
 {
 	bt_mesh_settings_store_schedule(BT_MESH_SETTINGS_IV_PENDING);
@@ -198,7 +193,6 @@ int bt_mesh_net_create(uint16_t idx, uint8_t flags, const uint8_t key[16],
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		BT_DBG("Storing network information persistently");
-		store_net();
 		bt_mesh_subnet_store(idx);
 		store_iv(false);
 	}

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -17,6 +17,19 @@
 				    CONFIG_BT_MESH_IVU_DIVIDER)
 #define BT_MESH_IVU_TIMEOUT        K_HOURS(BT_MESH_IVU_HOURS)
 
+/* Minimum valid Mesh Network PDU length. The Network headers
+ * themselves take up 9 bytes. After that there is a minimum of 1 byte
+ * payload for both CTL=1 and CTL=0 PDUs (smallest OpCode is 1 byte). CTL=1
+ * PDUs must use a 64-bit (8 byte) NetMIC, whereas CTL=0 PDUs have at least
+ * a 32-bit (4 byte) NetMIC and AppMIC giving again a total of 8 bytes.
+ */
+#define BT_MESH_NET_MIN_PDU_LEN (BT_MESH_NET_HDR_LEN + 1 + 8)
+/* Maximum valid Mesh Network PDU length. The longest packet can either be a
+ * transport control message (CTL=1) of 12 bytes + 8 bytes of NetMIC, or an
+ * access message (CTL=0) of 16 bytes + 4 bytes of NetMIC.
+ */
+#define BT_MESH_NET_MAX_PDU_LEN (BT_MESH_NET_HDR_LEN + 16 + 4)
+
 struct bt_mesh_net_cred;
 
 struct bt_mesh_node {

--- a/subsys/bluetooth/mesh/proxy.c
+++ b/subsys/bluetooth/mesh/proxy.c
@@ -272,7 +272,7 @@ static void send_filter_status(struct bt_mesh_proxy_client *client,
 
 static void proxy_cfg(struct bt_mesh_proxy_client *client)
 {
-	NET_BUF_SIMPLE_DEFINE(buf, 29);
+	NET_BUF_SIMPLE_DEFINE(buf, BT_MESH_NET_MAX_PDU_LEN);
 	struct bt_mesh_net_rx rx;
 	uint8_t opcode;
 	int err;


### PR DESCRIPTION
Pulls in 3 Bluetooth Mesh bugfix PRs and one controller bugfix PR from upstream:
- zephyrproject-rtos/zephyr#32069 (merged upstream)
- zephyrproject-rtos/zephyr#31909 (merged upstream)
- zephyrproject-rtos/zephyr#32080 (merged upstream)
- zephyrproject-rtos/zephyr#32160 (merged upstream)
