### PR TITLE
[nrf fromtree] logging: Fix tracking of active messages

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -847,6 +847,7 @@ uint32_t z_vrfy_log_buffered_cnt(void)
 void z_log_dropped(void)
 {
 	atomic_inc(&dropped_cnt);
+	atomic_dec(&buffered_cnt);
 }
 
 uint32_t z_log_dropped_read_and_clear(void)


### PR DESCRIPTION
A variable is tracking number of buffered messages. This is used
to trigger processing thread in certain cases. Counter was not
handled correctly when message was dropped. In certain cases that
can lead to hanging of log processing.

Added counter decrementation in the callback called whenever
message is dropped.

Ref. NCSIDB-630.

Cherry-picked from cbd05448fd2599e96bcafd6b4e52d7daffaca490.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>