### PR TITLE
[nrf noup] modules: Change mbedtls heap size config

### DIFF
--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -138,6 +138,7 @@ config MBEDTLS_ENABLE_HEAP
 config MBEDTLS_HEAP_SIZE
 	int "Heap size for mbed TLS"
 	default 10240 if OPENTHREAD_COMMISSIONER || OPENTHREAD_JOINER
+	default 8320 if BUILD_WITH_TFM
 	default 512
 	depends on MBEDTLS_ENABLE_HEAP
 	help


### PR DESCRIPTION
-This sets the default value for the mbedtls heap size
 when we build with TF-M

 Ref: NCSDK-10020

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>