### PR TITLE
[nrf fromtree] scripts: size_report: fix bug where key is used

### DIFF
--- a/scripts/footprint/size_report
+++ b/scripts/footprint/size_report
@@ -601,7 +601,7 @@ def main():
 
     symbols = get_symbols(elf, addr_ranges)
 
-    for sym in symbols['unassigned']:
+    for sym in symbols['unassigned'].values():
         print("WARN: Symbol '{0}' is not in RAM or ROM".format(sym['name']))
 
     symbol_dict = None


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/34213

When printing the unassigned values the 'sym' variable is
used as a dict from which we try to get the 'name' value.
However, 'symbols['unassigned']' gives a list of keys, so
we get an 'TypeError' when trying to access ['name'] of
a string (the key).

Fix this issue by iterating over the values from
the 'symbols['unassigned']' dict instead.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>