### PR TITLE
[nrf fromlist] Add initial Thingy53 support.

### DIFF
--- a/boards/arm/thingy53_nrf5340/CMakeLists.txt
+++ b/boards/arm/thingy53_nrf5340/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+
+if ((CONFIG_BOARD_THINGY53_NRF5340_CPUAPP OR CONFIG_BOARD_THINGY53_NRF5340_CPUAPPNS)
+    AND CONFIG_BOARD_ENABLE_CPUNET)
+	zephyr_library()
+	zephyr_library_sources(nrf5340_cpunet_reset.c)
+endif()
+
+if (CONFIG_BOARD_THINGY53_NRF5340_CPUAPP OR CONFIG_BOARD_THINGY53_NRF5340_CPUAPPNS)
+	zephyr_library_sources(board.c)
+endif()

--- a/boards/arm/thingy53_nrf5340/Kconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig
@@ -1,0 +1,109 @@
+# Thingy53 NRF5340 board configuration
+
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config THINGY53_MISO_WORKAROUND
+	bool "MISO workaround"
+	default SPI
+	help
+	  Workaround SPI bus MISO issues. The workaround sets dedicated pin
+	  high in order to avoid voltage drops on the SPI MISO line.
+
+config THINGY53_INIT_PRIORITY
+	int "Init priority"
+	default 70
+	help
+	  Initialization pririty of the Thingy53 board including powering external sensors
+	  and enabling existing workarounds.
+
+config IPM_NRFX
+	default IPM
+
+config RPMSG_SERVICE_DUAL_IPM_SUPPORT
+	default RPMSG_SERVICE
+
+if RPMSG_SERVICE_DUAL_IPM_SUPPORT
+
+config IPM_MSG_CH_0_ENABLE
+	default y
+
+config IPM_MSG_CH_1_ENABLE
+	default y
+
+config RPMSG_SERVICE_IPM_TX_NAME
+	default "IPM_0" if RPMSG_SERVICE_MODE_MASTER
+	default "IPM_1" if RPMSG_SERVICE_MODE_REMOTE
+
+config RPMSG_SERVICE_IPM_RX_NAME
+	default "IPM_1" if RPMSG_SERVICE_MODE_MASTER
+	default "IPM_0" if RPMSG_SERVICE_MODE_REMOTE
+
+config IPM_MSG_CH_0_TX
+	default RPMSG_SERVICE_MODE_MASTER
+
+config IPM_MSG_CH_0_RX
+	default RPMSG_SERVICE_MODE_REMOTE
+
+config IPM_MSG_CH_1_TX
+	default RPMSG_SERVICE_MODE_REMOTE
+
+config IPM_MSG_CH_1_RX
+	default RPMSG_SERVICE_MODE_MASTER
+
+endif # RPMSG_SERVICE_DUAL_IPM_SUPPORT
+
+if BOARD_THINGY53_NRF5340_CPUAPP || BOARD_THINGY53_NRF5340_CPUAPPNS
+
+config BOARD_ENABLE_DCDC_APP
+	bool "Enable Application MCU DCDC converter"
+	select SOC_DCDC_NRF53X_APP
+	default y
+
+config BOARD_ENABLE_DCDC_NET
+	bool "Enable Network MCU DCDC converter"
+	select SOC_DCDC_NRF53X_NET
+	default y
+
+config BOARD_ENABLE_DCDC_HV
+	bool "Enable High Voltage DCDC converter"
+	select SOC_DCDC_NRF53X_HV
+	default y
+
+config BOARD_ENABLE_CPUNET
+	bool "Enable nRF53 Network MCU"
+	help
+	  This option enables releasing the Network 'force off' signal, which
+	  as a consequence will power up the Network MCU during system boot.
+	  Additionally, the option allocates GPIO pins that will be used by UARTE
+	  of the Network MCU.
+	  Note: GPIO pin allocation can only be configured by the secure Application
+	  MCU firmware, so when this option is used with the non-secure version of
+	  the board, the application needs to take into consideration, that the
+	  secure firmware image must already have configured GPIO allocation for the
+	  Network MCU.
+	default y if (BT || NRF_802154_SER_HOST)
+
+config DOMAIN_CPUNET_BOARD
+	string
+	default "thingy53_nrf5340_cpunet"
+	depends on BOARD_ENABLE_CPUNET
+	help
+	  The board which will be used for CPUNET domain when creating a multi
+	  image application where one or more images should be located on
+	  another board. For example hci_rpmsg on the nRF5340_cpunet for
+	  Bluetooth applications.
+
+endif # BOARD_THINGY53_NRF5340_CPUAPP || BOARD_THINGY53_NRF5340_CPUAPPNS
+
+if BOARD_THINGY53_NRF5340_CPUNET
+
+config DOMAIN_CPUAPP_BOARD
+	string
+	default "thingy53_nrf5340_cpuapp"
+	help
+	  The board which will be used for CPUAPP domain when creating a multi
+	  image application where one or more images should be located on
+	  another board.
+
+endif # BOARD_THINGY53_NRF5340_CPUNET

--- a/boards/arm/thingy53_nrf5340/Kconfig.board
+++ b/boards/arm/thingy53_nrf5340/Kconfig.board
@@ -1,0 +1,21 @@
+# Thingy53 NRF5340 board configuration
+
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_NRF5340_CPUAPP_QKAA
+
+config BOARD_THINGY53_NRF5340_CPUAPP
+	bool "Thingy53 nRF5340 Application MCU"
+
+config BOARD_THINGY53_NRF5340_CPUAPPNS
+	bool "Thingy53 nRF5340 Application MCU non-secure"
+
+endif # SOC_NRF5340_CPUAPP_QKAA
+
+if SOC_NRF5340_CPUNET_QKAA
+
+config BOARD_THINGY53_NRF5340_CPUNET
+	bool "Thingy53 NRF5340 Network MCU"
+
+endif # SOC_NRF5340_CPUNET_QKAA

--- a/boards/arm/thingy53_nrf5340/Kconfig.defconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig.defconfig
@@ -1,0 +1,103 @@
+# Thingy53 NRF5340 board configuration
+
+# Copyright (c) 2021 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_THINGY53_NRF5340_CPUAPP || BOARD_THINGY53_NRF5340_CPUAPPNS
+
+config BOARD
+	default "thingy53_nrf5340_cpuapp"
+
+# By default, if we build for a Non-Secure version of the board,
+# force building with TF-M as the Secure Execution Environment.
+
+config BUILD_WITH_TFM
+	# Temporarily disable building Non-Secure images with TF-M support by
+	# default.
+	# default y if BOARD_THINGY53_NRF5340_CPUAPPNS
+	default n
+
+# Code Partition:
+#
+# For the secure version of the board the firmware is linked at the beginning
+# of the flash, or into the code-partition defined in DT if it is intended to
+# be loaded by MCUboot. If the secure firmware is to be combined with a non-
+# secure image (TRUSTED_EXECUTION_SECURE=y), the secure FW image shall always
+# be restricted to the size of its code partition.
+#
+# For the non-secure version of the board, the firmware
+# must be linked into the code-partition (non-secure) defined in DT, regardless.
+# Apply this configuration below by setting the Kconfig symbols used by
+# the linker according to the information extracted from DT partitions.
+
+# SRAM Partition:
+#
+# If the secure firmware is to be combined with a non-secure image
+# (TRUSTED_EXECUTION_SECURE=y), the secure FW image SRAM shall always
+# be restricted to the secure image SRAM partition (sram-secure-partition).
+# Otherwise (if TRUSTED_EXECUTION_SECURE is not set) the whole zephyr,sram
+# may be used by the image.
+#
+# For the non-secure version of the board, the firmware image SRAM is
+# always restricted to the allocated non-secure SRAM partition.
+#
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+DT_CHOSEN_Z_SRAM_PARTITION := zephyr,sram-secure-partition
+
+if BOARD_THINGY53_NRF5340_CPUAPP && TRUSTED_EXECUTION_SECURE
+
+config FLASH_LOAD_SIZE
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+
+config SRAM_SIZE
+	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_SRAM_PARTITION),0,K)
+
+endif # BOARD_THINGY53_NRF5340_CPUAPP && TRUSTED_EXECUTION_SECURE
+
+if BOARD_THINGY53_NRF5340_CPUAPPNS
+
+config FLASH_LOAD_OFFSET
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+
+config FLASH_LOAD_SIZE
+	default $(dt_chosen_reg_size_hex,$(DT_CHOSEN_Z_CODE_PARTITION))
+
+endif # BOARD_THINGY53_NRF5340_CPUAPPNS
+
+choice BT_HCI_BUS_TYPE
+	default BT_RPMSG if BT
+endchoice
+
+config HEAP_MEM_POOL_SIZE
+	default 4096 if BT_RPMSG
+
+config BT_HAS_HCI_VS
+	default BT
+
+config USB_NRFX
+	default USB
+
+config USB_DEVICE_STACK
+	default USB
+
+config I2C
+	default y
+
+config SPI
+	default y
+
+endif # BOARD_THINGY53_NRF5340_CPUAPP || BOARD_THINGY53_NRF5340_CPUAPPNS
+
+if BOARD_THINGY53_NRF5340_CPUNET
+
+config BOARD
+	default "thingy53_nrf5340_cpunet"
+
+config BT_CTLR
+	default BT
+
+config BT_ECC
+	default BT
+
+endif # BOARD_THINGY53_NRF5340_CPUNET

--- a/boards/arm/thingy53_nrf5340/board.c
+++ b/boards/arm/thingy53_nrf5340/board.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <init.h>
+#include <hal/nrf_gpio.h>
+#include <nrfx.h>
+#include <device.h>
+#include <drivers/gpio.h>
+
+#include <logging/log.h>
+#define LOG_LEVEL LOG_LEVEL_ERR
+LOG_MODULE_REGISTER(thingy53_board_init, LOG_LEVEL);
+
+#define NRF21540FEM_CTRL_LABEL		 DT_NODELABEL(nrf21540fem_ctrl)
+#define NRF21540FEM_CTRL_RX_EN_PIN	 DT_GPIO_PIN(NRF21540FEM_CTRL_LABEL, rx_en_gpios)
+#define NRF21540FEM_CTRL_MODE_PIN	 DT_GPIO_PIN(NRF21540FEM_CTRL_LABEL, mode_gpios)
+#define NRF21540FEM_CTRL_TX_EN_PIN	 DT_GPIO_PIN(NRF21540FEM_CTRL_LABEL, tx_en_gpios)
+#define NRF21540FEM_CTRL_PDN_GPIO_NODE   DT_GPIO_CTLR(NRF21540FEM_CTRL_LABEL, pdn_gpios)
+#define NRF21540FEM_CTRL_PDN_PIN	 DT_GPIO_PIN(NRF21540FEM_CTRL_LABEL, pdn_gpios)
+#define NRF21540FEM_CTRL_PDN_FLAGS	 DT_GPIO_FLAGS(NRF21540FEM_CTRL_LABEL, pdn_gpios)
+
+#define REG_3V3_LABEL			 DT_NODELABEL(regulator_3v3)
+#define REG_3V3_GPIO_NODE		 DT_GPIO_CTLR(REG_3V3_LABEL, enable_gpios)
+#define REG_3V3_ENABLE_PIN		 DT_GPIO_PIN(REG_3V3_LABEL, enable_gpios)
+#define REG_3V3_ENABLE_FLAGS		 DT_GPIO_FLAGS(REG_3V3_LABEL, enable_gpios)
+
+#define SENSOR_PWR_CTRL_LABEL		 DT_NODELABEL(sensor_pwr_ctrl)
+#define SENSOR_PWR_CTRL_GPIO_NODE	 DT_GPIO_CTLR(SENSOR_PWR_CTRL_LABEL, enable_gpios)
+#define SENSOR_PWR_CTRL_PIN		 DT_GPIO_PIN(SENSOR_PWR_CTRL_LABEL, enable_gpios)
+#define SENSOR_PWR_CTRL_FLAGS		 DT_GPIO_FLAGS(SENSOR_PWR_CTRL_LABEL, enable_gpios)
+
+#define ADXL362_LABEL			 DT_NODELABEL(adxl362)
+#define ADXL362_GPIO_NODE		 DT_SPI_DEV_CS_GPIOS_CTLR(ADXL362_LABEL)
+#define ADXL362_CS			 DT_SPI_DEV_CS_GPIOS_PIN(ADXL362_LABEL)
+#define ADXL362_FLAGS			 DT_SPI_DEV_CS_GPIOS_FLAGS(ADXL362_LABEL)
+
+#define BMI270_LABEL			 DT_NODELABEL(bmi270)
+#define BMI270_GPIO_NODE		 DT_SPI_DEV_CS_GPIOS_CTLR(BMI270_LABEL)
+#define BMI270_CS			 DT_SPI_DEV_CS_GPIOS_PIN(BMI270_LABEL)
+#define BMI270_FLAGS			 DT_SPI_DEV_CS_GPIOS_FLAGS(BMI270_LABEL)
+
+#define NRF21540FEM_LABEL		 DT_NODELABEL(nrf21540fem)
+#define NRF21540FEM_GPIO_NODE		 DT_SPI_DEV_CS_GPIOS_CTLR(NRF21540FEM_LABEL)
+#define NRF21540FEM_CS			 DT_SPI_DEV_CS_GPIOS_PIN(NRF21540FEM_LABEL)
+#define NRF21540FEM_FLAGS		 DT_SPI_DEV_CS_GPIOS_FLAGS(NRF21540FEM_LABEL)
+
+static int setup(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	const struct device *gpio;
+	int err;
+
+	gpio = DEVICE_DT_GET(REG_3V3_GPIO_NODE);
+	if (!device_is_ready(gpio)) {
+		LOG_ERR("Gpio device not ready");
+		return -ENODEV;
+	}
+	err = gpio_pin_configure(gpio, REG_3V3_ENABLE_PIN,
+				 REG_3V3_ENABLE_FLAGS | GPIO_OUTPUT_ACTIVE);
+	if (err < 0) {
+		LOG_ERR("Failed to configure pin %d", REG_3V3_ENABLE_PIN);
+		return err;
+	}
+
+	gpio = DEVICE_DT_GET(SENSOR_PWR_CTRL_GPIO_NODE);
+	if (!device_is_ready(gpio)) {
+		LOG_ERR("Gpio device not ready");
+		return -ENODEV;
+	}
+	err = gpio_pin_configure(gpio, SENSOR_PWR_CTRL_PIN,
+				 SENSOR_PWR_CTRL_FLAGS | GPIO_OUTPUT_ACTIVE);
+	if (err < 0) {
+		LOG_ERR("Failed to configure pin %d", SENSOR_PWR_CTRL_PIN);
+		return err;
+	}
+
+	gpio = DEVICE_DT_GET(NRF21540FEM_CTRL_PDN_GPIO_NODE);
+	if (!device_is_ready(gpio)) {
+		LOG_ERR("Gpio device not ready");
+		return -ENODEV;
+	}
+	err = gpio_pin_configure(gpio, NRF21540FEM_CTRL_PDN_PIN,
+				 NRF21540FEM_CTRL_PDN_FLAGS |
+				 IS_ENABLED(CONFIG_THINGY53_MISO_WORKAROUND) ?
+				 GPIO_OUTPUT_ACTIVE : GPIO_OUTPUT_INACTIVE);
+	if (err < 0) {
+		LOG_ERR("Failed to configure NRF21540FEM PDN Pin");
+		return err;
+	}
+
+	gpio = DEVICE_DT_GET(ADXL362_GPIO_NODE);
+	if (!device_is_ready(gpio)) {
+		LOG_ERR("Gpio device not ready");
+		return -ENODEV;
+	}
+	err = gpio_pin_configure(gpio, ADXL362_CS, ADXL362_FLAGS | GPIO_OUTPUT_INACTIVE);
+	if (err < 0) {
+		LOG_ERR("Failed to configure ADXL362 CS Pin");
+		return err;
+	}
+
+	gpio = DEVICE_DT_GET(BMI270_GPIO_NODE);
+	if (!device_is_ready(gpio)) {
+		LOG_ERR("Gpio device not ready");
+		return -ENODEV;
+	}
+	err = gpio_pin_configure(gpio, BMI270_CS, BMI270_FLAGS | GPIO_OUTPUT_INACTIVE);
+	if (err < 0) {
+		LOG_ERR("Failed to configure BMI270 CS Pin");
+		return err;
+	}
+
+	gpio = DEVICE_DT_GET(NRF21540FEM_GPIO_NODE);
+	if (!device_is_ready(gpio)) {
+		LOG_ERR("Gpio device not ready");
+		return -ENODEV;
+	}
+	err = gpio_pin_configure(gpio, NRF21540FEM_CS, NRF21540FEM_FLAGS | GPIO_OUTPUT_INACTIVE);
+	if (err < 0) {
+		LOG_ERR("Failed to configure NRF21540FEM CS Pin");
+		return err;
+	}
+
+#if (CONFIG_BOARD_ENABLE_CPUNET && \
+	(CONFIG_BOARD_THINGY53_NRF5340_CPUAPP || CONFIG_BOARD_THINGY53_NRF5340_CPUAPPNS))
+	/* Give nRF21540fem control pins to NetworkMCU */
+	nrf_gpio_pin_mcu_select(NRF21540FEM_CTRL_TX_EN_PIN,
+				GPIO_PIN_CNF_MCUSEL_NetworkMCU); /* TX_EN */
+	nrf_gpio_pin_mcu_select(32 + NRF21540FEM_CTRL_PDN_PIN,
+				GPIO_PIN_CNF_MCUSEL_NetworkMCU); /* PDN */
+	nrf_gpio_pin_mcu_select(32 + NRF21540FEM_CTRL_RX_EN_PIN,
+				GPIO_PIN_CNF_MCUSEL_NetworkMCU); /* RX_EN */
+	nrf_gpio_pin_mcu_select(32 + NRF21540FEM_CTRL_MODE_PIN,
+				GPIO_PIN_CNF_MCUSEL_NetworkMCU); /* MODE */
+#endif /* (CONFIG_BOARD_ENABLE_CPUNET &&
+	* (CONFIG_BOARD_THINGY53_NRF5340_CPUAPP || CONFIG_BOARD_THINGY53_NRF5340_CPUAPPNS))
+	*/
+
+	return 0;
+}
+
+SYS_INIT(setup, POST_KERNEL, CONFIG_THINGY53_INIT_PRIORITY);

--- a/boards/arm/thingy53_nrf5340/board.cmake
+++ b/boards/arm/thingy53_nrf5340/board.cmake
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: Apache-2.0
+
+if(CONFIG_BOARD_THINGY53_NRF5340_CPUAPPNS)
+  set(TFM_PUBLIC_KEY_FORMAT "full")
+endif()
+
+if((CONFIG_BOARD_THINGY53_NRF5340_CPUAPP OR CONFIG_BOARD_THINGY53_NRF5340_CPUAPPNS))
+board_runner_args(jlink "--device=nrf5340_xxaa_app" "--speed=4000")
+endif()
+
+if(CONFIG_BOARD_THINGY53_NRF5340_CPUNET)
+board_runner_args(jlink "--device=nrf5340_xxaa_net" "--speed=4000")
+endif()
+
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/thingy53_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/thingy53_nrf5340/nrf5340_cpunet_reset.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019-2021 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <init.h>
+#include <logging/log.h>
+
+#include <soc.h>
+
+LOG_MODULE_REGISTER(thingy53_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
+
+static int remoteproc_mgr_boot(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	/* Retain nRF5340 Network MCU in Secure domain (bus
+	 * accesses by Network MCU will have Secure attribute set).
+	 */
+	NRF_SPU->EXTDOMAIN[0].PERM = 1 << 4;
+#endif /* !CONFIG_TRUSTED_EXECUTION_NONSECURE */
+
+#if !defined(CONFIG_TRUSTED_EXECUTION_SECURE)
+	/*
+	 * Building Zephyr with CONFIG_TRUSTED_EXECUTION_SECURE=y implies
+	 * building also a Non-Secure image. The Non-Secure image will, in
+	 * this case do the remainder of actions to properly configure and
+	 * boot the Network MCU.
+	 */
+
+	/* Release the Network MCU, 'Release force off signal' */
+	NRF_RESET->NETWORK.FORCEOFF = RESET_NETWORK_FORCEOFF_FORCEOFF_Release;
+
+	LOG_DBG("Network MCU released.");
+#endif /* !CONFIG_TRUSTED_EXECUTION_SECURE */
+
+	return 0;
+}
+
+SYS_INIT(remoteproc_mgr_boot, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/boards/arm/thingy53_nrf5340/pre_dt_board.cmake
+++ b/boards/arm/thingy53_nrf5340/pre_dt_board.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2021 Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - flash-controller@39000 & kmu@39000
+# - power@5000 & clock@5000
+# - /reserved-memory/image@20000000 & /reserved-memory/image_s@20000000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/ {
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,bt-c2h-uart = &uart0;
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio1 14 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 1";
+		};
+		button1: button_1 {
+			gpios = <&gpio1 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 2";
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		red_led: led_1 {
+			gpios = <&gpio1 8 GPIO_ACTIVE_HIGH>;
+			label = "RGB red LED";
+		};
+		green_led: led_2 {
+			gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
+			label = "RGB green LED";
+		};
+		blue_led: led_3 {
+			gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+			label = "RGB blue LED";
+		};
+	};
+
+	pwmdevs {
+		compatible = "pwm-leds";
+		red_led_pwm: led_pwm_0 {
+			pwms = <&pwm0 40>;
+			label = "Red PWM LED";
+		};
+
+		green_led_pwm: led_pwm_1 {
+			pwms = <&pwm0 38>;
+			label = "Green PWM LED";
+		};
+
+		blue_led_pwm: led_pwm_2 {
+			pwms = <&pwm0 39>;
+			label = "Blue PWM LED";
+		};
+
+		buzzer_pwm0: buzzer_pwm_0 {
+			pwms = <&pwm1 47>;
+			label = "Buzzer PWM";
+		};
+	};
+
+	vbatt {
+		compatible = "voltage-divider";
+		io-channels = <&adc 2>;
+		output-ohms = <180000>;
+		full-ohms = <(1500000 + 180000)>;
+		power-gpios = <&gpio0 16 0>;
+	};
+
+	regulator_3v3: regulator-3v3-ctrl {
+		compatible = "regulator-fixed-sync", "regulator-fixed";
+		label = "vsys-3v3-ctrl";
+		regulator-name = "ncp114";
+		enable-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		regulator-boot-on;
+	};
+
+	sensor_pwr_ctrl: sensor-pwr-ctrl {
+		compatible = "regulator-fixed-sync", "regulator-fixed";
+		label = "sens-pwr-ctrl";
+		regulator-name = "tck106ag";
+		enable-gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+	};
+
+	nrf21540fem_ctrl: nrf21540fem-ctrl {
+		compatible = "nordic,nrf21540-fem";
+		rx-en-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+		mode-gpios  = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+		pdn-gpios   = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+		tx-en-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+	};
+
+	aliases {
+		sw0 = &button0;
+		sw1 = &button1;
+		led0 = &red_led;
+		led1 = &green_led;
+		led2 = &blue_led;
+		pwm-led0= &red_led_pwm;
+		pwm-led1 = &green_led_pwm;
+		pwm-led2 = &blue_led_pwm;
+		buzzer-pwm = &buzzer_pwm0;
+	};
+};
+
+/* RGB LED control */
+&pwm0 {
+	status = "okay";
+	ch0-pin = <40>;
+	ch1-pin = <38>;
+	ch2-pin = <39>;
+};
+
+/* Buzzer control */
+&pwm1 {
+	status = "okay";
+	ch0-pin = <47>;
+};
+
+&adc {
+	status = "okay";
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&i2c1 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	sda-gpios = <&gpio1 2 0>;
+	scl-gpios = <&gpio1 3 0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	bmm150@10 {
+		compatible = "bosch,bmm150";
+		label = "BMM150";
+		reg = <0x10>;
+	};
+
+	bh1749@38 {
+		compatible = "rohm,bh1749";
+		label = "BH1749";
+		reg = <0x38>;
+		int-gpios = <&gpio1 5 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+	};
+};
+
+/* External i2c device */
+&i2c2 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	sda-gpios = <&gpio0 5 0>;
+	scl-gpios = <&gpio0 4 0>;
+	clock-frequency = <I2C_BITRATE_FAST>;
+
+	/* Sub-nodes for one/multiple external device(s):
+	 *
+	 *	device_1@i2c_address_1 {
+	 *		compatible = "manufacturer,device_1";
+	 *		label = "LABEL_NAME";
+	 *		reg = <i2c_address_1>;
+	 *		int-gpios = <gpio_node pin flags>;
+	 *	};
+	 *
+	 *	device_2@i2c_address_2 {
+	 *		compatible = "manufacturer,device_2";
+	 *		label = "LABEL_NAME";
+	 *		reg = <i2c_address_2>;
+	 *		int-gpios = <gpio_node pin flags>;
+	 *	};
+	 */
+};
+
+&spi3 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	sck-pin = <29>;
+	mosi-pin = <28>;
+	miso-pin = <26>;
+	cs-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>,
+		   <&gpio1 4  GPIO_ACTIVE_LOW>,
+		   <&gpio0 24 GPIO_ACTIVE_LOW>;
+
+	adxl362: spi-dev-adxl362@0 {
+		compatible = "adi,adxl362";
+		label = "ADXL362";
+		spi-max-frequency = <8000000>;
+		reg = <0>;
+		int1-gpios = <&gpio0 19 0>;
+	};
+
+	bmi270: spi-dev-bmi270@1 {
+		compatible = "bosch,bmi270";
+		label = "BMI270";
+		spi-max-frequency = <8000000>;
+		reg = <1>;
+		int1-gpios = <&gpio0 23 0>;
+	};
+
+	nrf21540fem: spi-dev-nrf21540fem@2 {
+		compatible = "nordic,nrf21540-fem-spi";
+		status = "okay";
+		reg = <2>;
+		label = "FEM_SPI_IF";
+		spi-max-frequency = <8000000>;
+	};
+};
+
+/* UART0 GPIOs can be configured for other use-cases */
+&uart0 {
+	current-speed = <115200>;
+	status = "okay";
+	tx-pin = <12>;
+	rx-pin = <11>;
+	rts-pin = <10>;
+	cts-pin = <9>;
+};
+
+&qspi {
+	status = "okay";
+	sck-pin = <17>;
+	io-pins = <13>, <14>;
+	csn-pins = <18>;
+	mx25r64: mx25r6435f@0 {
+		compatible = "nordic,qspi-nor";
+		reg = <0>;
+		/* MX24R64 supports only pp and pp4io */
+		/* Thingy:53 supports only pp and pp2o options */
+		writeoc = "pp";
+		/* MX24R64 supports all readoc options */
+		/* Thingy:53 supports only fastread and read2io options */
+		readoc = "read2io";
+		sck-frequency = <8000000>;
+		label = "MX25R64";
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 68 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
+};
+
+&timer0 {
+	status = "okay";
+};
+
+&timer1 {
+	status = "okay";
+};
+
+&timer2 {
+	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x00010000>;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+		};
+		slot0_ns_partition: partition@50000 {
+			label = "image-0-nonsecure";
+		};
+		slot1_partition: partition@80000 {
+			label = "image-1";
+		};
+		slot1_ns_partition: partition@c0000 {
+			label = "image-1-nonsecure";
+		};
+		scratch_partition: partition@f0000 {
+			label = "image-scratch";
+			reg = <0x000f0000 0xa000>;
+		};
+		storage_partition: partition@fa000 {
+			label = "storage";
+			reg = <0x000fa000 0x00006000>;
+		};
+	};
+};
+
+/ {
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram0_image: image@20000000 {
+			/* Zephyr image(s) memory */
+		};
+
+		sram0_s: image_s@20000000 {
+			/* Secure image memory */
+		};
+
+		sram0_ns: image_ns@20040000 {
+			/* Non-Secure image memory */
+		};
+	};
+};
+
+/* Include partition configuration file */
+#include "thingy53_nrf5340_partition_conf.dts"

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp.dts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/dts-v1/;
+#include <nordic/nrf5340_cpuapp_qkaa.dtsi>
+#include "thingy53_nrf5340_common.dts"
+
+/ {
+	model = "Nordic Thingy 53 NRF5340 Application";
+	compatible = "nordic,thingy-53-nrf5340-cpuapp";
+
+	chosen {
+		zephyr,sram = &sram0_image;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+		zephyr,sram-secure-partition = &sram0_s;
+		zephyr,sram-non-secure-partition = &sram0_ns;
+	};
+};
+
+&usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+};

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp.yaml
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp.yaml
@@ -1,0 +1,17 @@
+identifier: thingy53_nrf5340_cpuapp
+name: Thingy53-NRF5340-application-MCU
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - xtools
+  - zephyr
+ram: 448
+flash: 1024
+supported:
+  - gpio
+  - i2c
+  - pwm
+  - watchdog
+  - usb_cdc
+  - usb_device

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_defconfig
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_defconfig
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_NRF53X=y
+CONFIG_SOC_NRF5340_CPUAPP_QKAA=y
+CONFIG_BOARD_THINGY53_NRF5340_CPUAPP=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable TrustZone-M
+CONFIG_ARM_TRUSTZONE_M=y
+
+# Enable GPIO
+CONFIG_GPIO=y
+
+# Enable console
+CONFIG_CONSOLE=y

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuappns.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuappns.dts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf5340_cpuappns_qkaa.dtsi>
+#include "thingy53_nrf5340_common.dts"
+
+/ {
+	model = "Nordic Thingy53 NRF5340 Application";
+	compatible = "nordic,thingy-53-nrf5340-cpuapp";
+
+	chosen {
+		zephyr,sram = &sram0_ns;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_ns_partition;
+	};
+};
+
+&usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+};

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuappns.yaml
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuappns.yaml
@@ -1,0 +1,16 @@
+identifier: thingy53_nrf5340_cpuappns
+name: Thingy53-NRF5340-application-MCU-Non-Secure
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - xtools
+  - zephyr
+ram: 192
+flash: 192
+supported:
+  - i2c
+  - pwm
+  - watchdog
+  - usb_cdc
+  - usb_device

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuappns_defconfig
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuappns_defconfig
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_NRF53X=y
+CONFIG_SOC_NRF5340_CPUAPP_QKAA=y
+CONFIG_BOARD_THINGY53_NRF5340_CPUAPPNS=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable TrustZone-M
+CONFIG_ARM_TRUSTZONE_M=y
+
+# This Board implies building Non-Secure firmware
+CONFIG_TRUSTED_EXECUTION_NONSECURE=y
+
+# Enable GPIO
+CONFIG_GPIO=y
+
+# Enable console
+CONFIG_CONSOLE=y

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/dts-v1/;
+#include <nordic/nrf5340_cpunet_qkaa.dtsi>
+
+/ {
+	model = "Nordic Thingy 53 NRF5340 Network";
+	compatible = "nordic,thingy-53-nrf5340-cpunet";
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,bt-c2h-uart = &uart0;
+		zephyr,sram = &sram1;
+		zephyr,flash = &flash1;
+		zephyr,code-partition = &slot0_partition;
+	};
+
+	buttons {
+		compatible = "gpio-keys";
+		button0: button_0 {
+			gpios = <&gpio1 14 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 1";
+		};
+		button1: button_1 {
+			gpios = <&gpio1 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "Push button 2";
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		red_led: led_1 {
+			gpios = <&gpio1 8 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+			label = "RGB red LED";
+		};
+		green_led: led_2 {
+			gpios = <&gpio1 6 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+			label = "RGB green LED";
+		};
+		blue_led: led_3 {
+			gpios = <&gpio1 7 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+			label = "RGB blue LED";
+		};
+	};
+
+	nrf_radio_fem: nrf21540_fem {
+		compatible = "nordic,nrf21540-fem";
+		rx-en-gpios = <&gpio1 11 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+		mode-gpios = <&gpio1 12 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+		pdn-gpios = <&gpio1 10 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+		tx-en-gpios = <&gpio0 30 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
+	};
+
+	aliases {
+		sw0 = &button0;
+		sw1 = &button1;
+		led0 = &red_led;
+		led1 = &green_led;
+		led2 = &blue_led;
+	};
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&i2c0 {
+	status = "disabled";
+};
+
+&spi0 {
+	status = "disabled";
+};
+
+&uart0 {
+	compatible = "nordic,nrf-uarte";
+	status = "disabled";
+	current-speed = <115200>;
+	tx-pin = <12>;
+	rx-pin = <11>;
+	rts-pin = <10>;
+	cts-pin = <9>;
+};
+
+&timer0 {
+	status = "okay";
+};
+
+&timer1 {
+	status = "okay";
+};
+
+&timer2 {
+	status = "okay";
+};
+
+&flash1 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0xc000>;
+		};
+		slot0_partition: partition@c000 {
+			label = "image-0";
+			reg = <0x0000C000 0x12000>;
+		};
+		slot1_partition: partition@1e000 {
+			label = "image-1";
+			reg = <0x0001E000 0x12000>;
+		};
+		scratch_partition: partition@30000 {
+			label = "image-scratch";
+			reg = <0x00030000 0xa000>;
+		};
+		storage_partition: partition@3a000 {
+			label = "storage";
+			reg = <0x0003a000 0x6000>;
+		};
+	};
+};
+
+/* Include shared RAM configuration file */
+#include "thingy53_nrf5340_shared_sram_planning_conf.dts"

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.yaml
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.yaml
@@ -1,0 +1,12 @@
+identifier: thingy53_nrf5340_cpunet
+name: Thingy53-NRF5340-network-MCU
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - xtools
+  - zephyr
+ram: 64
+flash: 256
+supported:
+  - watchdog

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet_defconfig
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet_defconfig
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_NRF53X=y
+CONFIG_SOC_NRF5340_CPUNET_QKAA=y
+CONFIG_BOARD_THINGY53_NRF5340_CPUNET=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# Enable GPIO
+CONFIG_GPIO=y
+
+# Enable console
+CONFIG_CONSOLE=y

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_partition_conf.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_partition_conf.dts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/*
+ * Default Flash planning for thingy53_nrf5340.
+ *
+ * Zephyr build for nRF5340 with ARM TrustZone-M support,
+ * implies building Secure and Non-Secure Zephyr images.
+ *
+ * Secure image will be placed, by default, in flash0
+ * (or in slot0, if MCUboot is present).
+ * Secure image will use sram0 for system memory.
+ *
+ * Non-Secure image will be placed in slot0_ns, and use
+ * sram0_ns for system memory.
+ *
+ * Note that the Secure image only requires knowledge of
+ * the beginning of the Non-Secure image (not its size).
+ */
+
+&slot0_partition {
+	reg = <0x00010000 0x40000>;
+};
+
+&slot0_ns_partition {
+	reg = <0x00050000 0x30000>;
+};
+
+&slot1_partition {
+	reg = <0x00080000 0x40000>;
+};
+
+&slot1_ns_partition {
+	reg = <0x000c0000 0x30000>;
+};
+
+/* Default SRAM planning when building for nRF5340 with
+ * ARM TrustZone-M support
+ * - Lowest 256 kB SRAM allocated to Secure image (sram0_s)
+ * - Middle 192 kB allocated to Non-Secure image (sram0_ns)
+ * - Upper 64 kB SRAM allocated as Shared memory (sram0_shared)
+ *   (see nrf5340_shared_sram_planning_conf.dts)
+ */
+&sram0_image {
+	reg = <0x20000000 DT_SIZE_K(448)>;
+};
+
+&sram0_s {
+	reg = <0x20000000 0x40000>;
+};
+
+&sram0_ns {
+	reg = <0x20040000 0x30000>;
+};
+
+/* Include shared RAM configuration file */
+#include "thingy53_nrf5340_shared_sram_planning_conf.dts"

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_shared_sram_planning_conf.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_shared_sram_planning_conf.dts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Default shared SRAM planning when building for nRF5340.
+ * This file is included by both nRF5340 CPUAPP (Application MCU)
+ * and nRF5340 CPUNET (Network MCU).
+ * - 64 kB SRAM allocated as Shared memory (sram0_shared)
+ * - Region defined after the image SRAM of Application MCU
+ */
+
+/ {
+	chosen {
+		/* shared memory reserved for the inter-processor communication */
+		zephyr,ipc_shm = &sram0_shared;
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		sram0_shared: memory@20070000 {
+			/* SRAM allocated to shared memory */
+			reg = <0x20070000 0x10000>;
+		};
+	};
+};

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -414,6 +414,8 @@ static int bme680_init(const struct device *dev)
 
 	data->i2c_slave_addr = DT_INST_REG_ADDR(0);
 
+	k_msleep(2); /* Start up delay */
+
 	if (bme680_chip_init(dev) < 0) {
 		return -EINVAL;
 	}

--- a/drivers/sensor/bmm150/bmm150.c
+++ b/drivers/sensor/bmm150/bmm150.c
@@ -592,6 +592,8 @@ static int bmm150_init(const struct device *dev)
 		return -EINVAL;
 	}
 
+	k_msleep(1); /* Start up delay */
+
 	if (bmm150_init_chip(dev) < 0) {
 		LOG_ERR("failed to initialize chip");
 		return -EIO;

--- a/samples/sensor/bmm150/src/main.c
+++ b/samples/sensor/bmm150/src/main.c
@@ -37,7 +37,7 @@ void do_main(const struct device *dev)
 
 const struct device *sensor_search()
 {
-	static const char *const magn_sensor[] = { "bmm150", NULL };
+	static const char *const magn_sensor[] = { "BMM150", NULL };
 	const struct device *dev;
 	int i;
 


### PR DESCRIPTION
There is a thing I'm concerned about.
Setting `CONFIG_CONSOLE=y` in `*_defconfig` files even tho there is nothing connected to the UART by default.
I left this for now as its done similarly for Thingy52 but I'm open for suggestions.

My thinking is not to enable it by default, or enable it together with Segger RTT.