### PR TITLE
dfu/boot: Kconfig for MCUboot's bootutil

### DIFF
--- a/modules/Kconfig.mcuboot_bootutil
+++ b/modules/Kconfig.mcuboot_bootutil
@@ -21,4 +21,21 @@ module-str = MCUboot bootutil
 source "subsys/logging/Kconfig.template.log_config"
 endif
 
+config BOOT_IMAGE_ACCESS_HOOKS
+	bool "Enable hooks for overriding MCUboot's bootutil native routines"
+	help
+	  Allow to provide procedures for override or extend native
+	  MCUboot's routines required for access the image data.
+
+config BOOT_IMAGE_ACCESS_HOOKS_FILE
+	string "Hooks implementation file path"
+	depends on BOOT_IMAGE_ACCESS_HOOKS
+	help
+	  Path to the file which implements hooks.
+	  You can use either absolute or relative path.
+	  In case relative path is used, the build system assumes that it starts
+	  from the directory where the project KConfig configuration file is
+	  located. If the key file is not there, the build system uses relative
+	  path that starts from the Application cmake directory.
+
 endif # MCUBOOT_BOOTUTIL_LIB


### PR DESCRIPTION
Mcuboot's bootutil libraries has option to use hooks which
allows to customize its behavior while proceeding on images
date. This patch introduces configuration options required that.

upstream https://github.com/zephyrproject-rtos/zephyr/pull/38496

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>