### PR TITLE
[nrf fromtree] modules: hal_nordic: Improve reservation of resources for BT_CTLR

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -275,8 +275,14 @@ void nrfx_busy_wait(uint32_t usec_to_wait);
 #define NRFX_GPIOTE_CHANNELS_USED NRFX_GPIOTE_CHANNELS_USED_BY_BT_CTLR
 
 #if defined(CONFIG_BT_CTLR)
-#include <../subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_resources.h>
-
+/*
+ * The enabled Bluetooth controller subsystem is responsible for providing
+ * definitions of the BT_CTLR_USED_* symbols used below in a file named
+ * bt_ctlr_used_resources.h and for adding its location to global include
+ * paths so that the file can be included here for all Zephyr libraries that
+ * are to be built.
+ */
+#include <bt_ctlr_used_resources.h>
 #define NRFX_PPI_CHANNELS_USED_BY_BT_CTLR    BT_CTLR_USED_PPI_CHANNELS
 #define NRFX_PPI_GROUPS_USED_BY_BT_CTLR      BT_CTLR_USED_PPI_GROUPS
 #define NRFX_GPIOTE_CHANNELS_USED_BY_BT_CTLR BT_CTLR_USED_GPIOTE_CHANNELS

--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -275,26 +275,11 @@ void nrfx_busy_wait(uint32_t usec_to_wait);
 #define NRFX_GPIOTE_CHANNELS_USED NRFX_GPIOTE_CHANNELS_USED_BY_BT_CTLR
 
 #if defined(CONFIG_BT_CTLR)
-
-#if defined(CONFIG_BT_LL_SOFTDEVICE)
-#include <mpsl.h>
-#if defined(PPI_PRESENT)
-	/* PPI channels 17 - 31, for the nRF52 Series */
-	#define PPI_CHANNELS_USED_BY_CTLR (BIT_MASK(15) << 17)
-#else
-	/* DPPI channels 0 - 13, for the nRF53 Series */
-	#define PPI_CHANNELS_USED_BY_CTLR BIT_MASK(14)
-#endif
-#define NRFX_PPI_CHANNELS_USED_BY_BT_CTLR    (PPI_CHANNELS_USED_BY_CTLR | MPSL_RESERVED_PPI_CHANNELS)
-#define NRFX_PPI_GROUPS_USED_BY_BT_CTLR	     0
-#define NRFX_GPIOTE_CHANNELS_USED_BY_BT_CTLR 0
-#else
 #include <../subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_resources.h>
+
 #define NRFX_PPI_CHANNELS_USED_BY_BT_CTLR    BT_CTLR_USED_PPI_CHANNELS
 #define NRFX_PPI_GROUPS_USED_BY_BT_CTLR      BT_CTLR_USED_PPI_GROUPS
 #define NRFX_GPIOTE_CHANNELS_USED_BY_BT_CTLR BT_CTLR_USED_GPIOTE_CHANNELS
-#endif
-
 #else
 #define NRFX_PPI_CHANNELS_USED_BY_BT_CTLR    0
 #define NRFX_PPI_GROUPS_USED_BY_BT_CTLR      0

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/nrfx_glue/bt_ctlr_used_resources.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/nrfx_glue/bt_ctlr_used_resources.h
@@ -3,12 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "radio_nrf5_fem.h"
+#include "../radio/radio_nrf5_fem.h"
 
 #ifdef DPPI_PRESENT
-#include "radio_nrf5_dppi_resources.h"
+#include "../radio/radio_nrf5_dppi_resources.h"
 #else
-#include "radio_nrf5_ppi_resources.h"
+#include "../radio/radio_nrf5_ppi_resources.h"
 #endif
 
 #if defined(HAL_RADIO_GPIO_HAVE_PA_PIN) || \

--- a/subsys/bluetooth/controller/ll_sw/nrf.cmake
+++ b/subsys/bluetooth/controller/ll_sw/nrf.cmake
@@ -100,3 +100,9 @@ zephyr_library_include_directories(
   ll_sw/nordic
   hci/nordic
 )
+
+# This path needs to be added globally as it is supposed to be used
+# in nrfx_glue.h when other libraries are built.
+zephyr_include_directories(
+  ll_sw/nordic/hal/nrf5/nrfx_glue
+)


### PR DESCRIPTION
Instead of including from nrfx_glue.h a specific Zephyr Bluetooth
controller header file that defines PPI and GPIOTE resources to be
reserved for exclusive use by the controller, include a file with
only a fixed name and expect the chosen Bluetooth controller to
provide the location of this file in include paths. This way, when
a different Bluetooth controller implementation is used downstream,
a different file can be easily pointed to.