### PR TITLE
net: sockets: Fix build issue with posix

### DIFF
--- a/include/net/socket_select.h
+++ b/include/net/socket_select.h
@@ -109,7 +109,6 @@ void ZSOCK_FD_SET(int fd, zsock_fd_set *set);
 #ifdef CONFIG_NET_SOCKETS_POSIX_NAMES
 
 #define fd_set zsock_fd_set
-#define timeval zsock_timeval
 #define FD_SETSIZE ZSOCK_FD_SETSIZE
 
 static inline int select(int nfds, zsock_fd_set *readfds,

--- a/include/net/socket_types.h
+++ b/include/net/socket_types.h
@@ -16,36 +16,37 @@
 
 #include <zephyr/types.h>
 
-#ifdef CONFIG_POSIX_API
+
+#ifdef CONFIG_NEWLIB_LIBC
+
+#include <newlib.h>
+
 #ifdef __NEWLIB__
 #include <sys/_timeval.h>
-#else
+#else /* __NEWLIB__ */
 #include <sys/types.h>
+/* workaround for older Newlib 2.x, as it lacks sys/_timeval.h */
+struct timeval {
+	time_t tv_sec;
+	suseconds_t tv_usec;
+};
 #endif /* __NEWLIB__ */
-#endif /* CONFIG_POSIX_API */
+
+#else /* CONFIG_NEWLIB_LIBC */
+
+#ifdef CONFIG_ARCH_POSIX
+#include <bits/types/struct_timeval.h>
+#else
+#include <sys/_timeval.h>
+#endif
+
+#endif /* CONFIG_NEWLIB_LIBC */
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#ifdef CONFIG_POSIX_API
-/* Rely on the underlying libc definition */
-#ifdef __NEWLIB__
 #define zsock_timeval timeval
-#else
-/* workaround for older Newlib 2.x, as it lacks sys/_timeval.h */
-struct zsock_timeval {
-	time_t tv_sec;
-	suseconds_t tv_usec;
-};
-#endif /* __NEWLIB__ */
-#else
-struct zsock_timeval {
-	/* Using longs, as many (?) implementations seem to use it. */
-	long tv_sec;
-	long tv_usec;
-};
-#endif /* CONFIG_POSIX_API */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Cheery pick commit 697f415bbf ("net: sockets: Use struct timeval provided by libc")
from upstream Zephyr that fixes a build issue with using posix/time.h
along with net/socket.h in the same file.