### PR TITLE
[nrf fromtree] mcumgr: smp: Fix NULL pointer reference

### DIFF
--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -117,6 +117,9 @@ zephyr_smp_split_frag(struct net_buf **nb, void *arg, uint16_t mtu)
 		frag = src;
 	} else {
 		frag = zephyr_smp_alloc_rsp(src, arg);
+		if (!frag) {
+			return NULL;
+		}
 
 		/* Copy fragment payload into new buffer. */
 		net_buf_add_mem(frag, src->data, mtu);
@@ -184,6 +187,7 @@ zephyr_smp_tx_rsp(struct smp_streamer *ns, void *rsp, void *arg)
 	while (nb != NULL) {
 		frag = zephyr_smp_split_frag(&nb, zst, mtu);
 		if (frag == NULL) {
+			zephyr_smp_free_buf(nb, zst);
 			return MGMT_ERR_ENOMEM;
 		}
 

--- a/subsys/mgmt/mcumgr/smp_bt.c
+++ b/subsys/mgmt/mcumgr/smp_bt.c
@@ -55,6 +55,9 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 	struct net_buf *nb;
 
 	nb = mcumgr_buf_alloc();
+	if (!nb) {
+		return BT_GATT_ERR(BT_ATT_ERR_INSUFFICIENT_RESOURCES);
+	}
 	net_buf_add_mem(nb, buf, len);
 
 	ud = net_buf_user_data(nb);

--- a/subsys/mgmt/mcumgr/smp_udp.c
+++ b/subsys/mgmt/mcumgr/smp_udp.c
@@ -121,6 +121,11 @@ static void smp_udp_receive_thread(void *p1, void *p2, void *p3)
 
 			/* store sender address in user data for reply */
 			nb = mcumgr_buf_alloc();
+			if (!nb) {
+				LOG_ERR("Failed to allocate mcumgr buffer");
+				/* No free space, drop smp frame */
+				continue;
+			}
 			net_buf_add_mem(nb, conf->recv_buffer, len);
 			ud = net_buf_user_data(nb);
 			net_ipaddr_copy(ud, &addr);


### PR DESCRIPTION
SMP implementation across bt/udp does not check
if allocation of the buffer was successful.
If the buffer is not granted an error shall be
returned.

This patch fixes BUS FAULT issue when NULL
pointer is referenced.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>