### PR TITLE
[nrf fromtree] actions: clang: invoke twister with -M to keep size down

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -56,7 +56,7 @@ jobs:
           #source zephyr-env.sh
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=llvm
-          ./scripts/twister --inline-logs -N -v -p native_posix --subset ${{matrix.subset}}/${MATRIX_SIZE} --retry-failed 3
+          ./scripts/twister --inline-logs -M -N -v -p native_posix --subset ${{matrix.subset}}/${MATRIX_SIZE} --retry-failed 3
 
       - name: Upload Unit Test Results
         if: always()


### PR DESCRIPTION
Use the -M option to cleanup as we go to deal with any
disk space issues.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>
(cherry picked from commit c71e2dc0077d658b61a8981df6181269890fbc66)
Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>