### PR TITLE
[nrf fromlist] boards: arm: nrf9160dk_nrf9160: Generic nrf52 reset

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/nrf52840_reset.c
+++ b/boards/arm/nrf9160dk_nrf9160/nrf52840_reset.c
@@ -51,7 +51,7 @@ int bt_hci_transport_setup(const struct device *h4)
 	k_sleep(K_MSEC(10));
 
 	/* Drain bytes */
-	while (uart_fifo_read(h4, &c, 1)) {
+	while (h4 && uart_fifo_read(h4, &c, 1)) {
 		continue;
 	}
 


### PR DESCRIPTION
Added option to skip reading uart data during nrf52840 reset.

Original PR: https://github.com/zephyrproject-rtos/zephyr/pull/42316

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>