### PR TITLE
Bluetooth: Mesh: nRF Connect SDK v1.8 feature freeze patches

### DIFF
--- a/doc/reference/bluetooth/mesh/access.rst
+++ b/doc/reference/bluetooth/mesh/access.rst
@@ -100,6 +100,16 @@ populate the :c:member:`bt_mesh_model_pub.update` callback. The
 message is published, allowing the model to change the payload to reflect its
 current state.
 
+By setting :c:member:`bt_mesh_model_pub.retr_update` to 1, the model can
+configure the :c:member:`bt_mesh_model_pub.update` callback to be triggered
+on every retransmission. This can, for example, be used by models that make
+use of a Delay parameter, which can be adjusted for every retransmission.
+The :c:func:`bt_mesh_model_pub_is_retransmission` function can be
+used to differentiate a first publication and a retransmission.
+The :c:macro:`BT_MESH_PUB_MSG_TOTAL` and :c:macro:`BT_MESH_PUB_MSG_NUM` macros
+can be used to return total number of transmissions and the retransmission
+number within one publication interval.
+
 Extended models
 ===============
 

--- a/doc/reference/bluetooth/mesh/shell.rst
+++ b/doc/reference/bluetooth/mesh/shell.rst
@@ -11,7 +11,7 @@ The Bluetooth mesh shell interface provides access to most Bluetooth mesh featur
 Prerequisites
 *************
 
-The Bluetooth mesh shell subsystem depends on the :ref:`bluetooth_mesh_models_cfg_cli` and :ref:`bluetooth_mesh_models_health_cli` models.
+The Bluetooth mesh shell subsystem depends on the application to create the composition data and do the mesh initialization.
 
 Application
 ***********
@@ -125,7 +125,7 @@ General configuration
 ``mesh init``
 -------------
 
-	Initialize the mesh. This command must be run before any other mesh command.
+	Initialize the mesh shell. This command must be run before any other mesh command.
 
 
 ``mesh reset <addr>``
@@ -298,7 +298,7 @@ Provisioning
 Configuration Client model
 ==========================
 
-The Bluetooth mesh shell module instantiates a Configuration Client model for configuring itself and other nodes in the mesh network.
+The Configuration Client model is an optional mesh subsystem that can be enabled through the :kconfig:`CONFIG_BT_MESH_CFG_CLI` configuration option. If included, the Bluetooth mesh shell module instantiates a Configuration Client model for configuring itself and other nodes in the mesh network.
 
 The Configuration Client uses the general messages parameters set by ``mesh dst`` and ``mesh netidx`` to target specific nodes. When the Bluetooth mesh shell node is provisioned, the Configuration Client model targets itself by default. When another node has been provisioned by the Bluetooth mesh shell, the Configuration Client model targets the new node. The Configuration Client always sends messages using the Device key bound to the destination address, so it will only be able to configure itself and mesh nodes it provisioned.
 
@@ -583,7 +583,7 @@ The Configuration Client uses the general messages parameters set by ``mesh dst`
 Health Client model
 ===================
 
-The Bluetooth mesh shell module instantiates a Health Client model for configuring itself and other nodes in the mesh network.
+The Health Client model is an optional mesh subsystem that can be enabled through the :kconfig:`CONFIG_BT_MESH_HEALTH_CLI` configuration option. If included, the Bluetooth mesh shell module instantiates a Health Client model for configuring itself and other nodes in the mesh network.
 
 The Health Client uses the general messages parameters set by ``mesh dst`` and ``mesh netidx`` to target specific nodes. When the Bluetooth mesh shell node is provisioned, the Health Client model targets itself by default. When another node has been provisioned by the Bluetooth mesh shell, the Health Client model targets the new node. The Health Client always sends messages using the Device key bound to the destination address, so it will only be able to configure itself and mesh nodes it provisioned.
 

--- a/include/bluetooth/mesh/shell.h
+++ b/include/bluetooth/mesh/shell.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_BLUETOOTH_MESH_SHELL_H_
+#define ZEPHYR_INCLUDE_BLUETOOTH_MESH_SHELL_H_
+
+#include <bluetooth/mesh.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum number of faults the health server can have. */
+#define BT_MESH_SHELL_CUR_FAULTS_MAX 4
+
+/** @def BT_MESH_SHELL_HEALTH_PUB_DEFINE
+ *
+ *  A helper to define a health publication context for shell with the shell's
+ *  maximum number of faults the element can have.
+ *
+ *  @param _name Name given to the publication context variable.
+ */
+#define BT_MESH_SHELL_HEALTH_PUB_DEFINE(_name)                                 \
+		BT_MESH_HEALTH_PUB_DEFINE(_name,                               \
+					  BT_MESH_SHELL_CUR_FAULTS_MAX);
+
+/** @brief External reference to health server */
+extern struct bt_mesh_health_srv bt_mesh_shell_health_srv;
+
+/** @brief External reference to health client */
+extern struct bt_mesh_health_cli bt_mesh_shell_health_cli;
+
+/** @brief External reference to provisioning handler. */
+extern struct bt_mesh_prov bt_mesh_shell_prov;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_BLUETOOTH_MESH_SHELL_H_ */

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -704,8 +704,6 @@ config BT_MESH_HEALTH_CLI
 config BT_MESH_SHELL
 	bool "Enable Bluetooth mesh shell"
 	select SHELL
-	depends on BT_MESH_CFG_CLI
-	depends on BT_MESH_HEALTH_CLI
 	help
 	  Activate shell module that provides Bluetooth mesh commands to
 	  the console.

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -241,6 +241,15 @@ static void mod_publish(struct k_work *work)
 
 	if (pub->count) {
 		pub->count--;
+
+		if (pub->retr_update && pub->update &&
+		    bt_mesh_model_pub_is_retransmission(pub->mod)) {
+			err = pub->update(pub->mod);
+			if (err) {
+				publish_sent(err, pub->mod);
+				return;
+			}
+		}
 	} else {
 		/* First publication in this period */
 		err = pub_period_start(pub);
@@ -766,7 +775,7 @@ int bt_mesh_model_publish(struct bt_mesh_model *model)
 	}
 
 	/* Account for initial transmission */
-	pub->count = BT_MESH_PUB_TRANSMIT_COUNT(pub->retransmit) + 1;
+	pub->count = BT_MESH_PUB_MSG_TOTAL(pub);
 
 	BT_DBG("Publish Retransmit Count %u Interval %ums", pub->count,
 	       BT_MESH_PUB_TRANSMIT_INT(pub->retransmit));

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -821,12 +821,12 @@ void bt_mesh_model_extensions_walk(struct bt_mesh_model *model,
 #else
 	struct bt_mesh_model *it;
 
-	if (model->next == NULL) {
-		(void)cb(model, user_data);
+	if (cb(model, user_data) == BT_MESH_WALK_STOP || !model->next) {
 		return;
 	}
 
-	for (it = model; (it != NULL) && (it->next != model); it = it->next) {
+	/* List is circular. Step through all models until we reach the start: */
+	for (it = model->next; it != model; it = it->next) {
 		if (cb(it, user_data) == BT_MESH_WALK_STOP) {
 			return;
 		}

--- a/subsys/bluetooth/mesh/cfg.c
+++ b/subsys/bluetooth/mesh/cfg.c
@@ -5,6 +5,8 @@
  */
 
 #include <bluetooth/mesh.h>
+#include <bluetooth/bluetooth.h>
+
 #include "mesh.h"
 #include "net.h"
 #include "rpl.h"
@@ -13,6 +15,7 @@
 #include "heartbeat.h"
 #include "friend.h"
 #include "cfg.h"
+#include "adv.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_CFG)
 #define LOG_MODULE_NAME bt_mesh_cfg
@@ -79,6 +82,11 @@ static enum bt_mesh_feat_state feature_get(int feature_flag)
 		       BT_MESH_FEATURE_DISABLED;
 }
 
+static int node_id_is_running(struct bt_mesh_subnet *sub, void *cb_data)
+{
+	return sub->node_id == BT_MESH_NODE_IDENTITY_RUNNING;
+}
+
 int bt_mesh_gatt_proxy_set(enum bt_mesh_feat_state gatt_proxy)
 {
 	int err;
@@ -90,6 +98,11 @@ int bt_mesh_gatt_proxy_set(enum bt_mesh_feat_state gatt_proxy)
 	err = feature_set(BT_MESH_GATT_PROXY, gatt_proxy);
 	if (err) {
 		return err;
+	}
+
+	if (gatt_proxy == BT_MESH_FEATURE_DISABLED &&
+	    !bt_mesh_subnet_find(node_id_is_running, NULL)) {
+		bt_mesh_adv_update();
 	}
 
 	bt_mesh_hb_feature_changed(BT_MESH_FEAT_PROXY);

--- a/subsys/bluetooth/mesh/gatt_services.c
+++ b/subsys/bluetooth/mesh/gatt_services.c
@@ -572,6 +572,7 @@ static int gatt_proxy_advertise(struct bt_mesh_subnet *sub)
 	int32_t remaining = SYS_FOREVER_MS;
 	int subnet_count;
 	int err = -EBUSY;
+	bool planned = false;
 
 	BT_DBG("");
 
@@ -604,29 +605,44 @@ static int gatt_proxy_advertise(struct bt_mesh_subnet *sub)
 		}
 	}
 
-	if (sub->node_id == BT_MESH_NODE_IDENTITY_RUNNING) {
-		uint32_t active = k_uptime_get_32() - sub->node_id_start;
+	for (int i = 0; i < subnet_count; i++) {
 
-		if (active < NODE_ID_TIMEOUT) {
-			remaining = NODE_ID_TIMEOUT - active;
-			BT_DBG("Node ID active for %u ms, %d ms remaining",
-			       active, remaining);
-			err = node_id_adv(sub, remaining);
-		} else {
-			bt_mesh_proxy_identity_stop(sub);
-			BT_DBG("Node ID stopped");
+		if (sub->node_id == BT_MESH_NODE_IDENTITY_RUNNING) {
+			uint32_t active = k_uptime_get_32() - sub->node_id_start;
+
+			if (active < NODE_ID_TIMEOUT) {
+				remaining = NODE_ID_TIMEOUT - active;
+				BT_DBG("Node ID active for %u ms, %d ms remaining",
+				       active, remaining);
+				err = node_id_adv(sub, remaining);
+				planned = true;
+			} else {
+				bt_mesh_proxy_identity_stop(sub);
+				BT_DBG("Node ID stopped");
+			}
 		}
+
+		/* Mesh Profile Specification v1.0.1, section 7.2.2.2.1
+		 * A node that does not support the Proxy feature or
+		 * has the GATT Proxy state disabled shall not advertise with Network ID.
+		 */
+		if (sub->node_id == BT_MESH_NODE_IDENTITY_STOPPED &&
+		    bt_mesh_gatt_proxy_get() == BT_MESH_FEATURE_ENABLED) {
+			err = net_id_adv(sub, remaining);
+			planned = true;
+		}
+
+		beacon_sub = bt_mesh_subnet_next(sub);
+
+		if (planned) {
+			BT_DBG("Advertising %d ms for net_idx 0x%04x", remaining, sub->net_idx);
+			return err;
+		}
+
+		sub = beacon_sub;
 	}
 
-	if (sub->node_id == BT_MESH_NODE_IDENTITY_STOPPED) {
-		err = net_id_adv(sub, remaining);
-	}
-
-	BT_DBG("Advertising %d ms for net_idx 0x%04x", remaining, sub->net_idx);
-
-	beacon_sub = bt_mesh_subnet_next(beacon_sub);
-
-	return err;
+	return 0;
 }
 
 static void subnet_evt(struct bt_mesh_subnet *sub, enum bt_mesh_key_evt evt)

--- a/subsys/bluetooth/mesh/gatt_services.c
+++ b/subsys/bluetooth/mesh/gatt_services.c
@@ -849,8 +849,8 @@ bool bt_mesh_proxy_relay(struct net_buf *buf, uint16_t dst)
 		}
 
 		if (client->filter_type == PROV) {
-			BT_ERR("Invalid PDU type for Proxy Client");
-			return -EINVAL;
+			BT_WARN("Invalid PDU type for Proxy Client");
+			continue;
 		}
 
 		/* Proxy PDU sending modifies the original buffer,

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -89,6 +89,15 @@ struct bt_mesh_net bt_mesh = {
 	.local_queue = SYS_SLIST_STATIC_INIT(&bt_mesh.local_queue),
 };
 
+/* Mesh Profile Specification 3.10.6
+ * The node shall not execute more than one IV Index Recovery within a period of
+ * 192 hours.
+ *
+ * Mark that the IV Index Recovery has been done to prevent two recoveries to be
+ * done before a normal IV Index update has been completed within 96h+96h.
+ */
+static bool ivi_was_recovered;
+
 NET_BUF_POOL_DEFINE(loopback_buf_pool, CONFIG_BT_MESH_LOOPBACK_BUFS,
 		    LOOPBACK_MAX_PDU_LEN, LOOPBACK_USER_DATA_SIZE, NULL);
 
@@ -257,23 +266,23 @@ bool bt_mesh_net_iv_update(uint32_t iv_index, bool iv_update)
 			return false;
 		}
 
-		if (iv_index > bt_mesh.iv_index + 1) {
+		if ((iv_index > bt_mesh.iv_index + 1) ||
+		    (iv_index == bt_mesh.iv_index + 1 && !iv_update)) {
+			if (ivi_was_recovered) {
+				BT_ERR("IV Index Recovery before minimum delay");
+				return false;
+			}
+			/* The Mesh profile specification allows to initiate an
+			 * IV Index Recovery procedure if previous IV update has
+			 * been missed. This allows the node to remain
+			 * functional.
+			 */
 			BT_WARN("Performing IV Index Recovery");
+			ivi_was_recovered = true;
 			bt_mesh_rpl_clear();
 			bt_mesh.iv_index = iv_index;
 			bt_mesh.seq = 0U;
 			goto do_update;
-		}
-
-		if (iv_index == bt_mesh.iv_index + 1 && !iv_update) {
-			BT_WARN("Ignoring new index in normal mode");
-			return false;
-		}
-
-		if (!iv_update) {
-			/* Nothing to do */
-			BT_DBG("Already in Normal state");
-			return false;
 		}
 	}
 
@@ -292,20 +301,21 @@ bool bt_mesh_net_iv_update(uint32_t iv_index, bool iv_update)
 		return false;
 	}
 
-do_update:
-	atomic_set_bit_to(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS, iv_update);
-	bt_mesh.ivu_duration = 0U;
-
 	if (iv_update) {
 		bt_mesh.iv_index = iv_index;
 		BT_DBG("IV Update state entered. New index 0x%08x",
 		       bt_mesh.iv_index);
 
 		bt_mesh_rpl_reset();
+		ivi_was_recovered = false;
 	} else {
 		BT_DBG("Normal mode entered");
 		bt_mesh.seq = 0U;
 	}
+
+do_update:
+	atomic_set_bit_to(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS, iv_update);
+	bt_mesh.ivu_duration = 0U;
 
 	k_work_reschedule(&bt_mesh.ivu_timer, BT_MESH_IVU_TIMEOUT);
 

--- a/tests/bluetooth/mesh_shell/src/main.c
+++ b/tests/bluetooth/mesh_shell/src/main.c
@@ -5,12 +5,77 @@
  */
 
 #include <sys/printk.h>
+#include <stdlib.h>
 #include <zephyr.h>
 
 #include <shell/shell.h>
 
+#include <bluetooth/bluetooth.h>
+#include <bluetooth/mesh.h>
+#include <bluetooth/mesh/shell.h>
+
+static struct bt_mesh_cfg_cli cfg_cli;
+
+BT_MESH_SHELL_HEALTH_PUB_DEFINE(health_pub);
+
+static struct bt_mesh_model root_models[] = {
+	BT_MESH_MODEL_CFG_SRV,
+	BT_MESH_MODEL_CFG_CLI(&cfg_cli),
+	BT_MESH_MODEL_HEALTH_SRV(&bt_mesh_shell_health_srv, &health_pub),
+	BT_MESH_MODEL_HEALTH_CLI(&bt_mesh_shell_health_cli),
+};
+
+static struct bt_mesh_elem elements[] = {
+	BT_MESH_ELEM(0, root_models, BT_MESH_MODEL_NONE),
+};
+
+static const struct bt_mesh_comp comp = {
+	.cid = CONFIG_BT_COMPANY_ID,
+	.elem = elements,
+	.elem_count = ARRAY_SIZE(elements),
+};
+
+static void bt_ready(int err)
+{
+	if (err && err != -EALREADY) {
+		printk("Bluetooth init failed (err %d)\n", err);
+		return;
+	}
+
+	printk("Bluetooth initialized\n");
+
+	err = bt_mesh_init(&bt_mesh_shell_prov, &comp);
+	if (err) {
+		printk("Initializing mesh failed (err %d)\n", err);
+		return;
+	}
+
+	if (IS_ENABLED(CONFIG_SETTINGS)) {
+		settings_load();
+	}
+
+	printk("Mesh initialized\n");
+
+	if (bt_mesh_is_provisioned()) {
+		printk("Mesh network restored from flash\n");
+	} else {
+		printk("Use \"pb-adv on\" or \"pb-gatt on\" to "
+			    "enable advertising\n");
+	}
+}
+
 void main(void)
 {
+	int err;
+
+	printk("Initializing...\n");
+
+	/* Initialize the Bluetooth Subsystem */
+	err = bt_enable(bt_ready);
+	if (err && err != -EALREADY) {
+		printk("Bluetooth init failed (err %d)\n", err);
+	}
+
 	printk("Press the <Tab> button for supported commands.\n");
 	printk("Before any Mesh commands you must run \"mesh init\"\n");
 }


### PR DESCRIPTION
Pulls in the following PRs from Zephyr main:
- zephyrproject-rtos/zephyr#40158
- zephyrproject-rtos/zephyr#40387
- zephyrproject-rtos/zephyr#40135
- zephyrproject-rtos/zephyr#39664
- zephyrproject-rtos/zephyr#39010
- zephyrproject-rtos/zephyr#38296

Does not include the Proxy split PR (zephyrproject-rtos/zephyr#36871), and its followup PRs.
Also does not include zephyrproject-rtos/zephyr#40109, as it's a pure feature addition that's not in Zephyr v2.7, and is not a requested feature in the nRF Connect SDK.
