### PR TITLE
[nrf noup] dts: silence warning for cryptocell_sw

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -56,13 +56,13 @@
 			 */
 			#include "nrf5340_cpuapp_peripherals.dtsi"
 		};
+	};
 
-		/* For cryptocell access via platform library; see above */
-		cryptocell_sw: cryptocell-sw {
-			compatible = "nordic,nrf-cc312-sw";
-			#address-cells = <0>;
-			label = "CRYPTOCELL_SW";
-		};
+	/* For cryptocell access via platform library; see above */
+	cryptocell_sw: cryptocell-sw {
+		compatible = "nordic,nrf-cc312-sw";
+		#address-cells = <0>;
+		label = "CRYPTOCELL_SW";
 	};
 };
 

--- a/dts/arm/nordic/nrf9160ns.dtsi
+++ b/dts/arm/nordic/nrf9160ns.dtsi
@@ -62,13 +62,13 @@
 			status = "disabled";
 			label = "GPIOTE_1";
 		};
+	};
 
-		/* For cryptocell access via platform library; see above */
-		cryptocell_sw: cryptocell-sw {
-			compatible = "nordic,nrf-cc310-sw";
-			#address-cells = <0>;
-			label = "CRYPTOCELL_SW";
-		};
+
+	/* For cryptocell access via platform library; see above */
+	cryptocell_sw: cryptocell-sw {
+		compatible = "nordic,nrf-cc310-sw";
+		label = "CRYPTOCELL_SW";
 	};
 };
 


### PR DESCRIPTION
squash! [nrf noup] dts: choose cryptocell for entropy when available

Move these nodes outside of /soc to avoid a simple_bus_reg warning
from dtc. No functional changes expected.

NCSDK-12745

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>