### PR TITLE
[nrf fromtree] Bluetooth: Adds preprocessor to L2CAP tester app

### DIFF
--- a/tests/bluetooth/tester/src/l2cap.c
+++ b/tests/bluetooth/tester/src/l2cap.c
@@ -139,6 +139,7 @@ static void disconnected_cb(struct bt_l2cap_chan *l2cap_chan)
 		    CONTROLLER_INDEX, (uint8_t *) &ev, sizeof(ev));
 }
 
+#if defined(CONFIG_BT_L2CAP_ECRED)
 static void reconfigured_cb(struct bt_l2cap_chan *l2cap_chan)
 {
 	struct l2cap_reconfigured_ev ev;
@@ -155,13 +156,16 @@ static void reconfigured_cb(struct bt_l2cap_chan *l2cap_chan)
 	tester_send(BTP_SERVICE_ID_L2CAP, L2CAP_EV_RECONFIGURED,
 		    CONTROLLER_INDEX, (uint8_t *)&ev, sizeof(ev));
 }
+#endif
 
 static const struct bt_l2cap_chan_ops l2cap_ops = {
 	.alloc_buf	= alloc_buf_cb,
 	.recv		= recv_cb,
 	.connected	= connected_cb,
 	.disconnected	= disconnected_cb,
+#if defined(CONFIG_BT_L2CAP_ECRED)
 	.reconfigured	= reconfigured_cb,
+#endif
 };
 
 static struct channel *get_free_channel()
@@ -282,6 +286,7 @@ rsp:
 		   status);
 }
 
+#if defined(CONFIG_BT_L2CAP_ECRED)
 static void reconfigure(uint8_t *data, uint16_t len)
 {
 	const struct l2cap_reconfigure_cmd *cmd = (void *)data;
@@ -331,6 +336,7 @@ rsp:
 	tester_rsp(BTP_SERVICE_ID_L2CAP, L2CAP_RECONFIGURE, CONTROLLER_INDEX,
 		   status);
 }
+#endif
 
 #if defined(CONFIG_BT_EATT)
 void disconnect_eatt_chans(uint8_t *data, uint16_t len)
@@ -541,7 +547,9 @@ static void supported_commands(uint8_t *data, uint16_t len)
 	tester_set_bit(cmds, L2CAP_DISCONNECT);
 	tester_set_bit(cmds, L2CAP_LISTEN);
 	tester_set_bit(cmds, L2CAP_SEND_DATA);
+#if defined(CONFIG_BT_L2CAP_ECRED)
 	tester_set_bit(cmds, L2CAP_RECONFIGURE);
+#endif
 	tester_set_bit(cmds, L2CAP_CREDITS);
 #if defined(CONFIG_BT_EATT)
 	tester_set_bit(cmds, L2CAP_DISCONNECT_EATT_CHANS);
@@ -569,9 +577,11 @@ void tester_handle_l2cap(uint8_t opcode, uint8_t index, uint8_t *data,
 	case L2CAP_LISTEN:
 		listen(data, len);
 		return;
+#if defined(CONFIG_BT_L2CAP_ECRED)
 	case L2CAP_RECONFIGURE:
 		reconfigure(data, len);
 		return;
+#endif
 	case L2CAP_CREDITS:
 		credits(data, len);
 		return;


### PR DESCRIPTION
Adds preprocessor ifdefs to reconfigure() in L2CAP tester application
depending on the KConfig option CONFIG_BT_L2CAP_ECRED
Fixes issue #40456

Signed-off-by: Johan Lundin <johan.lundin@nordicsemi.no>
(cherry picked from commit 403fbfcc12068d890d771bcc7bfa9352fe593baf)
Signed-off-by: Johan Lundin <johan.lundin@nordicsemi.no>