### PR TITLE
[nrf fromlist] soc: nrf53: Fix configuration of HFXO capacitance

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -165,7 +165,16 @@ endchoice
 
 choice SOC_HFXO_LOAD_CAPACITANCE
 	prompt "HFXO load capacitance"
-	default SOC_HFXO_CAP_EXTERNAL
+	default SOC_HFXO_CAP_DEFAULT
+
+config SOC_HFXO_CAP_DEFAULT
+	bool "SoC default"
+	help
+	  When this option is used, the SoC initialization routine does not
+	  touch the XOSC32MCAPS register value, so the default setting for
+	  the SoC is in effect. Please note that this may not necessarily be
+	  the reset value (0) for the register, as the register can be set
+	  during the device trimming in the SystemInit() function.
 
 config SOC_HFXO_CAP_EXTERNAL
 	bool "Use external load capacitors"

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -96,7 +96,7 @@ static int nordicsemi_nrf53_init(const struct device *arg)
 		 + ((offset - 8) << 4) + 32) >> 6;
 
 	nrf_oscillators_hfxo_cap_set(NRF_OSCILLATORS, true, capvalue);
-#else
+#elif defined(CONFIG_SOC_HFXO_CAP_EXTERNAL)
 	nrf_oscillators_hfxo_cap_set(NRF_OSCILLATORS, false, 0);
 #endif
 #endif /* defined(CONFIG_SOC_NRF5340_CPUAPP) && ... */


### PR DESCRIPTION
This is a follow-up to commit 60d9988401e59093edb0cd638b1b737288477cb0.

Add a third option for the HFXO capacitance that keeps the default
value of the XOSC32MCAPS register untouched. The message in the above
commit incorrectly claimed that external load capacitors for HFXO
(the reset value of the XOSC32MCAPS register) was the configuration
in effect before. In fact, the register value was modified during
the device trimming in the SystemInit() function to use the internal
capacitors, and that is the configuration required for proper RADIO
operation on nRF5340 DK, for instance.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/36320

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>