### PR TITLE
ci: manifest: do not persist git credentials

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -15,6 +15,7 @@ jobs:
           path: zephyrproject/zephyr
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@main


### PR DESCRIPTION
With this setting enabled, Git credentials are not kept after checkout.
Credentials are not necessary after the checkout step, since we do not
do any further manual push/pull operations.

(cherry picked from commit 52e06334fbeabd5d764935c1fc47d7225216fff4)