### PR TITLE
Desktop: Backport fixes needed for desktop application

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -101,7 +101,7 @@ config BT_HCI_ECC_STACK_SIZE
 	# NOTE: This value is derived from other symbols and should only be
 	# changed if required by architecture
 	int "HCI ECC thread stack size"
-	default 1100
+	default 1140
 	help
 	  NOTE: This is an advanced setting and should not be changed unless
 	  absolutely necessary


### PR DESCRIPTION
Update zephyr with 2 fixes need by the desktop application.

 - Bluetooth: host: Fix ECC thread stack size too small
 - drivers: led_pwm: Handle power state changes