### PR TITLE
Autopts rpmsg l2cap le cfc bv06c downstream

### DIFF
--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include "bttester.h"
 
 #define CONTROLLER_INDEX 0
-#define DATA_MTU 264
+#define DATA_MTU (256 + BT_L2CAP_CHAN_SEND_RESERVE)
 #define CHANNELS 2
 #define SERVERS 1
 


### PR DESCRIPTION
With this change, L2CAP/LE/CFC/BV-06-C can be supported when using
BT_RPMSG and the others HCI transports.

Depending on CONFIG_BT_HCI_RESERVE, the HCI transport requires extra
headroom in a BT buffer.

Signed-off-by: Ryan Chu ryan.chu@nordicsemi.no