### PR TITLE
[nrf noup] include: net: add TCP sesstimeo socket option for nRF91

### DIFF
--- a/include/net/socket_ncs.h
+++ b/include/net/socket_ncs.h
@@ -100,6 +100,10 @@ enum net_local_protocol {
  *  option before the next send call.
  */
 #define SO_RAI_WAIT_MORE 54
+/** sockopt: Configurable TCP server session timeout in minutes.
+ * Range is 0 to 135. 0 is no timeout and 135 is 2 h 15 min. Default is 0 (no timeout).
+ */
+#define SO_TCP_SRV_SESSTIMEO 55
 
 /* NCS specific PDN options */
 


### PR DESCRIPTION
This commit adds a new socket option `SO_TCP_SRV_SESSTIMEO` for
configuring TCP session server timeout in minutes. Legal values
range from 0 to 135.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>