### PR TITLE
[nrf noup] action: clang: set the name of checkout repo to zephyr

### DIFF
--- a/.github/workflows/bsim.yaml
+++ b/.github/workflows/bsim.yaml
@@ -42,13 +42,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          path: ./zephyr
 
       - name: west setup
+        working-directory: ./zephyr
         run: |
           west init -l . || true
           west update
 
       - name: Run Bluetooth Tests with BSIM
+        working-directory: ./zephyr
         run: |
           #source zephyr-env.sh
           export ZEPHYR_BASE=${PWD}
@@ -61,7 +64,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Bluetooth Test Results
-          path: ./bsim_bt_out/bsim_results.xml
+          path: ./zephyr/bsim_bt_out/bsim_results.xml
 
   publish-test-results:
     name: "Publish Unit Tests Results"

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -38,13 +38,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          path: ./zephyr
 
       - name: west setup
+        working-directory: ./zephyr
         run: |
           west init -l . || true
           west update
 
       - name: Check Environment
+        working-directory: ./zephyr
         run: |
           cmake --version
           ${CLANG_ROOT_DIR}/bin/clang --version
@@ -52,6 +55,7 @@ jobs:
           ls -la
 
       - name: Run Tests with Twister
+        working-directory: ./zephyr
         run: |
           #source zephyr-env.sh
           export ZEPHYR_BASE=${PWD}
@@ -63,7 +67,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Unit Test Results (Subset ${{ matrix.subset }})
-          path: twister-out/twister.xml
+          path: zephyr/twister-out/twister.xml
 
   publish-test-results:
     name: "Publish Unit Tests Results"


### PR DESCRIPTION
Fixes isses with downstream forks, where repos names are not zephyr

Will have to be reworked after the upmerge

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>