### PR TITLE
linker: update posix linker template, linker.ld

### DIFF
--- a/include/arch/posix/linker.ld
+++ b/include/arch/posix/linker.ld
@@ -22,22 +22,31 @@
 SECTIONS
  {
 
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function.
- */
-#include <snippets-rom-start.ld>
+SECTION_PROLOGUE(rom_start,,)
+{
+	/* Located in generated directory. This file is populated by the
+	 * zephyr_linker_sources() Cmake function.
+	 */
+	#include <snippets-rom-start.ld>
+} GROUP_LINK_IN(ROMABLE_REGION)
 
 #include <linker/common-rom.ld>
 
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function.
- */
-#include <snippets-rodata.ld>
+SECTION_PROLOGUE(_RODATA_SECTION_NAME,,)
+{
+	/* Located in generated directory. This file is populated by the
+	 * zephyr_linker_sources() Cmake function.
+	 */
+	#include <snippets-rodata.ld>
+} GROUP_LINK_IN(ROMABLE_REGION)
 
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function.
- */
-#include <snippets-rwdata.ld>
+SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
+{
+	/* Located in generated directory. This file is populated by the
+	 * zephyr_linker_sources() Cmake function.
+	 */
+	#include <snippets-rwdata.ld>
+} GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
 #include <linker/common-ram.ld>
 
@@ -55,10 +64,13 @@ SECTIONS
 
 __data_region_end = .;
 
-/* Located in generated directory. This file is populated by the
- * zephyr_linker_sources() Cmake function.
- */
-#include <snippets-noinit.ld>
+SECTION_DATA_PROLOGUE(_NOINIT_SECTION_NAME,,)
+{
+	/* Located in generated directory. This file is populated by the
+	 * zephyr_linker_sources() Cmake function.
+	 */
+	#include <snippets-noinit.ld>
+} GROUP_LINK_IN(RAMABLE_REGION)
 
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.


### PR DESCRIPTION
The function `zephyr_linker_sources()` states:
> When placing into NOINIT, RWDATA, RODATA, ROM_START, the contents of
> the files will be placed inside an output section, so assume the
> section definition is already present.

However, in the posix linker.ld template the NOINIT, RWDATA, RODATA, and
ROM_START was not placed inside a pre-defined output section, which
means that linker scripts created for native_posix when
`zephyr_linker_sources()` is used are invalid

This result in the following failure:
> /usr/bin/ld:zephyr/linker_zephyr_prebuilt.cmd:81: syntax error
> collect2: error: ld returned 1 exit status

This PR fixes this issue be predefining output sections according to
the documented behavior.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>