### PR TITLE
[nrf fromlist] modules: Add TF-M SECURE_UART1 config

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -30,6 +30,11 @@ set(TFM_CRYPTO_MODULES
 
 
 if (CONFIG_BUILD_WITH_TFM)
+  if (CONFIG_TFM_SECURE_UART1)
+    list(APPEND TFM_CMAKE_ARGS -DSECURE_UART1=ON)
+  else()
+    list(APPEND TFM_CMAKE_ARGS -DSECURE_UART1=OFF)
+  endif()
   if (CONFIG_TFM_IPC)
     list(APPEND TFM_CMAKE_ARGS -DTFM_PSA_API=ON)
     # PSA API awareness for the Non-Secure application

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -49,6 +49,13 @@ menuconfig BUILD_WITH_TFM
 
 if BUILD_WITH_TFM
 
+config TFM_SECURE_UART1
+	bool "Use UART1 for TF-M logging"
+	default y
+	help
+	  Reserve the UART1 port for TF-M logging. This makes the UART1
+	  peripheral unavailable to the non-secure application.
+
 config TFM_KEY_FILE_S
 	string "Path to private key used to sign secure firmware images."
 	depends on BUILD_WITH_TFM


### PR DESCRIPTION
-This adds a Kconfig configuration which allows
 disabling SECURE_UART1.

Upstream PR: [pull/38670](https://github.com/zephyrproject-rtos/zephyr/pull/38670)

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>