### PR TITLE
[nrf noup] posix socket: sckt flags MSG_TRUNC and MSG_WAITALL added

### DIFF
--- a/include/posix/sys/socket.h
+++ b/include/posix/sys/socket.h
@@ -29,6 +29,8 @@ static inline int socketpair(int family, int type, int proto, int sv[2])
 
 #define MSG_PEEK ZSOCK_MSG_PEEK
 #define MSG_DONTWAIT ZSOCK_MSG_DONTWAIT
+#define MSG_TRUNC ZSOCK_MSG_TRUNC
+#define MSG_WAITALL ZSOCK_MSG_WAITALL
 
 static inline int shutdown(int sock, int how)
 {


### PR DESCRIPTION
Needed by: https://github.com/nrfconnect/sdk-nrf/pull/4074
Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>