### PR TITLE
[nrf fromtree] Bluetooth: Host: avoid runtime warning in bt_enable

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3562,7 +3562,7 @@ int bt_enable(bt_ready_cb_t cb)
 		if (err) {
 			return err;
 		}
-	} else {
+	} else if (IS_ENABLED(CONFIG_BT_DEVICE_NAME_DYNAMIC)) {
 		err = bt_set_name(CONFIG_BT_DEVICE_NAME);
 		if (err) {
 			BT_WARN("Failed to set device name (%d)", err);


### PR DESCRIPTION
Avoid runtime warning in bt_enable when CONFIG_BT_SETTINGS
and CONFIG_BT_DEVICE_NAME_DYNAMIC is not set.
This warning was intoroduced in
commit d76bba4b5ef85c6b25dfdf9c9809fcead0f4da5c
("Bluetooth: host: Device name handling of invalid length")

Signed-off-by: Martin Tverdal <martin.tverdal@nordicsemi.no>
(cherry picked from commit 0d4f685dbdb521a35abbb2ad764b775eb3ecdc66)
Signed-off-by: Martin Tverdal <martin.tverdal@nordicsemi.no>

https://github.com/nrfconnect/sdk-nrf/pull/6103