### PR TITLE
[nrf noup] linker: only add Sx labels if SECURE_BOOT is enabled

### DIFF
--- a/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -31,7 +31,7 @@
 
 #include <pm_config.h>
 
-#if CONFIG_NCS_IS_VARIANT_IMAGE
+#if CONFIG_NCS_IS_VARIANT_IMAGE && CONFIG_SECURE_BOOT
 /* We are linking against S1, create symbol containing the flash ID of S0.
  * This is used when writing code operating on the "other" slot.
  */


### PR DESCRIPTION
If CONFIG_SECURE_BOOT is not enabled then these symbols will
not be defined.

Ref: NCSDK-6211

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>