### PR TITLE
[nrf noup] cmake: linker: rework s1 linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1335,10 +1335,6 @@ set(logical_target_for_zephyr_elf ${logical_target_for_zephyr_elf} PARENT_SCOPE)
 # 2. it can be defined in Kconfig
 set_target_properties(${logical_target_for_zephyr_elf} PROPERTIES OUTPUT_NAME ${KERNEL_NAME})
 
-if (ZEPHYR_NRF_MODULE_DIR)
-  include(${ZEPHYR_NRF_MODULE_DIR}/cmake/s1.cmake)
-endif()
-
 set(post_build_commands "")
 set(post_build_byproducts "")
 

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -32,15 +32,13 @@
 
 #include <pm_config.h>
 
-#ifdef LINK_INTO_s1
+#if CONFIG_NCS_IS_VARIANT_IMAGE
 /* We are linking against S1, create symbol containing the flash ID of S0.
  * This is used when writing code operating on the "other" slot.
  */
 _image_1_primary_slot_id = PM_S0_ID;
 
-#define ROM_ADDR PM_ADDRESS + PM_S1_ADDRESS - PM_S0_ADDRESS
-
-#else /* ! LINK_INTO_s1 */
+#else /* ! CONFIG_NCS_IS_VARIANT_IMAGE */
 
 #ifdef PM_S1_ID
 /* We are linking against S0, create symbol containing the flash ID of S1.
@@ -49,8 +47,9 @@ _image_1_primary_slot_id = PM_S0_ID;
 _image_1_primary_slot_id = PM_S1_ID;
 #endif /* PM_S1_ID */
 
+#endif /* CONFIG_NCS_IS_VARIANT_IMAGE */
+
 #define ROM_ADDR PM_ADDRESS
-#endif /* LINK_MCUBOOT_INTO_s1 */
 #define ROM_SIZE PM_SIZE
 
 #define RAM_SIZE PM_SRAM_SIZE

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2034,9 +2034,9 @@ class CMake():
         cmake_args = [
             f'-B{self.build_dir}',
             f'-S{self.source_dir}',
-            f'-DEXTRA_CFLAGS="{cflags}"',
-            f'-DEXTRA_AFLAGS="{aflags}',
-            f'-DEXTRA_LDFLAGS="{ldflags}"',
+            f'-DEXTRA_CFLAGS={cflags}',
+            f'-DEXTRA_AFLAGS={aflags}',
+            f'-DEXTRA_LDFLAGS={ldflags}',
             f'-DEXTRA_GEN_DEFINES_ARGS={gen_defines_args}',
             f'-G{self.generator}'
         ]


### PR DESCRIPTION
With the latest updates in downstream we don't need to call
s1.cmake. Also the symbol to check in the linker to see if
we are being linked against S1 has changed.

Ref: NCSDK-13188
Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>