### PR TITLE
boards: actinius_*: fix board init priority

### DIFF
--- a/boards/arm/actinius_icarus/board.c
+++ b/boards/arm/actinius_icarus/board.c
@@ -40,5 +40,5 @@ static int board_actinius_icarus_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_actinius_icarus_init, POST_KERNEL,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+/* Needs to happen after GPIO driver init */
+SYS_INIT(board_actinius_icarus_init, POST_KERNEL, 99);

--- a/boards/arm/actinius_icarus_bee/board.c
+++ b/boards/arm/actinius_icarus_bee/board.c
@@ -40,5 +40,5 @@ static int board_actinius_icarus_bee_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_actinius_icarus_bee_init, POST_KERNEL,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+/* Needs to happen after GPIO driver init */
+SYS_INIT(board_actinius_icarus_bee_init, POST_KERNEL, 99);

--- a/boards/arm/actinius_icarus_som/board.c
+++ b/boards/arm/actinius_icarus_som/board.c
@@ -40,5 +40,5 @@ static int board_actinius_icarus_som_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(board_actinius_icarus_som_init, POST_KERNEL,
-	 CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+/* Needs to happen after GPIO driver init */
+SYS_INIT(board_actinius_icarus_som_init, POST_KERNEL, 99);


### PR DESCRIPTION
This is a request to backport #36906 from upstream (not yet merged upstream, but I would like to make sure that this fix makes it in the next minor release).

This fixes an issue that surfaced with Zephyr v2.6.0,
where the GPIO driver has not completed initialization
when attempting to use it during POST_KERNEL with
KERNEL_INIT_PRIORITY_DEFAULT.

Signed-off-by: Alex Tsamakos <alex@actinius.com>