### PR TITLE
[nrf noup] soc: Use DWT for null-pointer detection on nRF5340 net core

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig.defconfig
+++ b/soc/arm/nordic_nrf/Kconfig.defconfig
@@ -43,8 +43,10 @@ config GPIO
 	depends on SPI
 
 # Switch the default mechanism for null-pointer dereference detection from
-# DWT-based to MPU-based.
+# DWT-based to MPU-based, except for the network core on nRF5340 where the
+# MPU-based mechanism cannot be used.
 choice NULL_POINTER_EXCEPTION_DETECTION
+	default NULL_POINTER_EXCEPTION_DETECTION_DWT if SOC_NRF5340_CPUNET
 	default NULL_POINTER_EXCEPTION_DETECTION_MPU if TEST_ARM_CORTEX_M && !ARM_NONSECURE_FIRMWARE
 endchoice
 


### PR DESCRIPTION
This is a follow-up to commit 7c9139a300ace41d8f66270b3003684999c01d63
and should be squashed with it on the next upmerge.

The MPU-based null-pointer dereference detection cannot be used on
the network core in nRF5340 because of its flash base address and
this causes the zephyr/tests/arch/arm/arm_interrupt test to fail.
Use the DWT option instead for this core.

Ref. NCSDK-11348

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>