### PR TITLE
[nrf fromtree] Bugfixes related to Bluetooth ISO and ATT

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -44,7 +44,13 @@ Changes in this release
 Changes in this release
 =======================
 
-Removed APIs in this release:
+* GATT callbacks ``bt_gatt_..._func_t`` would previously be called with argument
+  ``conn = NULL`` in the event of a disconnect. This was not documented as part
+  of the API. This behavior is changed so the ``conn`` argument is provided as
+  normal when a disconnect occurs.
+
+Removed APIs in this release
+============================
 
 * The following Kconfig options related to radio front-end modules (FEMs) were
   removed:

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2622,8 +2622,6 @@ static void att_reset(struct bt_att *att)
 		net_buf_unref(buf);
 	}
 
-	att->conn = NULL;
-
 	/* Notify pending requests */
 	while (!sys_slist_is_empty(&att->reqs)) {
 		struct bt_att_req *req;
@@ -2632,13 +2630,17 @@ static void att_reset(struct bt_att *att)
 		node = sys_slist_get_not_empty(&att->reqs);
 		req = CONTAINER_OF(node, struct bt_att_req, node);
 		if (req->func) {
-			req->func(NULL, BT_ATT_ERR_UNLIKELY, NULL, 0,
+			req->func(att->conn, BT_ATT_ERR_UNLIKELY, NULL, 0,
 				  req->user_data);
 		}
 
 		bt_att_req_free(req);
 	}
 
+	/* FIXME: `att->conn` is not reference counted. Consider using `bt_conn_ref`
+	 * and `bt_conn_unref` to follow convention.
+	 */
+	att->conn = NULL;
 	k_mem_slab_free(&att_slab, (void **)&att);
 }
 

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -442,15 +442,16 @@ static void bt_iso_chan_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 #if defined(CONFIG_BT_ISO_UNICAST)
 			bool is_chan_connected;
 			struct bt_iso_cig *cig;
+			struct bt_iso_chan *cis_chan;
 
 			/* Update CIG state */
 			cig = get_cig(chan);
 			__ASSERT(cig != NULL, "CIG was NULL");
 
 			is_chan_connected = false;
-			SYS_SLIST_FOR_EACH_CONTAINER(&cig->cis_channels, chan, node) {
-				if (chan->state == BT_ISO_CONNECTED ||
-				chan->state == BT_ISO_CONNECT) {
+			SYS_SLIST_FOR_EACH_CONTAINER(&cig->cis_channels, cis_chan, node) {
+				if (cis_chan->state == BT_ISO_CONNECTED ||
+				    cis_chan->state == BT_ISO_CONNECT) {
 					is_chan_connected = true;
 					break;
 				}


### PR DESCRIPTION
Bugs:
1) BUS FAULT can happen when a central disconnects an ISO
2) bt_conn_index asserts when disconnecting while doing service
   discovery