### PR TITLE
[nrf noup] actions: fix clang/bluetooth/twister_test

### DIFF
--- a/.github/workflows/bluetooth.yaml
+++ b/.github/workflows/bluetooth.yaml
@@ -42,14 +42,17 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          path: ./zephyr
 
       - name: west setup
+        working-directory: ./zephyr
         run: |
           west init -l . || true
           west config --global update.narrow true
           west update 2>&1 1> west.update.log || west update 2>&1 1> west.update2.log
 
       - name: Run Bluetooth Tests with BSIM
+        working-directory: ./zephyr
         run: |
           export ZEPHYR_BASE=${PWD}
           WORK_DIR=${ZEPHYR_BASE}/bsim_bt_out tests/bluetooth/bsim_bt/compile.sh
@@ -61,7 +64,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Bluetooth Test Results
-          path: ./bsim_bt_out/bsim_results.xml
+          path: ./zephyr/bsim_bt_out/bsim_results.xml
 
   bluetooth-test-results:
     name: "Publish Bluetooth Test Results"

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -11,7 +11,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
   clang-build:
-    runs-on: zephyr_runner
+    runs-on: ubuntu-latest
     needs: clang-build-prep
     container:
       image: zephyrprojectrtos/ci:v0.21.0
@@ -39,8 +39,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          path: ./zephyr
 
       - name: Environment Setup
+        working-directory: ./zephyr
         run: |
           pip3 install GitPython
           echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -59,6 +61,7 @@ jobs:
           west update --path-cache /github/cache/zephyrproject 2>&1 1> west.log || west update --path-cache /github/cache/zephyrproject 2>&1 1> west2.log || ( rm -rf ../modules ../bootloader ../tools && west update --path-cache /github/cache/zephyrproject)
 
       - name: Check Environment
+        working-directory: ./zephyr
         run: |
           cmake --version
           ${CLANG_ROOT_DIR}/bin/clang --version
@@ -66,6 +69,7 @@ jobs:
           ls -la
 
       - name: Prepare ccache timestamp/data
+        working-directory: ./zephyr
         id: ccache_cache_timestamp
         shell: cmake -P {0}
         run: |
@@ -85,11 +89,13 @@ jobs:
           aws-region: us-east-2
 
       - name: ccache stats initial
+        working-directory: ./zephyr
         run: |
           test -d github/home/.ccache && rm -rf /github/home/.ccache && mv github/home/.ccache /github/home/.ccache
           ccache -M 10G -s
 
       - name: Run Tests with Twister
+        working-directory: ./zephyr
         id: twister
         run: |
           export ZEPHYR_BASE=${PWD}
@@ -109,6 +115,7 @@ jobs:
           fi
 
       - name: ccache stats post
+        working-directory: ./zephyr
         run: |
           ccache -s
 
@@ -117,7 +124,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Unit Test Results (Subset ${{ matrix.platform }})
-          path: twister-out/twister.xml
+          path: zephyr/twister-out/twister.xml
 
   clang-build-results:
     name: "Publish Unit Tests Results"

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: checkout
       uses: actions/checkout@v2
+      with:
+        path: ./zephyr
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -44,6 +46,7 @@ jobs:
       run: |
         pip3 install pytest colorama pyyaml ply mock
     - name: Run pytest
+      working-directory: ./zephyr
       env:
         ZEPHYR_BASE: ./
         ZEPHYR_TOOLCHAIN_VARIANT: zephyr


### PR DESCRIPTION
squash! [nrf noup] action: compliance/doc: set checkout folder name to zephyr

Fix paths and runners in clang bluetooth and twister_test
actions

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>