### PR TITLE
[nrf fromtree] drivers: serial: nrf_uarte: Conditionally call PPI driver

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -40,8 +40,6 @@ config UART_0_ENHANCED_POLL_OUT
 	bool "Efficient poll out on port 0"
 	default y
 	depends on UART_0_NRF_UARTE
-	select NRFX_PPI if HAS_HW_NRF_PPI
-	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 	help
 	  When enabled, polling out does not trigger interrupt which stops TX.
 	  Feature uses a PPI channel.
@@ -135,8 +133,6 @@ config UART_1_ASYNC
 config UART_1_ENHANCED_POLL_OUT
 	bool "Efficient poll out on port 1"
 	default y
-	select NRFX_PPI if HAS_HW_NRF_PPI
-	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 	help
 	  When enabled, polling out does not trigger interrupt which stops TX.
 	  Feature uses a PPI channel.
@@ -214,8 +210,6 @@ config UART_2_ASYNC
 config UART_2_ENHANCED_POLL_OUT
 	bool "Efficient poll out on port 2"
 	default y
-	select NRFX_PPI if HAS_HW_NRF_PPI
-	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 	help
 	  When enabled, polling out does not trigger interrupt which stops TX.
 	  Feature uses a PPI channel.
@@ -292,8 +286,6 @@ config UART_3_ASYNC
 config UART_3_ENHANCED_POLL_OUT
 	bool "Efficient poll out on port 3"
 	default y
-	select NRFX_PPI if HAS_HW_NRF_PPI
-	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 	help
 	  When enabled, polling out does not trigger interrupt which stops TX.
 	  Feature uses a PPI channel.
@@ -387,6 +379,17 @@ config NRFX_DPPI
 config UARTE_NRF_HW_ASYNC
 	bool
 	default y
+
+endif
+
+if UART_0_ENHANCED_POLL_OUT || UART_1_ENHANCED_POLL_OUT || \
+	UART_2_ENHANCED_POLL_OUT || UART_3_ENHANCED_POLL_OUT
+
+config UART_ENHANCED_POLL_OUT
+	bool
+	default y
+	select NRFX_PPI if HAS_HW_NRF_PPI
+	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 
 endif
 

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -51,6 +51,7 @@ LOG_MODULE_REGISTER(uart_nrfx_uarte, LOG_LEVEL_ERR);
 	(defined(CONFIG_UART_3_NRF_UARTE) && !defined(CONFIG_UART_3_ASYNC))
 #define UARTE_ANY_NONE_ASYNC 1
 #endif
+
 /*
  * RX timeout is divided into time slabs, this define tells how many divisions
  * should be made. More divisions - higher timeout accuracy and processor usage.
@@ -1669,7 +1670,8 @@ static int uarte_instance_init(const struct device *dev,
 	data->pm_state = DEVICE_PM_ACTIVE_STATE;
 #endif
 
-	if (get_dev_config(dev)->flags & UARTE_CFG_FLAG_PPI_ENDTX) {
+	if (IS_ENABLED(CONFIG_UART_ENHANCED_POLL_OUT) &&
+	    get_dev_config(dev)->flags & UARTE_CFG_FLAG_PPI_ENDTX) {
 		err = endtx_stoptx_ppi_init(uarte, data);
 		if (err < 0) {
 			return err;


### PR DESCRIPTION
Avoid calling PPI driver when enhanced poll functionality is
disabled. Fixing a case when driver failed to compile when
enhanced poll is disabled for all instances.


Original commit: https://github.com/zephyrproject-rtos/zephyr/commit/6a5d828948bbf7b4e8d1d0585f4750a46807d4e6 

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>