### PR TITLE
[nrf fromlist] Add multi-image for Thingy:53

### DIFF
--- a/drivers/flash/Kconfig.simulator
+++ b/drivers/flash/Kconfig.simulator
@@ -26,6 +26,15 @@ config FLASH_SIMULATOR_DOUBLE_WRITES
 	 If selected, writing to a non-erased program unit will succeed, otherwise, it will return an error.
 	 Keep in mind that write operations can only pull bits to zero, regardless.
 
+config FLASH_SIMULATOR_NOALLOC
+	bool "Reads, writes and erase are simulated within buffer of write_block_size size"
+	depends on !ARCH_POSIX
+	help
+	  Enabling this option will cause driver to allocate only write_block_size of buffer for
+	  flash simulation.  The driver will still respect size and offset, as set in a DTS,
+	  returning errors when flash operations would cross these.  The write will still
+	  respect write_block_size, and erase will expect page alignment.
+
 config FLASH_SIMULATOR_SIMULATE_TIMING
 	bool "Enable hardware timing simulation"
 

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -51,7 +51,11 @@
 #error "Erase unit must be a multiple of program unit"
 #endif
 
+#ifndef CONFIG_FLASH_SIMULATOR_NOALLOC
 #define MOCK_FLASH(addr) (mock_flash + (addr) - FLASH_SIMULATOR_BASE_OFFSET)
+#else
+#define MOCK_FLASH(addr) (mock_flash + ((addr) & 0))
+#endif
 
 /* maximum number of pages that can be tracked by the stats module */
 #define STATS_PAGE_COUNT_THRESHOLD 256
@@ -149,7 +153,11 @@ static int flash_fd = -1;
 static const char *flash_file_path;
 static const char default_flash_file_path[] = "flash.bin";
 #else
+#ifndef CONFIG_FLASH_SIMULATOR_NOALLOC
 static uint8_t mock_flash[FLASH_SIMULATOR_FLASH_SIZE];
+#else
+static uint8_t mock_flash[FLASH_SIMULATOR_PROG_UNIT];
+#endif
 #endif /* CONFIG_ARCH_POSIX */
 
 static const struct flash_driver_api flash_sim_api;
@@ -191,7 +199,11 @@ static int flash_sim_read(const struct device *dev, const off_t offset,
 
 	FLASH_SIM_STATS_INC(flash_sim_stats, flash_read_calls);
 
+#ifndef CONFIG_FLASH_SIMULATOR_NOALLOC
 	memcpy(data, MOCK_FLASH(offset), len);
+#else
+	memset(data, flash_sim_parameters.erase_value, len);
+#endif
 	FLASH_SIM_STATS_INCN(flash_sim_stats, bytes_read, len);
 
 #ifdef CONFIG_FLASH_SIMULATOR_SIMULATE_TIMING
@@ -280,12 +292,14 @@ static int flash_sim_write(const struct device *dev, const off_t offset,
 
 static void unit_erase(const uint32_t unit)
 {
+#ifndef CONFIG_FLASH_SIMULATOR_NOALLOC
 	const off_t unit_addr = FLASH_SIMULATOR_BASE_OFFSET +
 				(unit * FLASH_SIMULATOR_ERASE_UNIT);
 
 	/* erase the memory unit by setting it to erase value */
 	memset(MOCK_FLASH(unit_addr), FLASH_SIMULATOR_ERASE_VALUE,
 	       FLASH_SIMULATOR_ERASE_UNIT);
+#endif
 }
 
 static int flash_sim_erase(const struct device *dev, const off_t offset,

--- a/modules/Kconfig.mcuboot_bootutil
+++ b/modules/Kconfig.mcuboot_bootutil
@@ -21,4 +21,21 @@ module-str = MCUboot bootutil
 source "subsys/logging/Kconfig.template.log_config"
 endif
 
+config BOOT_IMAGE_ACCESS_HOOKS
+	bool "Enable hooks for overriding MCUboot's bootutil native routines"
+	help
+	  Allow to provide procedures for override or extend native
+	  MCUboot's routines required for access the image data.
+
+config BOOT_IMAGE_ACCESS_HOOKS_FILE
+	string "Hooks implementation file path"
+	depends on BOOT_IMAGE_ACCESS_HOOKS
+	help
+	  Path to the file which implements hooks.
+	  You can use either absolute or relative path.
+	  In case relative path is used, the build system assumes that it starts
+	  from the directory where the project KConfig configuration file is
+	  located. If the key file is not there, the build system uses relative
+	  path that starts from the Application cmake directory.
+
 endif # MCUBOOT_BOOTUTIL_LIB


### PR DESCRIPTION
Upstream PR:
https://github.com/zephyrproject-rtos/zephyr/pull/38496

Mcuboot's bootutil libraries has option to use hooks which allows to customize its behavior while proceeding on images date. This patch introduces configuration options required that.