### PR TITLE
[nrf fromtree] cmake: remove base_name for dep file

### DIFF
--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -67,7 +67,6 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     endif()
 
     zephyr_get_include_directories_for_lang(C current_includes)
-    get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
     get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
     add_custom_command(
@@ -81,7 +80,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
       COMMAND ${CMAKE_C_COMPILER}
       -x assembler-with-cpp
       ${NOSYSDEF_CFLAG}
-      -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
+      -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}
       -D_LINKER
       -D_ASMLANGUAGE
       -imacros ${AUTOCONF_H}


### PR DESCRIPTION
With CMake 3.20 relative path inside DEPFILEs are treated relative to
CMAKE_CURRENT_BINARY_DIR and are transformed by CMake in its internal
dep file.

Therefore Zephyr build system must no longer add `base_name` to the
`-MT` argument for the preprocessor.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>