### PR TITLE
[nrf fromtree] modules: trusted-firmware-m: Set TF-M isolation level

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -105,6 +105,10 @@ function(trusted_firmware_build)
     target_compile_definitions(app PRIVATE "TFM_PSA_API")
   endif()
 
+  if(TFM_ISOLATION_LEVEL)
+    set(TFM_ISOLATION_LEVEL_ARG -DTFM_ISOLATION_LEVEL=${TFM_ISOLATION_LEVEL})
+  endif()
+
   if (TFM_REGRESSION_S)
     set(TFM_REGRESSION_S_ARG -DTEST_S=ON)
   endif()


### PR DESCRIPTION
The CMake variable `TFM_ISOLATION_LEVEL_ARG` was not properly set when
application configures higher isolation level. This led to isolation
level always being to set 1.

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@linaro.org>
Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>