### PR TITLE
[nrf noup] adding NCS_<module_name>_KCONFIG for NCS extended modules

### DIFF
--- a/cmake/zephyr_module.cmake
+++ b/cmake/zephyr_module.cmake
@@ -80,6 +80,20 @@ if(WEST OR ZEPHYR_MODULES)
     endforeach()
   endif()
 
+  if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
+    file(STRINGS ${CMAKE_BINARY_DIR}/zephyr_modules.txt ZEPHYR_MODULES_TXT
+         ENCODING UTF-8)
+
+    set(ZEPHYR_MODULE_NAMES)
+    foreach(module ${ZEPHYR_MODULES_TXT})
+      # Match "<name>":"<path>" for each line of file, each corresponding to
+      # one module. The use of quotes is required due to CMake not supporting
+      # lazy regexes (it supports greedy only).
+      string(REGEX REPLACE "\"(.*)\":\".*\":\".*\"" "\\1" module_name ${module})
+      list(APPEND ZEPHYR_MODULE_NAMES ${module_name})
+    endforeach()
+  endif()
+
   foreach(root ${MODULE_EXT_ROOT})
     if(NOT EXISTS ${root})
       message(FATAL_ERROR "No `modules.cmake` found in module root `${root}`.")
@@ -88,11 +102,7 @@ if(WEST OR ZEPHYR_MODULES)
     include(${root}/modules/modules.cmake)
   endforeach()
 
-  if(EXISTS ${CMAKE_BINARY_DIR}/zephyr_modules.txt)
-    file(STRINGS ${CMAKE_BINARY_DIR}/zephyr_modules.txt ZEPHYR_MODULES_TXT
-         ENCODING UTF-8)
-    set(ZEPHYR_MODULE_NAMES)
-
+  if(DEFINED ZEPHYR_MODULES_TXT)
     foreach(module ${ZEPHYR_MODULES_TXT})
       # Match "<name>":"<path>" for each line of file, each corresponding to
       # one module. The use of quotes is required due to CMake not supporting
@@ -101,8 +111,6 @@ if(WEST OR ZEPHYR_MODULES)
       string(REGEX REPLACE "\"(.*)\":\".*\":\".*\"" "\\1" module_name ${module})
       string(REGEX REPLACE "\".*\":\"(.*)\":\".*\"" "\\1" module_path ${module})
       string(REGEX REPLACE "\".*\":\".*\":\"(.*)\"" "\\1" cmake_path ${module})
-
-      list(APPEND ZEPHYR_MODULE_NAMES ${module_name})
 
       zephyr_string(SANITIZE TOUPPER MODULE_NAME_UPPER ${module_name})
       if(NOT ${MODULE_NAME_UPPER} STREQUAL CURRENT)

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -278,6 +278,10 @@ class KconfigCheck(ComplianceTest):
                     re.sub('[^a-zA-Z0-9]', '_', module).upper(),
                     nrf_modules_dir + '/' + module + '/Kconfig'
                 ))
+                fp_module_file.write("NCS_{}_KCONFIG = {}\n".format(
+                    re.sub('[^a-zA-Z0-9]', '_', module).upper(),
+                    modules_dir + '/' + module + '/Kconfig'
+                ))
             fp_module_file.write(content)
 
     def parse_kconfig(self):


### PR DESCRIPTION
squash! [nrf noup] ci: set `ZEPHYR_<MODULE_NAME>_KCONFIG` for NCS modules

This commit extends the check_compliance to add
`NCS_<module_name>_KCONFIG` for nRF Connect SDK extended Kconfig which
are defined in their upstream repo and not in an `ext-root`.

This is needed so that users may remove optional modules in their
downstream manifest.

See: https://github.com/nrfconnect/sdk-nrf/pull/6080

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>