### PR TITLE
[nrf temphack] cmake: exclude print-ot-config for target ALL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,14 @@ endforeach()
 set(ZEPHYR_CURRENT_MODULE_DIR)
 set(ZEPHYR_CURRENT_CMAKE_DIR)
 
+# The OpenThread module creates a print-ot-config that uses an echo command
+# which fails on Windows, see more: https://github.com/openthread/openthread/pull/6175
+# This code disable the target from `ALL` but the target can still be manually
+# called by the user. All the target does is printing the current OpenThread configuration.
+if(TARGET print-ot-config)
+  set_property(TARGET print-ot-config PROPERTY EXCLUDE_FROM_ALL TRUE)
+endif()
+
 set(syscall_list_h   ${CMAKE_CURRENT_BINARY_DIR}/include/generated/syscall_list.h)
 set(syscalls_json    ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/syscalls.json)
 set(struct_tags_json ${CMAKE_CURRENT_BINARY_DIR}/misc/generated/struct_tags.json)


### PR DESCRIPTION
This is a temporary fix for excluding the `print-ot-config` from target ALL.

This temphack must be reverted when zephyr/openthread has been upmerged with
this commit: 32257403b04e437280379c7fba91dad213c73887

See more here:
https://github.com/openthread/openthread/pull/6175

This fixes the issue reported here:
https://devzone.nordicsemi.com/f/nordic-q-a/71586/ses-ncs-seem-to-build-ok-but-throws-error-starting-process-echo/294588

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

-------

Manifest: https://github.com/nrfconnect/sdk-nrf/pull/3956