### PR TITLE
[nrf noup] twister: Ignore build_on_all from samples/tests yamls

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2960,7 +2960,9 @@ class TestSuite(DisablePyTestCollectionMixin):
                         if tc.harness == 'console' and not tc.harness_config:
                             raise Exception('Harness config error: console harness defined without a configuration.')
                         tc.build_only = tc_dict["build_only"]
-                        tc.build_on_all = tc_dict["build_on_all"]
+
+                        # TEMPHACK: we have to ignore "build_on_all" until all yamls are fixed
+                        # tc.build_on_all = tc_dict["build_on_all"]
                         tc.slow = tc_dict["slow"]
                         tc.min_ram = tc_dict["min_ram"]
                         tc.depends_on = tc_dict["depends_on"]


### PR DESCRIPTION
An option "build_on_all: true" can be set in sample/testcase.yaml.
It tells Twister to add all existing platforms (~400) to the test
scope. This option is abused in (almost?) all Nordic samples and
tests. It is pointless as "platform_allow" is also used there
limiting the building/executing scope to selected platforms. Hovewer,
this causes huge mess in the genereted results reports, where ~400
platforms are added with all test statuses "skipped". This patch
make Twister to ignore "build_on_all: true" in yamls. A proper solution
will follow: all yamls will need to have "build_on_all: true" removed.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>