### PR TITLE
[nrf fromtree] Bluetooth: Disconnect L2CAP channel if peer sent too m…

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -263,7 +263,13 @@ static void bt_acl_recv(struct bt_conn *conn, struct net_buf *buf,
 
 		if (buf->len > net_buf_tailroom(conn->rx)) {
 			BT_ERR("Not enough buffer space for L2CAP data");
-			bt_conn_reset_rx_state(conn);
+
+			/* Frame is not complete but we still pass it to L2CAP
+			 * so that it may handle error on protocol level
+			 * eg disconnect channel.
+			 */
+			bt_l2cap_recv(conn, conn->rx, false);
+			conn->rx = NULL;
 			net_buf_unref(buf);
 			return;
 		}
@@ -308,7 +314,7 @@ static void bt_acl_recv(struct bt_conn *conn, struct net_buf *buf,
 	conn->rx = NULL;
 
 	BT_DBG("Successfully parsed %u byte L2CAP packet", buf->len);
-	bt_l2cap_recv(conn, buf);
+	bt_l2cap_recv(conn, buf, true);
 }
 
 void bt_conn_recv(struct bt_conn *conn, struct net_buf *buf, uint8_t flags)

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -312,7 +312,7 @@ static inline int bt_l2cap_send(struct bt_conn *conn, uint16_t cid,
 }
 
 /* Receive a new L2CAP PDU from a connection */
-void bt_l2cap_recv(struct bt_conn *conn, struct net_buf *buf);
+void bt_l2cap_recv(struct bt_conn *conn, struct net_buf *buf, bool complete);
 
 /* Perform connection parameter update request */
 int bt_l2cap_update_conn_param(struct bt_conn *conn,


### PR DESCRIPTION
…uch data

This was affecting L2CAP/LE/CFC/BV-26-C, L2CAP/LE/CFC/BV-27-C,
L2CAP/ECFC/BV-33-C and L2CAP/ECFC/BV-34-C qualification test cases.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>
(cherry picked from commit c3bb5ad47289eb7bab1a0ee9106f0570dc45f96b)
Signed-off-by: Alexandru Carbuneanu <alexandru.carbuneanu@nordicsemi.no>