### PR TITLE
boards: arm: nordic: nRF21540_dk_nrf52840 supports bluetooth controller

### DIFF
--- a/boards/arm/nrf21540dk_nrf52840/Kconfig.defconfig
+++ b/boards/arm/nrf21540dk_nrf52840/Kconfig.defconfig
@@ -19,8 +19,6 @@ config USB_DEVICE_STACK
 endif # USB
 
 config BT_CTLR
-	# Disabled until PA/LNA support for nRF21540 front-end is added
-	# in Zephyr Bluetooth Controller
-	# default BT
+	default BT
 
 endif # BOARD_NRF21540DK_NRF52840


### PR DESCRIPTION
The PA/LNA support for nRF21540 front-end is added in softdevice
controller.

Signed-off-by: Ryan Chu <ryan.chu@nordicsemi.no>