### PR TITLE
[nrf fromtree] subsys/mgmt/mcumgr: Fix collision with user defined groups

### DIFF
--- a/include/mgmt/mcumgr/zephyr_groups.h
+++ b/include/mgmt/mcumgr/zephyr_groups.h
@@ -12,9 +12,10 @@
 extern "C" {
 #endif
 
-/* The file contains definitions of Zephyr specific mgmt commands */
-
-#define ZEPHYR_MGMT_GRP_BASE		MGMT_GROUP_ID_PERUSER
+/* The file contains definitions of Zephyr specific mgmt commands. The group numbers decrease
+ * from PERUSER to avoid collision with user defined groups.
+ */
+#define ZEPHYR_MGMT_GRP_BASE		(MGMT_GROUP_ID_PERUSER - 1)
 
 /* Basic group */
 #define ZEPHYR_MGMT_GRP_BASIC		ZEPHYR_MGMT_GRP_BASE


### PR DESCRIPTION
[nrf fromtree] subsys/mgmt/mcumgr: Fix collision with user ...

...defined groups

The commit moves definition of Zephyr specific mcumgr basic group to
PERUSER - 1.  This has been done to avoid collision with application
specific groups, defined by users.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>