### PR TITLE
Bluetooth: Host: GATT and direction finding bug fixes

### DIFF
--- a/subsys/bluetooth/host/direction.c
+++ b/subsys/bluetooth/host/direction.c
@@ -282,7 +282,7 @@ prepare_cl_cte_rx_enable_cmd_params(struct net_buf **buf, struct bt_le_per_adv_s
 	uint8_t switch_pattern_len;
 
 	if (params->cte_types & BT_DF_CTE_TYPE_AOA) {
-		switch_pattern_len = cp->switch_pattern_len;
+		switch_pattern_len = params->num_ant_ids;
 	} else {
 		switch_pattern_len = ARRAY_SIZE(df_dummy_switch_pattern);
 	}
@@ -522,7 +522,7 @@ static int prepare_conn_cte_rx_enable_cmd_params(struct net_buf **buf, struct bt
 	uint8_t switch_pattern_len;
 
 	if (params->cte_types & BT_DF_CTE_TYPE_AOA) {
-		switch_pattern_len = cp->switch_pattern_len;
+		switch_pattern_len = params->num_ant_ids;
 	} else {
 		switch_pattern_len = ARRAY_SIZE(df_dummy_switch_pattern);
 	}

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4908,6 +4908,8 @@ void bt_gatt_connected(struct bt_conn *conn)
 		settings_load_subtree_direct(key, ccc_set_direct, (void *)key);
 	}
 
+	bt_gatt_foreach_attr(0x0001, 0xffff, update_ccc, &data);
+
 	/* BLUETOOTH CORE SPECIFICATION Version 5.1 | Vol 3, Part C page 2192:
 	 *
 	 * 10.3.1.1 Handling of GATT indications and notifications


### PR DESCRIPTION
Cherry-pick commits:
- revert of commit https://github.com/nrfconnect/sdk-zephyr/commit/0a1f553dc23ca9c2b42092dbba44ab0b3204990b.
- fix for wrong length of antenna identifiers for CTE RX