### PR TITLE
[nrf fromlist] modules: hal_nordic: nrf_802154_irq ZLI support

### DIFF
--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_irq_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_irq_zephyr.c
@@ -9,9 +9,16 @@
 #include <irq.h>
 #include <nrfx.h>
 
-void nrf_802154_irq_init(uint32_t irqn, uint32_t prio, nrf_802154_isr_t isr)
+void nrf_802154_irq_init(uint32_t irqn, int32_t prio, nrf_802154_isr_t isr)
 {
-	irq_connect_dynamic(irqn, prio, isr, NULL, 0);
+	uint32_t flags = 0U;
+
+	if (prio < 0) {
+		prio = 0;
+		flags |= IRQ_ZERO_LATENCY;
+	}
+
+	irq_connect_dynamic(irqn, prio, isr, NULL, flags);
 }
 
 void nrf_802154_irq_enable(uint32_t irqn)

--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: a42b016d7c7610489f5f8c79773fedc05ba352ee
+      revision: b1db86f188c3c5864985e1bd18a849d53f1c0a2d
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Parameter `prio` of `nrf_802154_irq_init` is now allowed to have
negative value what means use of ZLI priority or highest possible
priority if ZLIs are disabled.

Zephyr PR: https://github.com/zephyrproject-rtos/zephyr/pull/42355

Signed-off-by: Andrzej Kuros <andrzej.kuros@nordicsemi.no>