### PR TITLE
Revert noup commits no longer needed

### DIFF
--- a/drivers/flash/soc_flash_nrf.h
+++ b/drivers/flash/soc_flash_nrf.h
@@ -8,6 +8,7 @@
 #define __SOC_FLASH_NRF_H__
 
 #include <kernel.h>
+#include <soc.h>
 
 #define FLASH_OP_DONE    (0) /* 0 for compliance with the driver API. */
 #define FLASH_OP_ONGOING  1

--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
@@ -17,6 +17,3 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
 
 # Enable file system commands
 CONFIG_MCUMGR_CMD_FS_MGMT=y
-
-# Increase stack size to work around known issue NCSDK-6832
-CONFIG_MAIN_STACK_SIZE=2048

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -90,7 +90,6 @@ if BT_CTLR
 
 choice BT_LL_CHOICE
 	prompt "Bluetooth Link Layer Selection"
-	default BT_LL_SW_SPLIT
 	help
 	  Select the Bluetooth Link Layer to compile.
 


### PR DESCRIPTION
Revert default selection of CONFIG_LL_SW_SPLIT since CONFIG_LL_SOFTDEVICE is now the default.
Revert main stack size configuration in SMP_SVR and instead change the default main stack size to for easier stack size managament.