### PR TITLE
[nrf fromtree] twister: reenable build samples on Windows OS

### DIFF
--- a/doc/guides/test/twister.rst
+++ b/doc/guides/test/twister.rst
@@ -41,8 +41,8 @@ To run the script in the local tree, follow the steps below:
         $ source zephyr-env.sh
         $ ./scripts/twister
 
-If you have a system with a large number of cores, you can build and run
-all possible tests using the following options:
+If you have a system with a large number of cores and plenty of free storage space,
+you can build and run all possible tests using the following options:
 
 ::
 
@@ -512,12 +512,15 @@ Executing tests on a single device
 To use this feature on a single connected device, run twister with
 the following new options::
 
-	scripts/twister --device-testing --device-serial /dev/ttyACM0 -p \
-	frdm_k64f  -T tests/kernel
+	scripts/twister --device-testing --device-serial /dev/ttyACM0 \
+	--device-serial-baud 9600 -p frdm_k64f  -T tests/kernel
 
 The ``--device-serial`` option denotes the serial device the board is connected to.
 This needs to be accessible by the user running twister. You can run this on
 only one board at a time, specified using the ``--platform`` option.
+
+The ``--device-serial-baud`` option is only needed if your device does not run at
+115200 baud.
 
 
 Executing tests on multiple devices
@@ -525,8 +528,8 @@ Executing tests on multiple devices
 
 To build and execute tests on multiple devices connected to the host PC, a
 hardware map needs to be created with all connected devices and their
-details such as the serial device and their IDs if available. Run the following
-command to produce the hardware map::
+details such as the serial device, baud and their IDs if available.
+Run the following command to produce the hardware map::
 
     ./scripts/twister --generate-hardware-map map.yml
 
@@ -558,12 +561,16 @@ this example we are using a reel_board and an nrf52840dk_nrf52840::
     product: DAPLink CMSIS-DAP
     runner: pyocd
     serial: /dev/cu.usbmodem146114202
+    baud: '9600'
   - connected: true
     id: 000683759358
     platform: nrf52840dk_nrf52840
     product: J-Link
     runner: nrfjprog
     serial: /dev/cu.usbmodem0006837593581
+    baud: '9600'
+
+The baud entry is only needed if not running at 115200.
 
 If the map file already exists, then new entries are added and existing entries
 will be updated. This way you can use one single master hardware map and update

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -733,7 +733,7 @@ class DeviceHandler(Handler):
         else:
             serial_device = hardware.serial
 
-        logger.debug("Using serial device {}".format(serial_device))
+        logger.debug("Using serial device {} @ {} baud".format(serial_device, hardware.serial_baud))
 
         if (self.suite.west_flash is not None) or runner:
             command = ["west", "flash", "--skip-rebuild", "-d", self.build_dir]
@@ -790,7 +790,7 @@ class DeviceHandler(Handler):
         try:
             ser = serial.Serial(
                 serial_device,
-                baudrate=115200,
+                baudrate=hardware.serial_baud,
                 parity=serial.PARITY_NONE,
                 stopbits=serial.STOPBITS_ONE,
                 bytesize=serial.EIGHTBITS,
@@ -3933,10 +3933,12 @@ class Gcovr(CoverageTool):
                                ["-o", os.path.join(subdir, "index.html")],
                                stdout=coveragelog)
 
+
 class DUT(object):
     def __init__(self,
                  id=None,
                  serial=None,
+                 serial_baud=None,
                  platform=None,
                  product=None,
                  serial_pty=None,
@@ -3947,6 +3949,9 @@ class DUT(object):
                  runner=None):
 
         self.serial = serial
+        self.serial_baud = 115200
+        if serial_baud:
+            self.serial_baud = serial_baud
         self.platform = platform
         self.serial_pty = serial_pty
         self._counter = Value("i", 0)
@@ -4038,8 +4043,8 @@ class HardwareMap:
         self.detected = []
         self.duts = []
 
-    def add_device(self, serial, platform, pre_script, is_pty):
-        device = DUT(platform=platform, connected=True, pre_script=pre_script)
+    def add_device(self, serial, platform, pre_script, is_pty, baud=None):
+        device = DUT(platform=platform, connected=True, pre_script=pre_script, serial_baud=baud)
 
         if is_pty:
             device.serial_pty = serial
@@ -4059,6 +4064,7 @@ class HardwareMap:
             id = dut.get('id')
             runner = dut.get('runner')
             serial = dut.get('serial')
+            baud = dut.get('baud', None)
             product = dut.get('product')
             fixtures = dut.get('fixtures', [])
             new_dut = DUT(platform=platform,
@@ -4066,6 +4072,7 @@ class HardwareMap:
                           runner=runner,
                           id=id,
                           serial=serial,
+                          serial_baud=baud,
                           connected=serial is not None,
                           pre_script=pre_script,
                           post_script=post_script,

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -25,7 +25,6 @@ import glob
 import concurrent
 import xml.etree.ElementTree as ET
 import logging
-import pty
 from pathlib import Path
 from distutils.spawn import find_executable
 from colorama import Fore
@@ -57,6 +56,14 @@ try:
     import psutil
 except ImportError:
     print("Install psutil python module with pip to run in Qemu.")
+
+try:
+    import pty
+except ImportError as capture_error:
+    if os.name == "nt":  # "nt" means that program is running on Windows OS
+        pass  # "--device-serial-pty" option is not supported on Windows OS
+    else:
+        raise capture_error
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 if not ZEPHYR_BASE:
@@ -2686,7 +2693,7 @@ class TestSuite(DisablePyTestCollectionMixin):
             logger.info("Cannot read zephyr version.")
 
     def get_platform_instances(self, platform):
-        filtered_dict = {k:v for k,v in self.instances.items() if k.startswith(platform + "/")}
+        filtered_dict = {k:v for k,v in self.instances.items() if k.startswith(platform + os.sep)}
         return filtered_dict
 
     def config(self):

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -30,6 +30,9 @@ sequence:
       "serial":
         type: str
         required: false
+      "baud":
+        type: int
+        required: false
       "post_script":
         type: str
         required: false

--- a/scripts/twister
+++ b/scripts/twister
@@ -635,6 +635,7 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
                         help="""Script for controlling pseudoterminal.
                         Twister believes that it interacts with a terminal
                         when it actually interacts with the script.
+                        Not supported on Windows OS.
 
                         E.g "twister --device-testing
                         --device-serial-pty <script>
@@ -838,6 +839,10 @@ def main():
 
     if not options.coverage_platform:
         options.coverage_platform = options.platform
+
+    if options.device_serial_pty and os.name == "nt":  # OS is Windows
+        logger.error("--device-serial-pty is not supported on Windows OS")
+        sys.exit(1)
 
     if options.size:
         for fn in options.size:
@@ -1322,5 +1327,6 @@ if __name__ == "__main__":
     try:
         main()
     finally:
-        if os.isatty(1): # stdout is interactive
+        if (os.name != "nt") and os.isatty(1):
+            # (OS is not Windows) and (stdout is interactive)
             os.system("stty sane")

--- a/scripts/twister
+++ b/scripts/twister
@@ -214,7 +214,7 @@ logger.setLevel(logging.DEBUG)
 def size_report(sc):
     logger.info(sc.filename)
     logger.info("SECTION NAME             VMA        LMA     SIZE  HEX SZ TYPE")
-    for i in range(len(sc.sections)):
+    for i in enumerate(sc.sections):
         v = sc.sections[i]
 
         logger.info("%-17s 0x%08x 0x%08x %8d 0x%05x %-7s" %
@@ -621,6 +621,10 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         "-X", "--fixture", action="append", default=[],
         help="Specify a fixture that a board might support")
 
+    parser.add_argument(
+        "--device-serial-baud", action="store", default=None,
+        help="Serial device baud rate (default 115200)")
+
     serial = parser.add_mutually_exclusive_group()
     serial.add_argument("--device-serial",
                         help="""Serial device for accessing the board
@@ -925,9 +929,11 @@ def main():
             if options.platform and len(options.platform) == 1:
                 if options.device_serial:
                     hwm.add_device(options.device_serial,
-                                                 options.platform[0],
-                                                 options.pre_script,
-                                                 False)
+                                   options.platform[0],
+                                   options.pre_script,
+                                   False,
+                                   baud=options.device_serial_baud
+                                   )
                 else:
                     hwm.add_device(options.device_serial_pty,
                                                  options.platform[0],


### PR DESCRIPTION
Fix few limitation which do not allow to run Twister on Windows OS.
Especially turn off "import pty" module, due to the fact, that this
module can be used only on POSIX OS.

Fixes #40007

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>
(cherry picked from commit 8b773481e974ec952755e5cad1bd49604c6bb2a8)
Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>