### PR TITLE
[nrf fromlist] drivers: serial: nrfx_uarte: Add pullups to RXD and CTS

### DIFF
--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -995,7 +995,7 @@ static int uart_nrfx_init(const struct device *dev)
 	nrf_gpio_cfg_output(TX_PIN);
 
 	if (RX_PIN_USED) {
-		nrf_gpio_cfg_input(RX_PIN, NRF_GPIO_PIN_NOPULL);
+		nrf_gpio_cfg_input(RX_PIN, NRF_GPIO_PIN_PULLUP);
 	}
 
 	nrf_uart_txrx_pins_set(uart0_addr, TX_PIN, RX_PIN);
@@ -1009,7 +1009,7 @@ static int uart_nrfx_init(const struct device *dev)
 	}
 
 	if (HAS_PROP(cts_pin)) {
-		nrf_gpio_cfg_input(CTS_PIN, NRF_GPIO_PIN_NOPULL);
+		nrf_gpio_cfg_input(CTS_PIN, NRF_GPIO_PIN_PULLUP);
 	}
 
 	nrf_uart_hwfc_pins_set(uart0_addr, RTS_PIN, CTS_PIN);
@@ -1110,7 +1110,7 @@ static void uart_nrfx_pins_enable(const struct device *dev, bool enable)
 		nrf_gpio_pin_write(tx_pin, 1);
 		nrf_gpio_cfg_output(tx_pin);
 		if (RX_PIN_USED) {
-			nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
+			nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_PULLUP);
 		}
 
 		if (HAS_PROP(rts_pin)) {
@@ -1118,8 +1118,7 @@ static void uart_nrfx_pins_enable(const struct device *dev, bool enable)
 			nrf_gpio_cfg_output(rts_pin);
 		}
 		if (HAS_PROP(cts_pin)) {
-			nrf_gpio_cfg_input(cts_pin,
-					   NRF_GPIO_PIN_NOPULL);
+			nrf_gpio_cfg_input(cts_pin, NRF_GPIO_PIN_PULLUP);
 		}
 	} else {
 		nrf_gpio_cfg_default(tx_pin);

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1660,13 +1660,13 @@ static int uarte_instance_init(const struct device *dev,
 	nrf_gpio_cfg_output(config->pseltxd);
 
 	if (config->pselrxd !=  NRF_UARTE_PSEL_DISCONNECTED) {
-		nrf_gpio_cfg_input(config->pselrxd, NRF_GPIO_PIN_NOPULL);
+		nrf_gpio_cfg_input(config->pselrxd, NRF_GPIO_PIN_PULLUP);
 	}
 
 	nrf_uarte_txrx_pins_set(uarte, config->pseltxd, config->pselrxd);
 
 	if (config->pselcts != NRF_UARTE_PSEL_DISCONNECTED) {
-		nrf_gpio_cfg_input(config->pselcts, NRF_GPIO_PIN_NOPULL);
+		nrf_gpio_cfg_input(config->pselcts, NRF_GPIO_PIN_PULLUP);
 	}
 
 	if (config->pselrts != NRF_UARTE_PSEL_DISCONNECTED) {
@@ -1753,7 +1753,7 @@ static void uarte_nrfx_pins_enable(const struct device *dev, bool enable)
 		nrf_gpio_pin_write(tx_pin, 1);
 		nrf_gpio_cfg_output(tx_pin);
 		if (rx_pin != NRF_UARTE_PSEL_DISCONNECTED) {
-			nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_NOPULL);
+			nrf_gpio_cfg_input(rx_pin, NRF_GPIO_PIN_PULLUP);
 		}
 
 		if (IS_RTS_PIN_SET(get_dev_config(dev)->flags)) {
@@ -1763,7 +1763,7 @@ static void uarte_nrfx_pins_enable(const struct device *dev, bool enable)
 
 		if (IS_CTS_PIN_SET(get_dev_config(dev)->flags)) {
 			nrf_gpio_cfg_input(cts_pin,
-					   NRF_GPIO_PIN_NOPULL);
+					   NRF_GPIO_PIN_PULLUP);
 		}
 	} else {
 		nrf_gpio_cfg_default(tx_pin);


### PR DESCRIPTION
Configured UARTE input pins to have pullups. Otherwise when
uart is disconnected pins are floating and generate receiver
errors.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/36366

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>