### PR TITLE
[nrf noup] dts: Adding cryptocell_sw as chosen entropy

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -30,6 +30,15 @@
 
 	chosen {
 		zephyr,flash-controller = &flash_controller;
+
+		/*
+		 * By default, system entropy comes from the entropy_cc310.c
+		 * driver in the nrf repository. This is devicetree glue
+		 * needed to make the system aware of that fact. Individual
+		 * applications can override this by changing this property
+		 * value.
+		 */
+		zephyr,entropy = &cryptocell_sw;
 	};
 
 	soc {
@@ -60,6 +69,14 @@
 			status = "disabled";
 			label = "GPIOTE_1";
 		};
+
+		/* For cryptocell access via platform library; see above */
+		cryptocell_sw: cryptocell-sw {
+			compatible = "nordic,nrf-cc312-sw";
+			#address-cells = <0>;
+			label = "CRYPTOCELL_SW";
+		};
+
 	};
 };
 

--- a/dts/bindings/crypto/nordic,nrf-cc312-sw.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc312-sw.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2021, Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Stub access to cryptocell via platform driver
+
+  Non-secure configurations can use this compatible to declare
+  devicetree nodes which access the CC312 via callbacks into secure
+  code.
+
+compatible: "nordic,nrf-cc312-sw"
+
+include: base.yaml
+
+properties:
+  label:
+    required: true


### PR DESCRIPTION
-Adding cryptocell_sw as a chosen entropy source as the non-secure
 does not have access to a entropy peripheral and need to SPM (and
 later PSA APIs through the same driver)
-Not upstream as driver is only downstream

manifest pr: https://github.com/nrfconnect/sdk-nrf/pull/3978

ref: NCSDK-8246

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>