### PR TITLE
[nrf fromtree] dfu: boot: Add implementation for multi-image ...

### DIFF
--- a/include/dfu/mcuboot.h
+++ b/include/dfu/mcuboot.h
@@ -204,6 +204,17 @@ int boot_write_img_confirmed_multi(int image_index);
  */
 int mcuboot_swap_type(void);
 
+/**
+ * @brief Determines the action, if any, that mcuboot will take on the next
+ * reboot.
+ *
+ * @param image_index Image pair index.
+ *
+ * @return a BOOT_SWAP_TYPE_[...] constant on success, negative errno code on
+ * fail.
+ */
+int mcuboot_swap_type_multi(int image_index);
+
 
 /** Boot upgrade request modes */
 #define BOOT_UPGRADE_TEST       0

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -144,6 +144,11 @@ int boot_read_bank_header(uint8_t area_id,
 	return 0;
 }
 
+int mcuboot_swap_type_multi(int image_index)
+{
+	return boot_swap_type_multi(image_index);
+}
+
 int mcuboot_swap_type(void)
 {
 #ifdef FLASH_AREA_IMAGE_SECONDARY


### PR DESCRIPTION
... swap type check

Adds multi-image implementations for checking swap type based on image
index.

Upstream commit: bcbc53015d94d0568d799babec01654758a7aaf1

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>