### PR TITLE
[nrf fromtree] net: openthread: Add capability to disable properly CSL

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -787,7 +787,10 @@ static void nrf5_config_csl_period(uint16_t period)
 	/* A placeholder reception window is scheduled so that the radio driver is able to inject
 	 * the proper CSL Phase in the transmitted CSL Information Elements.
 	 */
-	nrf5_receive_at(nrf5_data.csl_rx_time, PH_DURATION, nrf_802154_channel_get(), DRX_SLOT_PH);
+	if (period > 0) {
+		nrf5_receive_at(nrf5_data.csl_rx_time, PH_DURATION, nrf_802154_channel_get(),
+				DRX_SLOT_PH);
+	}
 }
 
 static void nrf5_schedule_rx(uint8_t channel, uint32_t start, uint32_t duration)

--- a/subsys/net/lib/openthread/platform/radio.c
+++ b/subsys/net/lib/openthread/platform/radio.c
@@ -1052,9 +1052,14 @@ otError otPlatRadioEnableCsl(otInstance *aInstance, uint32_t aCslPeriod, otShort
 	/* Leave CSL Phase empty intentionally */
 	sys_put_le16(aCslPeriod, &ie_header[OT_IE_HEADER_SIZE + 2]);
 	config.ack_ie.data = ie_header;
-	config.ack_ie.data_len = OT_IE_HEADER_SIZE + OT_CSL_IE_SIZE;
 	config.ack_ie.short_addr = aShortAddr;
 	config.ack_ie.ext_addr = aExtAddr->m8;
+
+	if (aCslPeriod > 0) {
+		config.ack_ie.data_len = OT_IE_HEADER_SIZE + OT_CSL_IE_SIZE;
+	} else {
+		config.ack_ie.data_len = 0;
+	}
 	result = radio_api->configure(radio_dev, IEEE802154_CONFIG_ENH_ACK_HEADER_IE, &config);
 
 	config.csl_period = aCslPeriod;


### PR DESCRIPTION
This commit adds capability to disable CSL sampling by setting
CSL period to 0.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>
(cherry picked from commit 678a1709259d8c23b2487b5d428049ac9d67722b)