### PR TITLE
Bluetooth: Update experimental and backport fixes

### DIFF
--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -107,7 +107,7 @@ config BT_BROADCASTER
 endmenu
 
 config BT_EXT_ADV
-	bool "Extended Advertising and Scanning support [EXPERIMENTAL]"
+	bool "Extended Advertising and Scanning support"
 	help
 	  Select this to enable Extended Advertising API support.
 	  This enables support for advertising with multiple advertising sets,

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -95,7 +95,7 @@ choice BT_LL_CHOICE
 	  Select the Bluetooth Link Layer to compile.
 
 config BT_LL_SW_SPLIT
-	bool "Software-based BLE Link Layer"
+	bool "Software-based BLE Link Layer [EXPERIMENTAL]"
 	select BT_RECV_IS_RX_THREAD
 	select ENTROPY_GENERATOR
 	select NRF_HW_TIMER0_RESERVED

--- a/subsys/bluetooth/host/Kconfig.l2cap
+++ b/subsys/bluetooth/host/Kconfig.l2cap
@@ -57,7 +57,7 @@ config BT_L2CAP_DYNAMIC_CHANNEL
 	  allowing the creation of dynamic L2CAP Channels.
 
 config BT_L2CAP_ECRED
-	bool "L2CAP Enhanced Credit Based Flow Control support"
+	bool "L2CAP Enhanced Credit Based Flow Control support [EXPERIMENTAL]"
 	depends on BT_L2CAP_DYNAMIC_CHANNEL
 	help
 	  This option enables support for LE Connection oriented Channels with

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -471,6 +471,30 @@ static int bt_att_chan_send(struct bt_att_chan *chan, struct net_buf *buf,
 	return chan_send(chan, buf, cb);
 }
 
+static void att_send_process(struct bt_att *att)
+{
+	struct bt_att_chan *chan, *tmp;
+	struct net_buf *buf;
+	int err = -ENOENT;
+
+	buf = net_buf_get(&att->tx_queue, K_NO_WAIT);
+	if (!buf) {
+		return;
+	}
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&att->chans, chan, tmp, node) {
+		err = bt_att_chan_send(chan, buf, NULL);
+		if (err >= 0) {
+			break;
+		}
+	}
+
+	if (err < 0) {
+		/* Push it back if it could not be send */
+		k_queue_prepend(&att->tx_queue._queue, buf);
+	}
+}
+
 static void bt_att_chan_send_rsp(struct bt_att_chan *chan, struct net_buf *buf,
 				 bt_att_chan_sent_t cb)
 {
@@ -583,7 +607,7 @@ static int bt_att_chan_req_send(struct bt_att_chan *chan,
 	return err;
 }
 
-static void att_process(struct bt_att *att)
+static void att_req_send_process(struct bt_att *att)
 {
 	sys_snode_t *node;
 	struct bt_att_chan *chan, *tmp;
@@ -649,7 +673,7 @@ static uint8_t att_handle_rsp(struct bt_att_chan *chan, void *pdu, uint16_t len,
 
 process:
 	/* Process pending requests */
-	att_process(chan->att);
+	att_req_send_process(chan->att);
 	if (func) {
 		func(chan->att->conn, err, pdu, len, params);
 	}
@@ -2993,9 +3017,7 @@ void bt_att_req_free(struct bt_att_req *req)
 int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
 		void *user_data)
 {
-	struct bt_att_chan *chan, *tmp;
 	struct bt_att *att;
-	int ret;
 
 	__ASSERT_NO_MSG(conn);
 	__ASSERT_NO_MSG(buf);
@@ -3014,20 +3036,8 @@ int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
 					user_data);
 	}
 
-	ret = 0;
-
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&att->chans, chan, tmp, node) {
-		ret = bt_att_chan_send(chan, buf, NULL);
-		if (ret >= 0) {
-			break;
-		}
-	}
-
-	if (ret < 0) {
-		/* Queue buffer to be send later */
-		BT_DBG("Queueing buffer %p", buf);
-		net_buf_put(&att->tx_queue, buf);
-	}
+	net_buf_put(&att->tx_queue, buf);
+	att_send_process(att);
 
 	return 0;
 }
@@ -3035,7 +3045,6 @@ int bt_att_send(struct bt_conn *conn, struct net_buf *buf, bt_conn_tx_cb_t cb,
 int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req)
 {
 	struct bt_att *att;
-	struct bt_att_chan *chan, *tmp;
 
 	BT_DBG("conn %p req %p", conn, req);
 
@@ -3049,22 +3058,8 @@ int bt_att_req_send(struct bt_conn *conn, struct bt_att_req *req)
 		return -ENOTCONN;
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&att->chans, chan, tmp, node) {
-		/* If there is nothing pending use the channel */
-		if (!chan->req) {
-			int ret;
-
-			ret = bt_att_chan_req_send(chan, req);
-			if (ret >= 0) {
-				return ret;
-			}
-		}
-	}
-
-	/* Queue the request to be send later */
 	sys_slist_append(&att->reqs, &req->node);
-
-	BT_DBG("req %p queued", req);
+	att_req_send_process(att);
 
 	return 0;
 }

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -738,14 +738,8 @@ static uint8_t get_encryption_key_size(struct bt_smp *smp)
 /* Check that if a new pairing procedure with an existing bond will not lower
  * the established security level of the bond.
  */
-static bool update_keys_check(struct bt_smp *smp)
+static bool update_keys_check(struct bt_smp *smp, struct bt_keys *keys)
 {
-	struct bt_conn *conn = smp->chan.chan.conn;
-
-	if (!conn->le.keys) {
-		conn->le.keys = bt_keys_get_addr(conn->id, &conn->le.dst);
-	}
-
 	if (IS_ENABLED(CONFIG_BT_SMP_DISABLE_LEGACY_JW_PASSKEY) &&
 	    !atomic_test_bit(smp->flags, SMP_FLAG_SC) &&
 	    smp->method != LEGACY_OOB) {
@@ -757,27 +751,27 @@ static bool update_keys_check(struct bt_smp *smp)
 		return false;
 	}
 
-	if (!conn->le.keys ||
-	    !(conn->le.keys->keys & (BT_KEYS_LTK_P256 | BT_KEYS_LTK))) {
+	if (!keys ||
+	    !(keys->keys & (BT_KEYS_LTK_P256 | BT_KEYS_LTK))) {
 		return true;
 	}
 
-	if (conn->le.keys->enc_size > get_encryption_key_size(smp)) {
+	if (keys->enc_size > get_encryption_key_size(smp)) {
 		return false;
 	}
 
-	if ((conn->le.keys->keys & BT_KEYS_LTK_P256) &&
+	if ((keys->keys & BT_KEYS_LTK_P256) &&
 	    !atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
 		return false;
 	}
 
-	if ((conn->le.keys->flags & BT_KEYS_AUTHENTICATED) &&
+	if ((keys->flags & BT_KEYS_AUTHENTICATED) &&
 	     smp->method == JUST_WORKS) {
 		return false;
 	}
 
 	if (!IS_ENABLED(CONFIG_BT_SMP_ALLOW_UNAUTH_OVERWRITE) &&
-	    (!(conn->le.keys->flags & BT_KEYS_AUTHENTICATED)
+	    (!(keys->flags & BT_KEYS_AUTHENTICATED)
 	     && smp->method == JUST_WORKS)) {
 		return false;
 	}
@@ -2956,7 +2950,7 @@ static uint8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 
 	smp->method = get_pair_method(smp, req->io_capability);
 
-	if (!update_keys_check(smp)) {
+	if (!update_keys_check(smp, conn->le.keys)) {
 		return BT_SMP_ERR_AUTH_REQUIREMENTS;
 	}
 
@@ -3158,7 +3152,7 @@ static uint8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 
 	smp->method = get_pair_method(smp, rsp->io_capability);
 
-	if (!update_keys_check(smp)) {
+	if (!update_keys_check(smp, conn->le.keys)) {
 		return BT_SMP_ERR_AUTH_REQUIREMENTS;
 	}
 

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3792,6 +3792,18 @@ static uint8_t smp_ident_addr_info(struct bt_smp *smp, struct net_buf *buf)
 		return BT_SMP_ERR_INVALID_PARAMS;
 	}
 
+	if (bt_addr_le_cmp(&conn->le.dst, &req->addr) != 0) {
+		struct bt_keys *keys = bt_keys_find_addr(conn->id, &req->addr);
+
+		if (keys) {
+			if (!update_keys_check(smp, keys)) {
+				return BT_SMP_ERR_UNSPECIFIED;
+			}
+
+			bt_keys_clear(keys);
+		}
+	}
+
 	if (atomic_test_bit(smp->flags, SMP_FLAG_BOND)) {
 		const bt_addr_le_t *dst;
 		struct bt_keys *keys;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -2699,9 +2699,16 @@ static uint8_t get_auth(struct bt_conn *conn, uint8_t auth)
 
 static uint8_t remote_sec_level_reachable(struct bt_smp *smp)
 {
-	struct bt_conn *conn = smp->chan.chan.conn;
+	bt_security_t sec = smp->chan.chan.conn->required_sec_level;
 
-	switch (conn->required_sec_level) {
+	if (IS_ENABLED(CONFIG_BT_SMP_SC_ONLY)) {
+		sec = BT_SECURITY_L4;
+	}
+	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
+		sec = BT_SECURITY_L3;
+	}
+
+	switch (sec) {
 	case BT_SECURITY_L1:
 	case BT_SECURITY_L2:
 		return 0;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -2697,6 +2697,35 @@ static uint8_t get_auth(struct bt_conn *conn, uint8_t auth)
 	return auth;
 }
 
+static uint8_t remote_sec_level_reachable(struct bt_smp *smp)
+{
+	struct bt_conn *conn = smp->chan.chan.conn;
+
+	switch (conn->required_sec_level) {
+	case BT_SECURITY_L1:
+	case BT_SECURITY_L2:
+		return 0;
+
+	case BT_SECURITY_L4:
+		if (get_encryption_key_size(smp) != BT_SMP_MAX_ENC_KEY_SIZE) {
+			return BT_SMP_ERR_ENC_KEY_SIZE;
+		}
+
+		if (!atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
+			return BT_SMP_ERR_AUTH_REQUIREMENTS;
+		}
+		__fallthrough;
+	case BT_SECURITY_L3:
+		if (smp->method == JUST_WORKS) {
+			return BT_SMP_ERR_AUTH_REQUIREMENTS;
+		}
+
+		return 0;
+	default:
+		return BT_SMP_ERR_UNSPECIFIED;
+	}
+}
+
 static bool sec_level_reachable(struct bt_conn *conn)
 {
 	switch (conn->required_sec_level) {
@@ -2877,6 +2906,7 @@ static uint8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 	struct bt_conn *conn = smp->chan.chan.conn;
 	struct bt_smp_pairing *req = (void *)buf->data;
 	struct bt_smp_pairing *rsp;
+	uint8_t err;
 
 	BT_DBG("");
 
@@ -2954,15 +2984,17 @@ static uint8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 		return BT_SMP_ERR_AUTH_REQUIREMENTS;
 	}
 
+	err = remote_sec_level_reachable(smp);
+	if (err) {
+		return err;
+	}
+
 	if (!atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
 #if defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
 		return BT_SMP_ERR_AUTH_REQUIREMENTS;
 #else
 		if (IS_ENABLED(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)) {
-			uint8_t err;
-
-			err = smp_pairing_accept_query(smp->chan.chan.conn,
-						      req);
+			err = smp_pairing_accept_query(conn, req);
 			if (err) {
 				return err;
 			}
@@ -2972,22 +3004,8 @@ static uint8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 #endif /* CONFIG_BT_SMP_SC_PAIR_ONLY */
 	}
 
-	if ((IS_ENABLED(CONFIG_BT_SMP_SC_ONLY) ||
-	     conn->required_sec_level == BT_SECURITY_L4) &&
-		smp->method == JUST_WORKS) {
-		return BT_SMP_ERR_AUTH_REQUIREMENTS;
-	}
-
-	if ((IS_ENABLED(CONFIG_BT_SMP_SC_ONLY) ||
-	     conn->required_sec_level == BT_SECURITY_L4) &&
-	       get_encryption_key_size(smp) != BT_SMP_MAX_ENC_KEY_SIZE) {
-		return BT_SMP_ERR_ENC_KEY_SIZE;
-	}
-
 	if (IS_ENABLED(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)) {
-		uint8_t err;
-
-		err = smp_pairing_accept_query(smp->chan.chan.conn, req);
+		err = smp_pairing_accept_query(conn, req);
 		if (err) {
 			return err;
 		}
@@ -2997,7 +3015,7 @@ static uint8_t smp_pairing_req(struct bt_smp *smp, struct net_buf *buf)
 	    !atomic_test_bit(smp->flags, SMP_FLAG_SEC_REQ) &&
 	    bt_auth && bt_auth->pairing_confirm) {
 		atomic_set_bit(smp->flags, SMP_FLAG_USER);
-		bt_auth->pairing_confirm(smp->chan.chan.conn);
+		bt_auth->pairing_confirm(conn);
 		return 0;
 	}
 
@@ -3116,6 +3134,7 @@ static uint8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 	struct bt_conn *conn = smp->chan.chan.conn;
 	struct bt_smp_pairing *rsp = (void *)buf->data;
 	struct bt_smp_pairing *req = (struct bt_smp_pairing *)&smp->preq[1];
+	uint8_t err;
 
 	BT_DBG("");
 
@@ -3156,15 +3175,17 @@ static uint8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 		return BT_SMP_ERR_AUTH_REQUIREMENTS;
 	}
 
+	err = remote_sec_level_reachable(smp);
+	if (err) {
+		return err;
+	}
+
 	if (!atomic_test_bit(smp->flags, SMP_FLAG_SC)) {
 #if defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
 		return BT_SMP_ERR_AUTH_REQUIREMENTS;
 #else
 		if (IS_ENABLED(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)) {
-			uint8_t err;
-
-			err = smp_pairing_accept_query(smp->chan.chan.conn,
-						       rsp);
+			err = smp_pairing_accept_query(conn, rsp);
 			if (err) {
 				return err;
 			}
@@ -3174,25 +3195,11 @@ static uint8_t smp_pairing_rsp(struct bt_smp *smp, struct net_buf *buf)
 #endif /* CONFIG_BT_SMP_SC_PAIR_ONLY */
 	}
 
-	if ((IS_ENABLED(CONFIG_BT_SMP_SC_ONLY) ||
-	     conn->required_sec_level == BT_SECURITY_L4) &&
-	     smp->method == JUST_WORKS) {
-		return BT_SMP_ERR_AUTH_REQUIREMENTS;
-	}
-
-	if ((IS_ENABLED(CONFIG_BT_SMP_SC_ONLY) ||
-	     conn->required_sec_level == BT_SECURITY_L4) &&
-	     get_encryption_key_size(smp) != BT_SMP_MAX_ENC_KEY_SIZE) {
-		return BT_SMP_ERR_ENC_KEY_SIZE;
-	}
-
 	smp->local_dist &= SEND_KEYS_SC;
 	smp->remote_dist &= RECV_KEYS_SC;
 
 	if (IS_ENABLED(CONFIG_BT_SMP_APP_PAIRING_ACCEPT)) {
-		uint8_t err;
-
-		err = smp_pairing_accept_query(smp->chan.chan.conn, rsp);
+		err = smp_pairing_accept_query(conn, rsp);
 		if (err) {
 			return err;
 		}

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BT_MESH
-	bool "Bluetooth Mesh support"
+	bool "Bluetooth Mesh support [EXPERIMENTAL]"
 	select TINYCRYPT
 	select TINYCRYPT_AES
 	select TINYCRYPT_AES_CMAC


### PR DESCRIPTION
Update experimental tag in Bluetooth to be aligned with unqualified bluetooth features:
 - Zephyr controller does not yet have a qualification for this release.
 - Bluetooth Mesh does not yet have a qualification for this release.
 - Remove experimental on qualified feature Extended Advertising.
 - Add experimental on unqualified feature L2CAP Enhanced Credit Based Flow Control.

Cherry-pick fixes:
 - Fix ATT packet reordering
 - Fix not overwriting the Bond when peer has stopped using the IRK stored in the Bond information.
 - Fail pairing early during Pairing Feature Exchange if the required security cannot be reached.
 - Fail pairing early during Pairing Feature Exchange in SC-only mode if security is initiated by remote that cannot reach L4.