### PR TITLE
[nrf fromtree] twisterlib: checking for classname and testname

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3428,7 +3428,7 @@ class TestSuite(DisablePyTestCollectionMixin):
                         classname = p + ":" + ".".join(instance.testcase.name.split(".")[:2])
 
                     # remove testcases that are being re-run from exiting reports
-                    for tc in eleTestsuite.findall(f'testcase/[@classname="{classname}"]'):
+                    for tc in eleTestsuite.findall(f'testcase/[@classname="{classname}"][@name="{instance.testcase.name}"]'):
                         eleTestsuite.remove(tc)
 
                     eleTestcase = ET.SubElement(eleTestsuite, 'testcase',


### PR DESCRIPTION
Currently duplicated testcases are only determined by the classname.
This results in testcases not beeing added to the twister.xml if the
testcases are from the same class (e.g. sample.yaml), but with different
names.

The changed check if the combination of classname and testname
already exists.


Signed-off-by: Sebastian Wezel <sebastian.wezel@nordicsemi.no>