### PR TITLE
[nrf fromtree] kernel/timeout: Schedule zero-time timeouts

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -134,7 +134,8 @@ void z_add_timeout(struct _timeout *to, _timeout_func_t fn,
 			 */
 			int32_t next_time = next_timeout();
 
-			if (_current_cpu->slice_ticks != next_time) {
+			if (next_time == 0 ||
+			    _current_cpu->slice_ticks != next_time) {
 				z_clock_set_timeout(next_time, false);
 			}
 #else


### PR DESCRIPTION
Fix an edge case that snuck in with the recent fix: if timeslicing is
enabled, the CPU's slice_ticks will be zero, and thus match a timeout
object's dticks value of zero, and thus get suppressed (because "we
already have a timeout scheduled for that") incorrectly.

Fixes #31789

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>