### PR TITLE
[nrf fromtree] test/subsys/storage/steram_flash: fix build size issue

### DIFF
--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -22,7 +22,7 @@
 #define FLASH_NAME DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
 
 /* so that we don't overwrite the application when running on hw */
-#define FLASH_BASE (64*1024)
+#define FLASH_BASE (128*1024)
 #define FLASH_AVAILABLE (FLASH_SIZE-FLASH_BASE)
 
 static const struct device *fdev;


### PR DESCRIPTION
This test uses SoC's flash from offset of 64 KB which might
overlap with executable for a target
(for instance nrf52840dk_nrf52840).
This patch moves this region to 128 KB which solves the issue.

mirror of https://github.com/zephyrproject-rtos/zephyr/pull/42192

fixes NCSDK-13488

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>