### PR TITLE
[nrf noup] Add tfm read service to nRF SoC Flash driver

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -37,12 +37,17 @@ LOG_MODULE_REGISTER(flash_nrf);
 
 #define SOC_NV_FLASH_NODE DT_INST(0, soc_nv_flash)
 
-#if CONFIG_ARM_NONSECURE_FIRMWARE && CONFIG_SPM
+#if CONFIG_ARM_NONSECURE_FIRMWARE
+#if CONIFG_SPM
 #include <secure_services.h>
+#else
+#include <tfm_ns_interface.h>
+#include <tfm/tfm_ioctl_api.h>
+#endif /* CONFIG_SPM */
 #if USE_PARTITION_MANAGER
 #include <pm_config.h>
 #endif /* USE_PARTITION_MANAGER */
-#endif /* CONFIG_ARM_NONSECURE_FIRMWARE  && CONFIG_SPM */
+#endif /* CONFIG_ARM_NONSECURE_FIRMWARE */
 
 #ifndef CONFIG_SOC_FLASH_NRF_RADIO_SYNC_NONE
 #define FLASH_SLOT_WRITE     7500
@@ -153,10 +158,20 @@ static int flash_nrf_read(const struct device *dev, off_t addr,
 		return 0;
 	}
 
-#if CONFIG_ARM_NONSECURE_FIRMWARE && CONFIG_SPM && USE_PARTITION_MANAGER \
-	&& CONFIG_SPM_SECURE_SERVICES
-	if (addr < PM_APP_ADDRESS) {
+#if CONFIG_ARM_NONSECURE_FIRMWARE && USE_PARTITION_MANAGER
+	if ((addr < PM_APP_ADDRESS) || (addr > (PM_APP_ADDRESS + PM_APP_SIZE))) {
+#if CONFIG_SPM && CONFIG_SPM_SECURE_SERVICES
 		return spm_request_read(data, addr, len);
+#else
+		uint32_t err = 0;
+		enum tfm_platform_err_t plt_err;
+		plt_err = tfm_platform_mem_read(&data, addr, len, &err);
+		if (plt_err != TFM_PLATFORM_ERR_SUCCESS || err != 0) {
+			LOG_ERR("tfm_..._mem_read failed: plt_err: 0x%x, err: 0x%x\n", plt_err, err);
+			return -EINVAL;
+		}
+		return 0;
+#endif
 	}
 #endif
 


### PR DESCRIPTION
This adds the functionality to read memory which are residing in the
secure part of flash from a non-secure application when building with
TF-M.

Currently we check if the address space is not inside the non-secure
applapplication address space. If the address space is outside we do a
request to TF-M so that the secure application can either return success
or fail if the address space is not allowed to be read.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>