### PR TITLE
SMP Packet re-assembly at BT transport level 

### DIFF
--- a/include/mgmt/mcumgr/smp.h
+++ b/include/mgmt/mcumgr/smp.h
@@ -85,6 +85,14 @@ struct zephyr_smp_transport {
 	zephyr_smp_transport_get_mtu_fn *zst_get_mtu;
 	zephyr_smp_transport_ud_copy_fn *zst_ud_copy;
 	zephyr_smp_transport_ud_free_fn *zst_ud_free;
+
+#ifdef CONFIG_MCUMGR_SMP_REASSEMBLY
+	/* Packet reassembly internal data, API access only */
+	struct {
+		struct net_buf *current;	/* net_buf used for reassembly */
+		uint16_t expected;		/* expected bytes to come */
+	} __reassembly;
+#endif
 };
 
 /**

--- a/subsys/mgmt/mcumgr/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/CMakeLists.txt
@@ -7,6 +7,7 @@ zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_BT smp_bt.c)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_SHELL smp_shell.c)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_UART smp_uart.c)
 zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_UDP smp_udp.c)
+zephyr_library_sources_ifdef(CONFIG_MCUMGR_SMP_REASSEMBLY smp_reassembly.c)
 add_subdirectory_ifdef(CONFIG_MCUMGR_GRP_ZEPHYR_BASIC zephyr_grp)
 
 add_subdirectory(lib)

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -505,6 +505,11 @@ config MCUMGR_SMP_UDP_MTU
 
 endif # MCUMGR_SMP_UDP
 
+config MCUMGR_SMP_REASSEMBLY
+	bool
+	help
+	  Enable structures and functions needed for packet reassembly by SMP backend.
+
 config MCUMGR_BUF_COUNT
 	int "Number of mcumgr buffers"
 	default 2 if MCUMGR_SMP_UDP

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -535,4 +535,9 @@ config MCUMGR_BUF_USER_DATA_SIZE
 	  Different mcumgr transports impose different requirements for this
 	  setting. A value of 4 is sufficient for UART, shell, and bluetooth.
 	  For UDP, the userdata must be large enough to hold a IPv4/IPv6 address.
+
+module = MCUMGR_SMP
+module-str = mcumgr_smp
+source "subsys/logging/Kconfig.template.log_config"
+
 endif # MCUMGR

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -297,6 +297,13 @@ endif
 
 endmenu
 
+config MCUMGR_SMP_REASSEMBLY_BT
+	bool "Enable packet reassembly in Bluetooth SMP transport"
+	select MCUMGR_SMP_REASSEMBLY
+	help
+	  When enabled, the SMP BT transport will buffer and reassemble received
+	  packet fragments before passing it for further processing.
+
 config MCUMGR_SMP_BT
 	bool "Bluetooth mcumgr SMP transport"
 	select BT

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -12,6 +12,9 @@
 #include "smp/smp.h"
 #include "mgmt/mcumgr/smp.h"
 
+#include <logging/log.h>
+LOG_MODULE_REGISTER(mcumgr_smp, CONFIG_MCUMGR_SMP_LOG_LEVEL);
+
 static const struct mgmt_streamer_cfg zephyr_smp_cbor_cfg;
 
 static void *

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -11,6 +11,7 @@
 #include "mgmt/mcumgr/buf.h"
 #include "smp/smp.h"
 #include "mgmt/mcumgr/smp.h"
+#include "smp_reassembly.h"
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(mcumgr_smp, CONFIG_MCUMGR_SMP_LOG_LEVEL);
@@ -292,6 +293,10 @@ zephyr_smp_transport_init(struct zephyr_smp_transport *zst,
 		.zst_ud_copy = ud_copy_func,
 		.zst_ud_free = ud_free_func,
 	};
+
+#ifdef CONFIG_MCUMGR_SMP_REASSEMBLY
+	zephyr_smp_reassembly_init(zst);
+#endif
 
 	k_work_init(&zst->zst_work, zephyr_smp_handle_reqs);
 	k_fifo_init(&zst->zst_fifo);

--- a/subsys/mgmt/mcumgr/smp_bt.c
+++ b/subsys/mgmt/mcumgr/smp_bt.c
@@ -21,6 +21,9 @@
 
 #include <mgmt/mcumgr/smp.h>
 
+#include <logging/log.h>
+LOG_MODULE_DECLARE(mcumgr_smp, CONFIG_MCUMGR_SMP_LOG_LEVEL);
+
 #define RESTORE_TIME	COND_CODE_1(CONFIG_MCUMGR_SMP_BT_CONN_PARAM_CONTROL, \
 				(CONFIG_MCUMGR_SMP_BT_CONN_PARAM_CONTROL_RESTORE_TIME), \
 				(0))

--- a/subsys/mgmt/mcumgr/smp_bt.c
+++ b/subsys/mgmt/mcumgr/smp_bt.c
@@ -20,6 +20,7 @@
 #include <mgmt/mcumgr/buf.h>
 
 #include <mgmt/mcumgr/smp.h>
+#include "smp_reassembly.h"
 
 #include <logging/log.h>
 LOG_MODULE_DECLARE(mcumgr_smp, CONFIG_MCUMGR_SMP_LOG_LEVEL);
@@ -168,6 +169,63 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 				const void *buf, uint16_t len, uint16_t offset,
 				uint8_t flags)
 {
+#ifdef CONFIG_MCUMGR_SMP_REASSEMBLY_BT
+	int ret;
+	bool started;
+
+	started = (zephyr_smp_reassembly_expected(&smp_bt_transport) >= 0);
+
+	LOG_DBG("started = %s, buf len = %d", started ? "true" : "false", len);
+	LOG_HEXDUMP_DBG(buf, len, "buf = ");
+
+	ret = zephyr_smp_reassembly_collect(&smp_bt_transport, buf, len);
+	LOG_DBG("collect = %d", ret);
+
+	/*
+	 * Collection can fail only due to failing to allocate memory or by receiving
+	 * more data than expected.
+	 */
+	if (ret == -ENOMEM) {
+		/* Failed to collect the buffer */
+		return BT_GATT_ERR(BT_ATT_ERR_INSUFFICIENT_RESOURCES);
+	} else if (ret < 0) {
+		/* Failed operation on already allocated buffer, drop the packet and report
+		 * error.
+		 */
+		struct smp_bt_user_data *ud =
+			(struct smp_bt_user_data *)zephyr_smp_reassembly_get_ud(&smp_bt_transport);
+
+		if (ud != NULL) {
+			bt_conn_unref(ud->conn);
+			ud->conn = NULL;
+		}
+
+		zephyr_smp_reassembly_drop(&smp_bt_transport);
+		return BT_GATT_ERR(BT_ATT_ERR_VALUE_NOT_ALLOWED);
+	}
+
+	if (!started) {
+		/*
+		 * Transport context is attached to the buffer after first fragment
+		 * has been collected.
+		 */
+		struct smp_bt_user_data *ud = zephyr_smp_reassembly_get_ud(&smp_bt_transport);
+
+		if (IS_ENABLED(CONFIG_MCUMGR_SMP_BT_CONN_PARAM_CONTROL)) {
+			conn_param_smp_enable(conn);
+		}
+
+		ud->conn = bt_conn_ref(conn);
+	}
+
+	/* No more bytes are expected for this packet */
+	if (ret == 0) {
+		zephyr_smp_reassembly_complete(&smp_bt_transport, false);
+	}
+
+	/* BT expects entire len to be consumed */
+	return len;
+#else
 	struct smp_bt_user_data *ud;
 	struct net_buf *nb;
 
@@ -187,10 +245,21 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 	zephyr_smp_rx_req(&smp_bt_transport, nb);
 
 	return len;
+#endif
 }
 
 static void smp_bt_ccc_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {
+#ifdef CONFIG_MCUMGR_SMP_REASSEMBLY_BT
+	if (zephyr_smp_reassembly_expected(&smp_bt_transport) >= 0 && value == 0) {
+		struct smp_bt_user_data *ud = zephyr_smp_reassembly_get_ud(&smp_bt_transport);
+
+		bt_conn_unref(ud->conn);
+		ud->conn = NULL;
+
+		zephyr_smp_reassembly_drop(&smp_bt_transport);
+	}
+#endif
 }
 
 static struct bt_gatt_attr smp_bt_attrs[] = {

--- a/subsys/mgmt/mcumgr/smp_reassembly.c
+++ b/subsys/mgmt/mcumgr/smp_reassembly.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr.h>
+#include <sys/byteorder.h>
+#include <net/buf.h>
+#include <mgmt/mcumgr/buf.h>
+#include <mgmt/mcumgr/smp.h>
+#include <mgmt/mgmt.h>
+#include <smp/smp.h>
+
+void zephyr_smp_reassembly_init(struct zephyr_smp_transport *zst)
+{
+	zst->__reassembly.current = NULL;
+	zst->__reassembly.expected = 0;
+}
+
+int zephyr_smp_reassembly_expected(const struct zephyr_smp_transport *zst)
+{
+	if (zst->__reassembly.current == NULL) {
+		return -EINVAL;
+	}
+
+	return zst->__reassembly.expected;
+}
+
+int zephyr_smp_reassembly_collect(struct zephyr_smp_transport *zst, const void *buf, uint16_t len)
+{
+	if (zst->__reassembly.current == NULL) {
+		/*
+		 * Collecting the first fragment: need to allocate buffer for it and prepare
+		 * the reassembly context.
+		 */
+		if (len >= sizeof(struct mgmt_hdr)) {
+			uint16_t expected = sys_be16_to_cpu(((struct mgmt_hdr *)buf)->nh_len);
+
+			/*
+			 * The length field in the header does not count the header size,
+			 * but the reassembly does so the size needs to be added to the number of
+			 * expected bytes.
+			 */
+			expected += sizeof(struct mgmt_hdr);
+
+			/* Joining net_bufs not supported yet */
+			if (len > CONFIG_MCUMGR_BUF_SIZE || expected > CONFIG_MCUMGR_BUF_SIZE) {
+				return -ENOSR;
+			}
+
+			if (len > expected) {
+				return -EOVERFLOW;
+			}
+
+			zst->__reassembly.current = mcumgr_buf_alloc();
+			if (zst->__reassembly.current != NULL) {
+				zst->__reassembly.expected = expected;
+			} else {
+				return -ENOMEM;
+			}
+		} else {
+			/* Not enough data to even collect header */
+			return -ENODATA;
+		}
+	}
+
+	/* len is expected to be > 0 */
+	if (zst->__reassembly.expected >= len) {
+		net_buf_add_mem(zst->__reassembly.current, buf, len);
+		zst->__reassembly.expected -= len;
+	} else {
+		/*
+		 * A fragment is longer than the expected size and will not fit into the buffer.
+		 */
+		return -EOVERFLOW;
+	}
+
+	return zst->__reassembly.expected;
+}
+
+int zephyr_smp_reassembly_complete(struct zephyr_smp_transport *zst, bool force)
+{
+	if (zst->__reassembly.current == NULL) {
+		return -EINVAL;
+	}
+
+	if (zst->__reassembly.expected == 0 || force) {
+		int expected = zst->__reassembly.expected;
+
+		zephyr_smp_rx_req(zst, zst->__reassembly.current);
+		zst->__reassembly.expected = 0;
+		zst->__reassembly.current = NULL;
+		return expected;
+	}
+	return -ENODATA;
+}
+
+int zephyr_smp_reassembly_drop(struct zephyr_smp_transport *zst)
+{
+	if (zst->__reassembly.current == NULL) {
+		return -EINVAL;
+	}
+
+	mcumgr_buf_free(zst->__reassembly.current);
+	zst->__reassembly.expected = 0;
+	zst->__reassembly.current = NULL;
+
+	return 0;
+}
+
+void *zephyr_smp_reassembly_get_ud(const struct zephyr_smp_transport *zst)
+{
+	if (zst->__reassembly.current != NULL) {
+		return net_buf_user_data(zst->__reassembly.current);
+	}
+
+	return NULL;
+}

--- a/subsys/mgmt/mcumgr/smp_reassembly.h
+++ b/subsys/mgmt/mcumgr/smp_reassembly.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_MGMT_SMP_REASSEMBLY_H_
+#define ZEPHYR_INCLUDE_MGMT_SMP_REASSEMBLY_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct zephyr_smp_transport;
+
+/**
+ * Initialize re-assembly context within zephyr_smp_transport
+ *
+ * @param zst	the SMP transport.
+ *
+ * Note: for efficiency there is no NULL check on @p zst pointer and it is caller's responsibility
+ * to validate the pointer before passing it to this function.
+ */
+void zephyr_smp_reassembly_init(struct zephyr_smp_transport *zst);
+
+/**
+ * Collect data to re-assembly buffer
+ *
+ * The function adds data to the end of current re-assembly buffer; it will allocate new buffer
+ * if there isn't one allocated.
+ *
+ * Note: Currently the function is not able to concatenate buffers so re-assembled packet needs
+ * to fit into one buffer.
+ *
+ * @param zst	the SMP transport;
+ * @param buf	buffer with data to add;
+ * @param len	length of data to add;
+ *
+ * Note: For efficiency there are ot NULL checks on @p zst and @p buf pointers and it is caller's
+ * responsibility to make sure these are not NULL.  Also @p len should not be 0 as there is no
+ * point in passing an empty fragment for re-assembly.
+ *
+ * @return	number of expected bytes left to complete the packet, 0 means buffer is complete
+ *		and no more fragments are expected;
+ *		-ENOSR if a packet length, read from header, is bigger than CONFIG_MCUMGR_BUF_SIZE,
+ *		which means there is no way to fit it in the configured buffer;
+ *		-EOVERFLOW if attempting to add a fragment that would make complete packet larger
+ *		than expected;
+ *		-ENOMEM if failed to allocate a new buffer for packet assembly;
+ *		-ENODATA if the first received fragment was not big enough to figure out a size
+ *		of the packet; MTU is set too low;
+ */
+int zephyr_smp_reassembly_collect(struct zephyr_smp_transport *zst, const void *buf, uint16_t len);
+
+/**
+ * Return number of expected bytes to complete the packet
+ *
+ * @param zst	the SMP transport;
+ *
+ * Note: for efficiency there is no NULL check on @p zst pointer and it is caller's responsibility
+ * to validate the pointer before passing it to this function.
+ *
+ * @return	number of bytes needed to complete the packet;
+ *		-EINVAL if there is no packet in re-assembly;
+ */
+int zephyr_smp_reassembly_expected(const struct zephyr_smp_transport *zst);
+
+/**
+ * Pass packet for further processing
+ *
+ * Checks if the packet has enough data to be re-assembled and passes it for further processing.
+ * If successful then the re-assembly context in @p zst will indicate that there is no
+ * re-assembly in progress.
+ * The function can be forced to pass a data for processing even if the packet is not complete,
+ * in which case it is users responsibility to use the user data, passed with the packet, to notify
+ * receiving end of such case.
+ *
+ * @param zst	the SMP transport;
+ * @param force	process anyway;
+ *
+ * Note: for efficiency there is no NULL check on @p zst pointer and it is caller's responsibility
+ * to validate the pointer before passing it to this function.
+ *
+ * @return	0 on success and not forced;
+ *		expected number of bytes if forced to complete buffer with not enough data;
+ *		-EINVAL if there is no re-assembly in progress;
+ *		-ENODATA if there is not enough data to consider packet re-assembled, it has not
+ *		been passed further.
+ */
+int zephyr_smp_reassembly_complete(struct zephyr_smp_transport *zst, bool force);
+
+/**
+ * Drop packet and release buffer
+ *
+ * @param zst	the SMP transport;
+ *
+ * Note: for efficiency there is no NULL check on @p zst pointer and it is caller's responsibility
+ * to validate the pointer before passing it to this function.
+ *
+ * @return	0 on success;
+ *		-EINVAL if there is no re-assembly in progress.
+ */
+int zephyr_smp_reassembly_drop(struct zephyr_smp_transport *zst);
+
+/**
+ * Get "user data" pointer for current packet re-assembly
+ *
+ * @param zst	the SMP transport;
+ *
+ * Note: for efficiency there is no NULL check on @p zst pointer and it is caller's responsibility
+ * to validate the pointer before passing it to this function.
+ *
+ * @return	pointer to "user data" of CONFIG_MCUMGR_BUF_USER_DATA_SIZE size;
+ *		NULL if no re-assembly in progress.
+ */
+void *zephyr_smp_reassembly_get_ud(const struct zephyr_smp_transport *zst);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ZEPHYR_INCLUDE_MGMT_SMP_REASSEMBLY_H_ */


### PR DESCRIPTION
The intention of this PR is to add packet re-assembly to SMP.
The PR consists of two commits:

  -  adding generic SMP packet re-assembly;
  -  adding modification of BT transport that allows to use re-assembly, if requested via Kconfig option.

Same as upstream https://github.com/zephyrproject-rtos/zephyr/pull/41306 except for unit-tests, which have not been included here.