### PR TITLE
[nrf noup] net: sockets: Add new DTLS and RAI socket options 

### DIFF
--- a/include/net/net_ip.h
+++ b/include/net/net_ip.h
@@ -47,7 +47,6 @@ extern "C" {
 #define PF_NET_MGMT     5          /**< Network management info.      */
 #define PF_LOCAL        6          /**< Inter-process communication   */
 #define PF_UNIX         PF_LOCAL   /**< Inter-process communication   */
-#define PF_LTE          102        /**< Specific to LTE.              */
 
 /* Address families. */
 #define AF_UNSPEC      PF_UNSPEC   /**< Unspecified address family.   */
@@ -58,7 +57,6 @@ extern "C" {
 #define AF_NET_MGMT    PF_NET_MGMT /**< Network management info.      */
 #define AF_LOCAL       PF_LOCAL    /**< Inter-process communication   */
 #define AF_UNIX        PF_UNIX     /**< Inter-process communication   */
-#define AF_LTE         PF_LTE      /**< Specific to LTE.              */
 
 /** Protocol numbers from IANA/BSD */
 enum net_ip_protocol {
@@ -82,23 +80,11 @@ enum net_ip_protocol_secure {
 	IPPROTO_DTLS_1_2 = 273,    /**< DTLS 1.2 protocol */
 };
 
-/* Protocol numbers for LTE protocols */
-enum net_lte_protocol {
-	NPROTO_AT = 513,
-	NPROTO_PDN = 514
-};
-
-/* Protocol numbers for LOCAL protocols */
-enum net_local_protocol {
-	NPROTO_DFU = 515
-};
-
 /** Socket type */
 enum net_sock_type {
-	SOCK_STREAM = 1,           /**< Stream socket type     */
-	SOCK_DGRAM,                /**< Datagram socket type   */
-	SOCK_RAW,                  /**< RAW socket type        */
-	SOCK_MGMT                  /**< Management socket type */
+	SOCK_STREAM = 1,           /**< Stream socket type   */
+	SOCK_DGRAM,                /**< Datagram socket type */
+	SOCK_RAW                   /**< RAW socket type      */
 };
 
 /** @brief Convert 16-bit value from network to host byte order.

--- a/include/net/socket.h
+++ b/include/net/socket.h
@@ -27,6 +27,7 @@
 #include <net/net_ip.h>
 #include <net/dns_resolve.h>
 #include <net/socket_select.h>
+#include <net/socket_ncs.h>
 #include <stdlib.h>
 
 #ifdef __cplusplus
@@ -55,12 +56,14 @@ struct zsock_pollfd {
 
 /** zsock_recv: Read data without removing it from socket input queue */
 #define ZSOCK_MSG_PEEK 0x02
-/** zsock_recv: Control received data truncation */
-#define ZSOCK_MSG_TRUNC 0x10
-/** zsock_recv: Request a blocking operation until the request is satisfied. */
-#define ZSOCK_MSG_WAITALL 0x20
+/** zsock_recv: return the real length of the datagram, even when it was longer
+ *  than the passed buffer
+ */
+#define ZSOCK_MSG_TRUNC 0x20
 /** zsock_recv/zsock_send: Override operation to non-blocking */
 #define ZSOCK_MSG_DONTWAIT 0x40
+/** zsock_recv: block until the full amount of data can be returned */
+#define ZSOCK_MSG_WAITALL 0x100
 
 /* Well-known values, e.g. from Linux man 2 shutdown:
  * "The constants SHUT_RD, SHUT_WR, SHUT_RDWR have the value 0, 1, 2,
@@ -124,7 +127,6 @@ struct zsock_pollfd {
  *    - 1 - server
  */
 #define TLS_DTLS_ROLE 6
-
 /** Socket option for setting the supported Application Layer Protocols.
  *  It accepts and returns a const char array of NULL terminated strings
  *  representing the supported application layer protocols listed during
@@ -138,12 +140,6 @@ struct zsock_pollfd {
 #define TLS_DTLS_HANDSHAKE_TIMEOUT_MIN 8
 #define TLS_DTLS_HANDSHAKE_TIMEOUT_MAX 9
 
-/** Socket option to control TLS session caching. Accepted values:
- *  - 0 - Disabled.
- *  - 1 - Enabled.
- */
-#define TLS_SESSION_CACHE 8
-
 /** @} */
 
 /* Valid values for TLS_PEER_VERIFY option */
@@ -154,10 +150,6 @@ struct zsock_pollfd {
 /* Valid values for TLS_DTLS_ROLE option */
 #define TLS_DTLS_ROLE_CLIENT 0 /**< Client role in a DTLS session. */
 #define TLS_DTLS_ROLE_SERVER 1 /**< Server role in a DTLS session. */
-
-/* Valid values for TLS_SESSION_CACHE option */
-#define TLS_SESSION_CACHE_DISABLED 0 /**< Disable TLS session caching. */
-#define TLS_SESSION_CACHE_ENABLED 1 /**< Enable TLS session caching. */
 
 struct zsock_addrinfo {
 	struct zsock_addrinfo *ai_next;
@@ -563,14 +555,6 @@ __syscall int z_zsock_getaddrinfo_internal(const char *host,
 #define AI_ADDRCONFIG 0x20
 /** Assume service (port) is numeric */
 #define AI_NUMERICSERV 0x400
-/** Assume `service` contains a Packet Data Network (PDN) ID.
- *  When specified together with the AI_NUMERICSERV flag,
- *  `service` shall be formatted as follows: "port:pdn_id"
- *  where "port" is the port number and "pdn_id" is the PDN ID.
- *  Example: "8080:1", port 8080 PDN ID 1.
- *  Example: "42:0", port 42 PDN ID 0.
- */
-#define AI_PDNSERV 0x1000
 
 /**
  * @brief Resolve a domain name to one or more network addresses
@@ -845,7 +829,7 @@ struct ifreq {
 #define SOL_SOCKET 1
 
 /* Socket options for SOL_SOCKET level */
-/** sockopt: Enable server address reuse */
+/** sockopt: Enable server address reuse (ignored, for compatibility) */
 #define SO_REUSEADDR 2
 /** sockopt: Type of the socket */
 #define SO_TYPE 3
@@ -861,13 +845,7 @@ struct ifreq {
 #define SO_SNDTIMEO 21
 
 /** sockopt: Bind a socket to an interface */
-#define SO_BINDTODEVICE 25
-/** sockopt: disable all replies to unexpected traffics */
-#define SO_SILENCE_ALL 30
-/** sockopt: disable IPv4 ICMP replies */
-#define SO_IP_ECHO_REPLY 31
-/** sockopt: disable IPv6 ICMP replies */
-#define SO_IPV6_ECHO_REPLY 32
+#define SO_BINDTODEVICE	25
 
 /** sockopt: Timestamp TX packets */
 #define SO_TIMESTAMPING 37
@@ -892,27 +870,6 @@ struct ifreq {
 /* Socket options for SOCKS5 proxy */
 /** sockopt: Enable SOCKS5 for Socket */
 #define SO_SOCKS5 60
-
-/* Protocol level for PDN. */
-#define SOL_PDN 514
-
-/* Socket options for SOL_PDN level */
-#define SO_PDN_AF 1
-#define SO_PDN_CONTEXT_ID 2
-#define SO_PDN_STATE 3
-
-/* Protocol level for DFU. */
-#define SOL_DFU 515
-
-/* Socket options for SOL_DFU level */
-#define SO_DFU_FW_VERSION 1
-#define SO_DFU_RESOURCES 2
-#define SO_DFU_TIMEO 3
-#define SO_DFU_APPLY 4
-#define SO_DFU_REVERT 5
-#define SO_DFU_BACKUP_DELETE 6
-#define SO_DFU_OFFSET 7
-#define SO_DFU_ERROR 20
 
 /** @cond INTERNAL_HIDDEN */
 /**

--- a/include/net/socket_ncs.h
+++ b/include/net/socket_ncs.h
@@ -44,11 +44,30 @@ enum net_local_protocol {
  *  - 0 - Disabled.
  *  - 1 - Enabled.
  */
-#define TLS_SESSION_CACHE 8
+#define TLS_SESSION_CACHE 10
+/** Socket option to purge session cache immediately.
+ *  This option accepts any value.
+ */
+#define TLS_SESSION_CACHE_PURGE 11
+/** Socket option to set DTLS handshake timeout, specifically for nRF sockets.
+ *  The option accepts an integer, indicating the total handshake timeout,
+ *  including retransmissions, in seconds.
+ *  Accepted values for the option are: 1, 3, 7, 15, 31, 63, 123.
+ */
+#define TLS_DTLS_HANDSHAKE_TIMEO 12
 
 /* Valid values for TLS_SESSION_CACHE option */
 #define TLS_SESSION_CACHE_DISABLED 0 /**< Disable TLS session caching. */
 #define TLS_SESSION_CACHE_ENABLED 1 /**< Enable TLS session caching. */
+
+/* Valid values for TLS_DTLS_HANDSHAKE_TIMEO option */
+#define TLS_DTLS_HANDSHAKE_TIMEO_1S 1 /**< 1 second */
+#define TLS_DTLS_HANDSHAKE_TIMEO_3S 3 /**< 1s + 2s */
+#define TLS_DTLS_HANDSHAKE_TIMEO_7S 7 /**< 1s + 2s + 4s */
+#define TLS_DTLS_HANDSHAKE_TIMEO_15S 15 /**< 1s + 2s + 4s + 8s */
+#define TLS_DTLS_HANDSHAKE_TIMEO_31S 31 /**< 1s + 2s + 4s + 8s + 16s */
+#define TLS_DTLS_HANDSHAKE_TIMEO_63S 63 /**< 1s + 2s + 4s + 8s + 16s + 32s */
+#define TLS_DTLS_HANDSHAKE_TIMEO_123S 123 /**< 1s + 2s + 4s + 8s + 16s + 32s + 60s */
 
 /* NCS specific socket options */
 
@@ -58,6 +77,29 @@ enum net_local_protocol {
 #define SO_IP_ECHO_REPLY 31
 /** sockopt: disable IPv6 ICMP replies */
 #define SO_IPV6_ECHO_REPLY 32
+/** sockopt: Release Assistance Indication feature: This will indicate that the
+ *  next call to send/sendto will be the last one for some time.
+ */
+#define SO_RAI_LAST 50
+/** sockopt: Release Assistance Indication feature: This will indicate that the
+ *  application will not send any more data.
+ */
+#define SO_RAI_NO_DATA 51
+/** sockopt: Release Assistance Indication feature: This will indicate that
+ *  after the next call to send/sendto, the application is expecting to receive
+ *  one more data packet before this socket will not be used again for some time.
+ */
+#define SO_RAI_ONE_RESP 52
+/** sockopt: Release Assistance Indication feature: If a client application
+ *  expects to use the socket more it can indicate that by setting this socket
+ *  option before the next send call which will keep the network up longer.
+ */
+#define SO_RAI_ONGOING 53
+/** sockopt: Release Assistance Indication feature: If a server application
+ *  expects to use the socket more it can indicate that by setting this socket
+ *  option before the next send call.
+ */
+#define SO_RAI_WAIT_MORE 54
 
 /* NCS specific PDN options */
 

--- a/include/net/socket_ncs.h
+++ b/include/net/socket_ncs.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_NET_SOCKET_NCS_H_
+#define ZEPHYR_INCLUDE_NET_SOCKET_NCS_H_
+
+/**
+ * @file
+ * @brief NCS specific additions to the BSD sockets API definitions
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* NCS specific protocol/address families. */
+
+#define PF_LTE 102 /**< Protocol family specific to LTE. */
+#define AF_LTE PF_LTE /**< Address family specific to LTE. */
+
+/* NCS specific protocol types. */
+
+/** Protocol numbers for LTE protocols */
+enum net_lte_protocol {
+	NPROTO_AT = 513,
+	NPROTO_PDN = 514
+};
+
+/** Protocol numbers for LOCAL protocols */
+enum net_local_protocol {
+	NPROTO_DFU = 515
+};
+
+/* NCS specific socket types. */
+
+#define SOCK_MGMT 4 /**< Management socket type. */
+
+/* NCS specific TLS options */
+
+/** Socket option to control TLS session caching. Accepted values:
+ *  - 0 - Disabled.
+ *  - 1 - Enabled.
+ */
+#define TLS_SESSION_CACHE 8
+
+/* Valid values for TLS_SESSION_CACHE option */
+#define TLS_SESSION_CACHE_DISABLED 0 /**< Disable TLS session caching. */
+#define TLS_SESSION_CACHE_ENABLED 1 /**< Enable TLS session caching. */
+
+/* NCS specific socket options */
+
+/** sockopt: disable all replies to unexpected traffics */
+#define SO_SILENCE_ALL 30
+/** sockopt: disable IPv4 ICMP replies */
+#define SO_IP_ECHO_REPLY 31
+/** sockopt: disable IPv6 ICMP replies */
+#define SO_IPV6_ECHO_REPLY 32
+
+/* NCS specific PDN options */
+
+/** Protocol level for PDN. */
+#define SOL_PDN 514
+
+/* Socket options for SOL_PDN level */
+#define SO_PDN_AF 1
+#define SO_PDN_CONTEXT_ID 2
+#define SO_PDN_STATE 3
+
+/* NCS specific DFU options */
+
+/** Protocol level for DFU. */
+#define SOL_DFU 515
+
+/* Socket options for SOL_DFU level */
+#define SO_DFU_FW_VERSION 1
+#define SO_DFU_RESOURCES 2
+#define SO_DFU_TIMEO 3
+#define SO_DFU_APPLY 4
+#define SO_DFU_REVERT 5
+#define SO_DFU_BACKUP_DELETE 6
+#define SO_DFU_OFFSET 7
+#define SO_DFU_ERROR 20
+
+/* NCS specific gettaddrinfo() flags */
+
+/** Assume `service` contains a Packet Data Network (PDN) ID.
+ *  When specified together with the AI_NUMERICSERV flag,
+ *  `service` shall be formatted as follows: "port:pdn_id"
+ *  where "port" is the port number and "pdn_id" is the PDN ID.
+ *  Example: "8080:1", port 8080 PDN ID 1.
+ *  Example: "42:0", port 42 PDN ID 0.
+ */
+#define AI_PDNSERV 0x1000
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_NET_SOCKET_NCS_H_ */


### PR DESCRIPTION
Introduce new nRF91 specific TLS and RAI socket options. 

Additionally, rework how local extensions to the networking headers are handled downstream. Instead of modifying the upstream socket.h header, introduce a new one, specifically for NCS extensions, and keep all of the local changes in there. The only change needed in the original header is an inclusion of the new header. This should help to keep the local changes in order and facilitate the future upmerge process.