### PR TITLE
Cherry-pick OpenThread stack overflow fixes

### DIFF
--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -131,7 +131,10 @@ config OPENTHREAD_THREAD_PRIORITY
 config OPENTHREAD_THREAD_STACK_SIZE
 	int "OpenThread thread stack size"
 	default 6144 if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
+	default 6240 if (OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER) && MPU_STACK_GUARD && FPU_SHARING && CPU_CORTEX_M
+	default 3168 if MPU_STACK_GUARD && FPU_SHARING && CPU_CORTEX_M
 	default 3072
+
 
 config OPENTHREAD_PKT_LIST_SIZE
 	int "List size for IPv6 packet buffering"
@@ -139,6 +142,7 @@ config OPENTHREAD_PKT_LIST_SIZE
 
 config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 	int "OpenThread radio transmit workqueue stack size"
+	default 608 if MPU_STACK_GUARD && FPU_SHARING && CPU_CORTEX_M
 	default 512
 
 endmenu # "Zephyr optimizations"

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -27,7 +27,8 @@ config SHELL_MINIMAL
 
 config SHELL_STACK_SIZE
 	int "Shell thread stack size"
-	default 2520 if OPENTHREAD_SHELL
+	default 3168 if OPENTHREAD_SHELL && OPENTHREAD_JOINER
+	default 2616 if OPENTHREAD_SHELL
 	default 2048 if MULTITHREADING
 	default 0 if !MULTITHREADING
 	help


### PR DESCRIPTION
Multiple OpenThread stack overflow issues were addressed recently in zephyr. Cherry-picked them as they did not make on time for the upmerge