### PR TITLE
[nrf fromtree] boards: mps2_an521: remove dependencies for

### DIFF
--- a/boards/arm/mps2_an521/Kconfig.defconfig
+++ b/boards/arm/mps2_an521/Kconfig.defconfig
@@ -17,10 +17,8 @@ config BOARD
 
 # By default, if we build for a Non-Secure version of the board,
 # force building with TF-M as the Secure Execution Environment.
-# Openamp samples assume the non-secure build is the remote
-# core image, so do not build with TF-M in this case.
 config BUILD_WITH_TFM
-	default y if TRUSTED_EXECUTION_NONSECURE && !OPENAMP
+	default y if TRUSTED_EXECUTION_NONSECURE
 
 
 if GPIO


### PR DESCRIPTION
...BUILD_WITH_TFM

We do not need to have dependencies any more on !OPENAMP
for BUILD_WITH_TFM in the mps2 an521 target, because we
now have different targets for the non-secure version of
the board and the remote core.

[nrf note]: This is already cherry-picked once in #511, but due to
reversal of a temphack, it was only partially picked, and the changes in
this patch were missing.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>
(cherry picked from commit e04a57de046e0e1fba25d3ecc11bd6d7611e3664)
Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>