### PR TITLE
[nrf noup]: Remove "toup" and "temphack" from sauce tags

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -38,7 +38,7 @@ jobs:
         git config --global user.name "Your Name"
         git remote -v
         # Sauce tag checks before rebasing
-        git log --oneline --first-parent origin/${BASE_REF}..HEAD | grep -E -v "\[nrf (mergeup|fromlist|toup|noup|temphack|fromtree)\]" && { echo 'Sauce tag missing'; exit 1; }
+        git log --oneline --first-parent origin/${BASE_REF}..HEAD | grep -E -v "\[nrf (mergeup|fromtree|fromlist|noup)\]" && { echo 'Sauce tag missing'; exit 1; }
         git rebase origin/${BASE_REF}
         # debug
         git log  --pretty=oneline | head -n 10


### PR DESCRIPTION
squash! [nrf noup] ci: Compliance workflow downstream tweaks

Those sauce tags have now been removed from the list of admissible ones.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>