### PR TITLE
[nrf_noup]: Disable loading of Kconfig.tls-generic

### DIFF
--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -9,6 +9,8 @@ menu "TLS configuration"
 
 menu "Supported TLS version"
 
+if !(NRF_SECURITY || NORDIC_SECURITY_BACKEND)
+
 config MBEDTLS_TLS_VERSION_1_0
 	bool "Enable support for TLS 1.0"
 	select MBEDTLS_CIPHER
@@ -33,6 +35,8 @@ config MBEDTLS_DTLS
 	bool "Enable support for DTLS"
 	depends on MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
 
+endif
+
 config MBEDTLS_SSL_EXPORT_KEYS
 	bool "Enable support for exporting SSL key block and master secret"
 	depends on MBEDTLS_TLS_VERSION_1_0 || MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
@@ -46,6 +50,8 @@ endmenu
 menu "Ciphersuite configuration"
 
 comment "Supported key exchange modes"
+
+if !(NRF_SECURITY || NORDIC_SECURITY_BACKEND)
 
 config MBEDTLS_KEY_EXCHANGE_ALL_ENABLED
 	bool "Enable all available ciphersuite modes"
@@ -80,12 +86,16 @@ config MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED
 		MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED || \
 		MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
 
+endif
+
 config MBEDTLS_PSK_MAX_LEN
 	int "Max size of TLS pre-shared keys"
 	default 32
 	depends on MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED
 	help
 	  Max size of TLS pre-shared keys, in bytes.
+
+if !(NRF_SECURITY || NORDIC_SECURITY_BACKEND)
 
 config MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
 	bool "Enable the RSA-only based ciphersuite modes"
@@ -119,7 +129,11 @@ if MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED || \
 	MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED || \
 	MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 
+endif
+
 comment "Supported elliptic curves"
+
+if !(NRF_SECURITY || NORDIC_SECURITY_BACKEND)
 
 config MBEDTLS_ECP_ALL_ENABLED
 	bool "Enable all available elliptic curves"
@@ -182,8 +196,11 @@ config MBEDTLS_ECP_NIST_OPTIM
 	bool "Enable NSIT curves optimization"
 
 endif
+endif
 
 comment "Supported cipher modes"
+
+if !(NRF_SECURITY || NORDIC_SECURITY_BACKEND)
 
 config MBEDTLS_CIPHER_ALL_ENABLED
 	bool "Enable all available ciphers"
@@ -248,7 +265,11 @@ config MBEDTLS_CHACHAPOLY_AEAD_ENABLED
 	bool "Enable the ChaCha20-Poly1305 AEAD algorithm"
 	depends on MBEDTLS_CIPHER_CHACHA20_ENABLED || MBEDTLS_MAC_POLY1305_ENABLED
 
+endif
+
 comment "Supported message authentication methods"
+
+if !(NRF_SECURITY || NORDIC_SECURITY_BACKEND)
 
 config MBEDTLS_MAC_ALL_ENABLED
 	bool "Enable all available MAC methods"
@@ -293,9 +314,13 @@ config MBEDTLS_MAC_CMAC_ENABLED
 	bool "Enable the CMAC (Cipher-based Message Authentication Code) mode for block ciphers."
 	depends on MBEDTLS_CIPHER_AES_ENABLED || MBEDTLS_CIPHER_DES_ENABLED
 
+endif
+
 endmenu
 
 comment "Random number generators"
+
+if !(NRF_SECURITY || NORDIC_SECURITY_BACKEND)
 
 config MBEDTLS_CTR_DRBG_ENABLED
 	bool "Enable the CTR_DRBG AES-256-based random generator"
@@ -306,13 +331,19 @@ config MBEDTLS_HMAC_DRBG_ENABLED
 	bool "Enable the HMAC_DRBG random generator"
 	select MBEDTLS_MD
 
+endif
+
 comment "Other configurations"
 
 config MBEDTLS_CIPHER
 	bool "Enable the generic cipher layer."
 
+if !(NRF_SECURITY || NORDIC_SECURITY_BACKEND)
+
 config MBEDTLS_MD
 	bool "Enable the generic message digest layer."
+
+endif
 
 config MBEDTLS_GENPRIME_ENABLED
 	bool "Enable the prime-number generation code."
@@ -331,9 +362,13 @@ config MBEDTLS_HAVE_ASM
 	  of asymmetric cryptography, however this might have an impact on the
 	  code size.
 
+if !(NRF_SECURITY || NORDIC_SECURITY_BACKEND)
+
 config MBEDTLS_ENTROPY_ENABLED
 	bool "Enable mbedTLS generic entropy pool"
 	depends on MBEDTLS_MAC_SHA256_ENABLED || MBEDTLS_MAC_SHA512_ENABLED
+
+endif
 
 config MBEDTLS_OPENTHREAD_OPTIMIZATIONS_ENABLED
 	bool "Enable mbedTLS optimizations for OpenThread"

--- a/modules/mbedtls/configs/config-tls-generic.h
+++ b/modules/mbedtls/configs/config-tls-generic.h
@@ -438,6 +438,10 @@
 #include CONFIG_MBEDTLS_USER_CONFIG_FILE
 #endif
 
+#if defined(CONFIG_NRF_CC3XX_PLATFORM)
+#define MBEDTLS_PLATFORM_ZEROIZE_ALT
+#endif
+
 #include "mbedtls/check_config.h"
 
 #endif /* MBEDTLS_CONFIG_H */


### PR DESCRIPTION
-Has unsupported TLS configurations (TLS 1.0, 1.1)
-Collides with PSA configurations
-Converted Zephyr configuration MBEDTLS_TLS_VERSION_1_2
 to standardized configuration MBEDTLS_SSL_PROTO_TLS1_2
-Disabled Kconfig.tls-generic specific configurations in zephyr
-Disabled usage of MBEDTLS_BUILTIN

ref: NCSDK-13503

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>