### PR TITLE
[nrf fromlist] drivers: ieee802154: Udpate nRF IEEE 802.15.4 radio driver

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -729,8 +729,11 @@ void nrf_802154_received_timestamp_raw(uint8_t *data, int8_t power, uint8_t lqi,
 	__ASSERT(false, "Not enough rx frames allocated for 15.4 driver");
 }
 
-void nrf_802154_receive_failed(nrf_802154_rx_error_t error)
+void nrf_802154_receive_failed(nrf_802154_rx_error_t error, uint32_t id)
 {
+	/* Only immediate reception windows are supported. */
+	__ASSERT_NO_MSG(id == NRF_802154_RESERVED_IMM_RX_WINDOW_ID);
+
 	enum ieee802154_rx_fail_reason reason;
 
 	switch (error) {

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
       revision: f1fa8241f8786198ba41155413243de36ed878a5
       path: modules/hal/infineon
     - name: hal_nordic
-      revision: fc301b97581d01cb5be47f837087a41632070434
+      revision: pull/94/head
       path: modules/hal/nordic
     - name: hal_openisa
       revision: 40d049f69c50b58ea20473bee14cf93f518bf262


### PR DESCRIPTION
This commit updates the revision of hal_nordic component
and introduces necessary changes to the IEEE 802.15.4 driver
to match latest nRF IEEE 802.15.4 radio driver API.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/34451

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>