### PR TITLE
Bluetooth: Cherry-pick upstream commits

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1572,6 +1572,10 @@ uint8_t ull_scan_rsp_set(struct ll_adv_set *adv, uint8_t len,
 	struct pdu_adv *pdu;
 	uint8_t idx;
 
+	if (len > PDU_AC_DATA_SIZE_MAX) {
+		return BT_HCI_ERR_INVALID_PARAM;
+	}
+
 	/* update scan pdu fields. */
 	prev = lll_adv_scan_rsp_peek(&adv->lll);
 	pdu = lll_adv_scan_rsp_alloc(&adv->lll, &idx);

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -872,6 +872,8 @@ static void l2cap_chan_tx_process(struct k_work *work)
 		if (sent < 0) {
 			if (sent == -EAGAIN) {
 				ch->tx_buf = buf;
+			} else {
+				net_buf_unref(buf);
 			}
 			break;
 		}

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5639,10 +5639,6 @@ int bt_smp_start_security(struct bt_conn *conn)
 			return -ENOTCONN;
 		}
 
-		if (!smp_keys_check(conn)) {
-			return smp_send_pairing_req(conn);
-		}
-
 		/* pairing is in progress */
 		if (atomic_test_bit(smp->flags, SMP_FLAG_PAIRING)) {
 			return -EBUSY;
@@ -5651,6 +5647,10 @@ int bt_smp_start_security(struct bt_conn *conn)
 		/* Encryption is in progress */
 		if (atomic_test_bit(smp->flags, SMP_FLAG_ENC_PENDING)) {
 			return -EBUSY;
+		}
+
+		if (!smp_keys_check(conn)) {
+			return smp_send_pairing_req(conn);
 		}
 
 		/* LE SC LTK and legacy master LTK are stored in same place */


### PR DESCRIPTION
[nrf fromtree] Bluetooth: host: Prevent race condition in pairing procedure

Moving the key check after checking that no pairing or encryption
procedure is started fixes a race condition that is seen in some PTS
tests:

GATT/CL/GAR/BI-04-C
GATT/CL/GAR/BI-16-C
GATT/CL/GAR/BI-21-C
GATT/CL/GAW/BI-05-C
GATT/CL/GAW/BI-12-C

[nrf fromlist] Bluetooth: L2CAP: Fix missing net_buf_unref()

In case of non-recoverable errors (e.g. the connection breaks while
transmitting), the l2cap_chan_tx_process deques the net_buf but does
not unreference it. As this is inside a work queue thread, the sending
thread gets no information on this error, relying on the tx_process to
ultimately free the buffer.

Upstream PR: zephyrproject-rtos/zephyr#36031

[nrf fromtree] Bluetooth: controller: Check length field of scan response data

Check the length field of the scan response data.

[nrf fromtree] Bluetooth: controller: Fix initial empty flag for peripheral

Fix to avoid an assertion when processing an acknowledgment
in the first connection event in peripheral role.

Ensure that empty flag reflects the state of the Tx queue,
as a peripheral the first connection event has no prior PDU
transmitted, an incorrect acknowledgment by peer should
not dequeue a PDU that has not been transmitted on air.

Relates to assert added in commit 2bfaadf ("Bluetooth: