### PR TITLE
[nrf noup] Fix complinace check

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -92,7 +92,7 @@ jobs:
           exit 1;
         fi
 
-        for file in Nits.txt checkpatch.txt Identity.txt Gitlint.txt pylint.txt Devicetree.txt Kconfig.txt Codeowners.txt; do
+        for file in Nits.txt checkpatch.txt Identity.txt Gitlint.txt pylint.txt Devicetree.txt KconfigBasic.txt Codeowners.txt; do
           if [[ -s $file ]]; then
             errors=$(cat $file)
             errors="${errors//'%'/'%25'}"


### PR DESCRIPTION
squash! [nrf noup] ci: NCS-specific CI tweaks

In nrf we changed Kconfig check to KconfigBasic but the workflow was
not changed to scan for the KconfigBasic.txt file which is generated
in place of Kconfig.txt .

compliance debug

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>