### PR TITLE
[nfr fromtree] doc: use extlink for github issue links

### DIFF
--- a/boards/arm/nucleo_f767zi/doc/index.rst
+++ b/boards/arm/nucleo_f767zi/doc/index.rst
@@ -127,7 +127,7 @@ features:
 
 
 (*) nucleo_f767zi with soc cut-A (Device marking A) has some ethernet
-    instability (https://github.com/zephyrproject-rtos/zephyr/issues/26519).
+    instability (:github:`26519`).
     Use of cut-Z is advised.
     see restrictions errata:
     https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/23/a6/11/0b/30/24/46/a5/DM00257543/files/DM00257543.pdf/jcr:content/translations/en.DM00257543.pdf

--- a/doc/contribute/coding_guidelines/index.rst
+++ b/doc/contribute/coding_guidelines/index.rst
@@ -926,7 +926,7 @@ Related GitHub Issues and Pull Requests are tagged with the `Inclusive Language 
        terminology is confirmed by a public announcement or updated
        specification.
 
-       See `Zephyr issue 27033`_.
+       See :github:`Zephyr issue 27033 <27033>`.
 
    * - :ref:`i2s_api`
      - * ``master / slave`` => TBD
@@ -951,7 +951,6 @@ Related GitHub Issues and Pull Requests are tagged with the `Inclusive Language 
 .. _I2C Specification: https://www.nxp.com/docs/en/user-guide/UM10204.pdf
 .. _Bluetooth Appropriate Language Mapping Tables: https://btprodspecificationrefs.blob.core.windows.net/language-mapping/Appropriate_Language_Mapping_Table.pdf
 .. _OSHWA Resolution to Redefine SPI Signal Names: https://www.oshwa.org/a-resolution-to-redefine-spi-signal-names/
-.. _Zephyr issue 27033: https://github.com/zephyrproject-rtos/zephyr/issues/27033
 
 Parasoft Codescan Tool
 **********************

--- a/doc/contribute/external.rst
+++ b/doc/contribute/external.rst
@@ -124,7 +124,8 @@ Follow the steps below to begin the submission process:
 #. Make sure to read through the :ref:`external-contributions` section in
    detail, so that you are informed of the criteria used by the TSC and board in
    order to approve or reject a request
-#. Use the `New External Source Code Issue`_ to open an issue
+#. Use the :github:`New External Source Code Issue
+   <new?assignees=&labels=RFC&template=ext-source.md&title=>` to open an issue
 #. Fill out all required sections, making sure you provide enough detail for the
    TSC to assess the merit of the request. Optionally you can also create a Pull
    Request that demonstrates the integration of the external source code and
@@ -163,6 +164,3 @@ The flowchart below shows an overview of the process:
    :align: center
 
    Submission process
-
-.. _New External Source Code Issue:
-   https://github.com/zephyrproject-rtos/zephyr/issues/new?assignees=&labels=RFC&template=ext-source.md&title=

--- a/doc/development_process/project_roles.rst
+++ b/doc/development_process/project_roles.rst
@@ -60,8 +60,8 @@ Contributors who show dedication and skill are granted the Triage permission
 level to the Zephyr GitHub repository.
 
 You may nominate yourself, or another GitHub user, for promotion to the Triage
-permission level by creating a GitHub issue, using the `nomination template
-<https://github.com/zephyrproject-rtos/zephyr/issues/new?assignees=&labels=bug&template=nomination.md&title=>`_.
+permission level by creating a GitHub issue, using the :github:`nomination
+template <new?assignees=&labels=bug&template=nomination.md&title=>`.
 
 Contributors granted the Triage permission level are permitted to add reviewers
 to a pull request and can be added as a reviewer by other GitHub users.

--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -16,7 +16,7 @@ command-prompt. This allows you to use software such as the :ref:`Zephyr SDK
 .. warning::
       Windows 10 version 1803 has an issue that will cause CMake to not work
       properly and is fixed in version 1809 (and later).
-      More information can be found in `Zephyr Issue 10420`_
+      More information can be found in :github:`Zephyr Issue 10420 <10420>`.
 
 #. `Install the Windows Subsystem for Linux (WSL)`_.
 
@@ -33,4 +33,3 @@ command-prompt. This allows you to use software such as the :ref:`Zephyr SDK
    the documentation itself here.
 
 .. _Install the Windows Subsystem for Linux (WSL): https://msdn.microsoft.com/en-us/commandline/wsl/install_guide
-.. _Zephyr Issue 10420: :github:`10420`

--- a/doc/getting_started/installation_win.rst
+++ b/doc/getting_started/installation_win.rst
@@ -33,4 +33,4 @@ command-prompt. This allows you to use software such as the :ref:`Zephyr SDK
    the documentation itself here.
 
 .. _Install the Windows Subsystem for Linux (WSL): https://msdn.microsoft.com/en-us/commandline/wsl/install_guide
-.. _Zephyr Issue 10420: https://github.com/zephyrproject-rtos/zephyr/issues/10420
+.. _Zephyr Issue 10420: :github:`10420`

--- a/doc/guides/west/why.rst
+++ b/doc/guides/west/why.rst
@@ -117,7 +117,4 @@ West is:
   interoperability with third party tools, and means Zephyr developers
   can always find out what is happening "under the hood" when using west.
 
-See `Zephyr issue #6205`_ and for more details and discussion.
-
-.. _Zephyr issue #6205:
-   :github:`6205`
+See :github:`Zephyr issue #6205 <6205>` and for more details and discussion.

--- a/doc/guides/west/why.rst
+++ b/doc/guides/west/why.rst
@@ -120,4 +120,4 @@ West is:
 See `Zephyr issue #6205`_ and for more details and discussion.
 
 .. _Zephyr issue #6205:
-   https://github.com/zephyrproject-rtos/zephyr/issues/6205
+   :github:`6205`

--- a/samples/bluetooth/ipsp/README.rst
+++ b/samples/bluetooth/ipsp/README.rst
@@ -38,8 +38,8 @@ Building and Running for Linux kernels released before 4.12
 
    For hosts using kernels released before 4.12,
    option :kconfig:`CONFIG_NET_L2_BT_ZEP1656`
-   must be selected. For more information, see `Zephyr issue #3111
-   <https://github.com/zephyrproject-rtos/zephyr/issues/3111>`_
+   must be selected. For more information, see :github:`Zephyr issue #3111
+   <3111>`.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/bluetooth/ipsp


### PR DESCRIPTION
Use extlink for GitHub issue links in documentation.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>
(cherry picked from commit 2c0e0a74af0c16a3ec3080645fa09e4f340283d6)