### PR TITLE
[nrf fromtree] ci: Bump to use SDK 0.13.1

### DIFF
--- a/.buildkite/daily.yml
+++ b/.buildkite/daily.yml
@@ -3,14 +3,14 @@ steps:
     - .buildkite/run.sh
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
-      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.13.0-rc3"
-    parallelism: 400
+      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.13.1"
+    parallelism: 475
     timeout_in_minutes: 210
     retry:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.17.5"
+          image: "zephyrprojectrtos/ci:v0.18.4"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,14 +3,14 @@ steps:
     - .buildkite/run.sh
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: "zephyr"
-      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.12.4"
+      ZEPHYR_SDK_INSTALL_DIR: "/opt/toolchains/zephyr-sdk-0.13.1"
     parallelism: 20
     timeout_in_minutes: 180
     retry:
       manual: true
     plugins:
       - docker#v3.5.0:
-          image: "zephyrprojectrtos/ci:v0.18.2"
+          image: "zephyrprojectrtos/ci:v0.18.4"
           propagate-environment: true
           volumes:
             - "/var/lib/buildkite-agent/git-mirrors:/var/lib/buildkite-agent/git-mirrors"

--- a/.github/workflows/bsim.yaml
+++ b/.github/workflows/bsim.yaml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: bsim-build-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.18.2
+      image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.1
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -14,14 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: clang-build-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.18.2
+      image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false
       matrix:
         subset: [1, 2, 3, 4, 5]
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.1
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       MATRIX_SIZE: 5
     steps:

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -8,7 +8,7 @@ jobs:
   check-errno:
     runs-on: ubuntu-latest
     container:
-      image: zephyrprojectrtos/ci:v0.18.2
+      image: zephyrprojectrtos/ci:v0.18.4
 
     steps:
       - name: checkout

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -27,12 +27,12 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-tracking-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.17.1
+      image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.1
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -16,12 +16,12 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.17.1
+      image: zephyrprojectrtos/ci:v0.18.4
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.12.4
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.1
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:


### PR DESCRIPTION
Now that SDK 0.13.1 is released bump buildkite & github workflows
to use this SDK version and the docker image that has it.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>
(cherry picked from commit b312470bbb4d1d00bbdb1e8540c4c1752e8adefc)
Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>