### PR TITLE
[nrf fromlist] modules: tfm: add configuration for disabling the RNG … 

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -17,6 +17,7 @@ set(TFM_VALID_PARTITIONS
 # List of all crypto modules that can be enabled/disabled
 # Corresponds to the *_MODULE_DISABLED configs in 'trusted-firmware-m/config/config_default.cmake'
 set(TFM_CRYPTO_MODULES
+  CRYPTO_RNG_MODULE
   CRYPTO_KEY_MODULE
   CRYPTO_AEAD_MODULE
   CRYPTO_MAC_MODULE

--- a/modules/trusted-firmware-m/Kconfig.tfm.crypto_modules
+++ b/modules/trusted-firmware-m/Kconfig.tfm.crypto_modules
@@ -7,6 +7,13 @@ if BUILD_WITH_TFM
 
 if TFM_PARTITION_CRYPTO
 
+config TFM_CRYPTO_RNG_MODULE_ENABLED
+	bool "Enable random number generator crypto module"
+	default y
+	help
+	  Enables the random number generator  module within the crypto partition.
+	  Unset this option if 'psa_generate_random' is not used.
+
 config TFM_CRYPTO_KEY_MODULE_ENABLED
 	bool "Enable KEY crypto module"
 	default y


### PR DESCRIPTION
A new configuration is available in TFM, expose this configuration.

Ref: NCSDK-10031
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>