### PR TITLE
fixup! [nrf noup] tree-wide: support NCS Partition

### DIFF
--- a/subsys/ipc/rpmsg_service/rpmsg_backend.h
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.h
@@ -13,8 +13,35 @@
 extern "C" {
 #endif
 
+#if CONFIG_PARTITION_MANAGER_ENABLED
+
+#include "pm_config.h"
+
+#if defined(PM_RPMSG_NRF53_SRAM_ADDRESS) || defined(PM__RPMSG_NRF53_SRAM_ADDRESS)
+
+#if defined(PM_RPMSG_NRF53_SRAM_ADDRESS)
+#define VDEV_START_ADDR PM_RPMSG_NRF53_SRAM_ADDRESS
+#define VDEV_SIZE PM_RPMSG_NRF53_SRAM_SIZE
+#else
+/* The current image is a child image in a different domain than the image
+ * which defined the required values. To reach the values of the parent domain
+ * we use the 'PM__' variant of the define.
+ */
+#define VDEV_START_ADDR PM__RPMSG_NRF53_SRAM_ADDRESS
+#define VDEV_SIZE PM__RPMSG_NRF53_SRAM_SIZE
+#endif /* defined(PM_RPMSG_NRF53_SRAM_ADDRESS) */
+
+#else
 #define VDEV_START_ADDR		CONFIG_RPMSG_SERVICE_SHM_BASE_ADDRESS
 #define VDEV_SIZE		    CONFIG_RPMSG_SERVICE_SHM_SIZE
+#endif /* defined(PM_RPMSG_NRF53_SRAM_ADDRESS) || defined(PM__RPMSG_NRF53_SRAM_ADDRESS) */
+
+#else
+
+#define VDEV_START_ADDR		CONFIG_RPMSG_SERVICE_SHM_BASE_ADDRESS
+#define VDEV_SIZE		    CONFIG_RPMSG_SERVICE_SHM_SIZE
+
+#endif /* CONFIG_PARTITION_MANAGER_ENABLED */
 
 #define VDEV_STATUS_ADDR	VDEV_START_ADDR
 #define VDEV_STATUS_SIZE	0x400


### PR DESCRIPTION
Will be squashed.

Use partition manager defines instead of kconfig deduced from
devicetree for RPMSG shared memory.

Ref: NCSDK-11234
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>