### PR TITLE
[nrf noup] net: mqtt: add native TLS support

### DIFF
--- a/doc/reference/networking/mqtt.rst
+++ b/doc/reference/networking/mqtt.rst
@@ -149,6 +149,7 @@ additional configuration information:
    tls_config->sec_tag_list = m_sec_tags;
    tls_config->sec_tag_count = ARRAY_SIZE(m_sec_tags);
    tls_config->hostname = MQTT_BROKER_HOSTNAME;
+   tls_config->set_native_tls = true;
 
 In this sample code, the ``m_sec_tags`` array holds a list of tags, referencing TLS
 credentials that the MQTT library should use for authentication. We do not specify
@@ -160,6 +161,8 @@ the ``peer_verify`` field.
 Note, that TLS credentials referenced by the ``m_sec_tags`` array must be
 registered in the system first. For more information on how to do that, refer
 to :ref:`secure sockets documentation <secure_sockets_interface>`.
+
+Finally, ``set_native_tls`` can be optionally set to enable native TLS support instead of offloading TLS operations to the modem.
 
 An example of how to use TLS with MQTT is also present in
 :ref:`mqtt-publisher-sample`.

--- a/include/net/mqtt.h
+++ b/include/net/mqtt.h
@@ -360,6 +360,9 @@ struct mqtt_sec_config {
 
 	/** Indicates the preference for copying certificates to the heap. */
 	int cert_nocopy;
+
+	/** Set socket to native TLS */
+	bool set_native_tls;
 };
 
 /** @brief MQTT transport type. */

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -22,10 +22,15 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 {
 	const struct sockaddr *broker = client->broker;
 	struct mqtt_sec_config *tls_config = &client->transport.tls.config;
+	int type = SOCK_STREAM;
 	int ret;
 
+	if (tls_config->set_native_tls) {
+		type |= SOCK_NATIVE_TLS;
+	}
+
 	client->transport.tls.sock = zsock_socket(broker->sa_family,
-						  SOCK_STREAM, IPPROTO_TLS_1_2);
+						  type, IPPROTO_TLS_1_2);
 	if (client->transport.tls.sock < 0) {
 		return -errno;
 	}


### PR DESCRIPTION
This commit adds an extra parameter in the configuration
structure to configure native TLS support at runtime.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>

I found it's not necessary to cascade the change to every single library and sample since the MQTT context is always defined static, hence the `set_native_tls` parameter is `false` by default. If support for native TLS is needed, other commits can be added to address that.