### PR TITLE
[nrf fromlist] drivers: ieee802154_nrf5: fix CSL for multicore devices

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -962,9 +962,12 @@ void nrf_802154_received_timestamp_raw(uint8_t *data, int8_t power, uint8_t lqi,
 
 void nrf_802154_receive_failed(nrf_802154_rx_error_t error, uint32_t id)
 {
+	const struct device *dev = net_if_get_device(nrf5_data.iface);
+
 #if defined(CONFIG_IEEE802154_CSL_ENDPOINT)
 	if ((id == DRX_SLOT_PH) || (id == DRX_SLOT_RX)) {
-		nrf5_stop(net_if_get_device(nrf5_data.iface));
+		__ASSERT_NO_MSG(nrf5_data.event_handler);
+		nrf5_data.event_handler(dev, IEEE802154_EVENT_SLEEP, NULL);
 		return;
 	}
 #else
@@ -994,9 +997,7 @@ void nrf_802154_receive_failed(nrf_802154_rx_error_t error, uint32_t id)
 
 	nrf5_data.last_frame_ack_fpb = false;
 	if (nrf5_data.event_handler) {
-		nrf5_data.event_handler(net_if_get_device(nrf5_data.iface),
-					IEEE802154_EVENT_RX_FAILED,
-					(void *)&reason);
+		nrf5_data.event_handler(dev, IEEE802154_EVENT_RX_FAILED, (void *)&reason);
 	}
 }
 


### PR DESCRIPTION
Due to serialization restrictions radio api calls cannot be nested, any
violation of this rule leads to a deadlock. This commit fixes the bug
by transferring the nested radio api call to ot_radio_workq.

Upstream PR: zephyrproject-rtos/zephyr#42484

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>