### PR TITLE
[nrf fromlist] twister: short build paths - fix

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -3904,7 +3904,7 @@ class TestSuite(DisablePyTestCollectionMixin):
         significant during building by CMake on Windows OS.
         """
 
-        os.makedirs(instance.build_dir)
+        os.makedirs(instance.build_dir, exist_ok=True)
 
         link_name = f"test_{self.link_dir_counter}"
         link_path = os.path.join(links_dir_path, link_name)


### PR DESCRIPTION
This changes was introduced to this open Upstream PR:
https://github.com/zephyrproject-rtos/zephyr/pull/41930

First part of "short build paths" was introduced to sdk-zephyr repo in
this commit:
https://github.com/nrfconnect/sdk-zephyr/commit/ee43917f19aadae60845528d541d08561f051dc0

This fix allow to avoid situation when Twister create original "long path" build directory, before "short build path" try to create such directory and this cause an error. 

Relevant PR on `sdk-nrf` repository with changes in `west.yml` manifest in `sdk-zephyr` version:
https://github.com/nrfconnect/sdk-nrf/pull/6873

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>