### PR TITLE
[nrf noup] Bluetooth: host: Accept duplicate device

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -775,7 +775,10 @@ void bt_id_add(struct bt_keys *keys)
 
 	err = hci_id_add(keys->id, &keys->addr, keys->irk.val);
 	if (err) {
-		BT_ERR("Failed to add IRK to controller");
+		/* Duplicate device is OK */
+		if (err != BT_HCI_ERR_INVALID_PARAM) {
+			BT_ERR("Failed to add IRK to controller");
+		}
 		goto done;
 	}
 


### PR DESCRIPTION
When duplicate device is found, controller can either return a success or Invalid HCI Command Parameters (0x12).
Host now will not treat duplicate device as error (DRGN-15879).

Signed-off-by: Azizah Ibrahim <azizah.ibrahim@nordicsemi.no>