### PR TITLE
[nrf fromtree] nRF53 GPIO forwarder and use in DF samples

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -103,7 +103,10 @@
 
 	gpio_fwd: nrf-gpio-forwarder {
 		compatible = "nordic,nrf-gpio-forwarder";
-		status = "disabled";
+		status = "okay";
+		uart {
+			gpios = <&gpio1 1 0>, <&gpio1 0 0>, <&gpio0 11 0>, <&gpio0 10 0>;
+		};
 	};
 
 	/* These aliases are provided for compatibility with samples */

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -101,6 +101,11 @@
 				 <5 &adc 5>;	/* A5 = P0.26 = AIN5 */
 	};
 
+	gpio_fwd: nrf-gpio-forwarder {
+		compatible = "nordic,nrf-gpio-forwarder";
+		status = "disabled";
+	};
+
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
@@ -13,12 +13,6 @@
 
 LOG_MODULE_REGISTER(nrf5340dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 
-/* TODO: This should come from DTS, possibly an overlay. */
-#define CPUNET_UARTE_PIN_TX 33
-#define CPUNET_UARTE_PIN_RX 32
-#define CPUNET_UARTE_PIN_RTS 11
-#define CPUNET_UARTE_PIN_CTS 10
-
 #if defined(CONFIG_BT_CTLR_DEBUG_PINS_CPUAPP)
 #include <../subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h>
 #else
@@ -28,15 +22,6 @@ LOG_MODULE_REGISTER(nrf5340dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 static void remoteproc_mgr_config(void)
 {
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM)
-	/* UARTE */
-	/* Assign specific GPIOs that will be used to get UARTE from
-	 * nRF5340 Network MCU.
-	 */
-	soc_secure_gpio_pin_mcu_select(CPUNET_UARTE_PIN_TX, NRF_GPIO_PIN_MCUSEL_NETWORK);
-	soc_secure_gpio_pin_mcu_select(CPUNET_UARTE_PIN_RX, NRF_GPIO_PIN_MCUSEL_NETWORK);
-	soc_secure_gpio_pin_mcu_select(CPUNET_UARTE_PIN_RTS, NRF_GPIO_PIN_MCUSEL_NETWORK);
-	soc_secure_gpio_pin_mcu_select(CPUNET_UARTE_PIN_CTS, NRF_GPIO_PIN_MCUSEL_NETWORK);
-
 	/* Route Bluetooth Controller Debug Pins */
 	DEBUG_SETUP();
 #endif /* !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM) */

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -83,13 +83,18 @@
 		regulator-boot-on;
 	};
 
-	nrf_radio_fem: fem {
-		compatible = "nordic,nrf21540-fem";
-		rx-en-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
-		mode-gpios  = <&gpio1 12 GPIO_ACTIVE_HIGH>;
-		pdn-gpios   = <&gpio1 10 GPIO_ACTIVE_HIGH>;
-		tx-en-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
-		spi-if = <&nrf_radio_fem_spi>;
+	gpio_fwd: nrf-gpio-forwarder {
+		compatible = "nordic,nrf-gpio-forwarder";
+		status = "okay";
+		fem-gpio-if {
+			gpios = <&gpio1 11 0>,
+				<&gpio1 12 0>,
+				<&gpio1 10 0>,
+				<&gpio0 30 0>;
+		};
+		fem-spi-if {
+			gpios = <&gpio0 24 0>;
+		};
 	};
 
 	aliases {

--- a/dts/bindings/gpio/nordic,nrf-gpio-forwarder.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio-forwarder.yaml
@@ -1,0 +1,76 @@
+# Copyright (c) 2020 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    This is an abstract device responsible for forwarding pins between cores.
+
+    In nRF53 family of SoCs, GPIO pins must be explicitly forwarded by
+    the application core to the network core if the latter should drive them.
+    The purpose of this abstract device is to represent all GPIO pins that the
+    nRF53 application core should forward to the nRF53 network core.
+
+    Once the control over selected GPIO pins is forwarded to it, the network
+    core is responsible for configuring the pins and driving them as needed.
+
+    Here is an example of how a nrf-gpio-forwarder can be used with a nRF5340
+    combined with a nRF21540 Front-End module. Consider the following node
+    present in DTS file targeted for the nRF5340 network core, which defines
+    the details of the nRF21540 Front-End module's interface:
+
+    nrf_radio_fem: nrf21540 {
+      compatible = "nordic,nrf21540-fem";
+      tx-en-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
+      rx-en-gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
+      pdn-gpios   = <&gpio1 10 GPIO_ACTIVE_HIGH>;
+      mode-gpios  = <&gpio1 12 GPIO_ACTIVE_HIGH>;
+    };
+
+    Since the nRF21540 Front-End module should be controlled by the nRF5340
+    network core, all the GPIO pins used to control it must be forwarded by
+    the nRF5340 application core to the network core. Consider the following
+    nrf-gpio-forwarder node defined in DTS file targeted for the nRF5340
+    application core:
+
+    gpio_fwd: nrf-gpio-forwarder {
+      compatible = "nordic,nrf-gpio-forwarder";
+      nrf21540-gpio-if {
+        gpios = <&gpio0 30 0>, <&gpio1 11 0>, <&gpio1 10 0>, <&gpio1 12 0>;
+      };
+    };
+
+    In the above example, the nrf-gpio-forwarder node is configured to forward
+    control over the following GPIO pins to the network core:
+
+      - P0.30 (matching `tx-en-gpios`)
+      - P1.11 (matching `rx-en-gpios`)
+      - P1.10 (matching `pdn-gpios`)
+      - P1.12 (matching `mode-gpios`)
+
+    Please note that the GPIO flags provided for child nodes of the forwarder
+    are ignored. In order to configure the GPIOs passed to the forwarder, their
+    GPIO flags must be set in the matching node that these GPIOs are forwarded
+    to. In the above example, the GPIO flags must be set in the nrf21540 node.
+    They are set to 0 in the nrf-gpio-forwarder node as they are ignored anyway.
+
+    Child nodes for the forwarder can be defined independently by multiple DTS
+    files. They are merged into a single node with multiple child nodes when
+    processing devicetree for an application build. However, in order for that
+    to happen, names of the child nodes must be unique in the scope of a single
+    nrf-gpio-forwarder instance.
+
+compatible: "nordic,nrf-gpio-forwarder"
+
+include: "base.yaml"
+
+child-binding:
+  description: Arrays of GPIOs to be forwarded.
+
+  properties:
+    gpios:
+      type: phandle-array
+      required: true
+      description: |
+          Array of GPIOs to be forwarded. Note that GPIO flags provided for
+          elements of this array are ignored. In order to configure the GPIOs
+          from this array, their GPIO flags must be set in the matching
+          node that these GPIOs are forwarded to.

--- a/samples/bluetooth/direction_finding_central/README.rst
+++ b/samples/bluetooth/direction_finding_central/README.rst
@@ -45,6 +45,9 @@ enabled:
   :zephyr_file:`samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52833.overlay`
   to a new file,
   :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
+* Make sure the same GPIO pins are assigned to Direction Finding Extension in file
+  :zephyr_file:`samples/bluetooth/direction_finding_central/boards/nrf5340dk_nrf5340_cpuapp.overlay`.
+  as those in the created file  :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52833.conf`
   to a new file,

--- a/samples/bluetooth/direction_finding_central/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_central/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* Enable pin forwarding to network core. The selected pins will be used by
+  * Radio Direction Finding Extension for antenna switching purposes.
+  *
+  * Note: Pay attention to assign the same GPIO pins as those provided in
+  * network core DTS overlay.
+  */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 0 0>,
+			<&gpio0 1 0>,
+			<&gpio0 2 0>,
+			<&gpio0 3 0>;
+		};
+};

--- a/samples/bluetooth/direction_finding_connectionless_rx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_rx/README.rst
@@ -45,6 +45,9 @@ enabled:
   :zephyr_file:`samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52833.overlay`
   to a new file,
   :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
+* Make sure the same GPIO pins are assigned to Direction Finding Extension in file
+  :zephyr_file:`samples/bluetooth/direction_finding_connectionless_rx/boards/nrf5340dk_nrf5340_cpuapp.overlay`.
+  as those in the created file :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52833.conf`
   to a new file,

--- a/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* Enable pin forwarding to network core. The selected pins will be used by
+  * Radio Direction Finding Extension for antenna switching purposes.
+  *
+  * Note: Pay attention to assign the same GPIO pins as those provided in
+  * network core DTS overlay.
+  */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 0 0>,
+			<&gpio0 1 0>,
+			<&gpio0 2 0>,
+			<&gpio0 3 0>;
+		};
+};

--- a/samples/bluetooth/direction_finding_connectionless_tx/README.rst
+++ b/samples/bluetooth/direction_finding_connectionless_tx/README.rst
@@ -45,6 +45,9 @@ support enabled:
   :zephyr_file:`samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52833.overlay`
   to a new file,
   :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
+* Make sure the same GPIO pins are assigned to Direction Finding Extension in file
+  :zephyr_file:`samples/bluetooth/direction_finding_connectionless_tx/boards/nrf5340dk_nrf5340_cpuapp.overlay`.
+  as those in the created file :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52833.conf`
   to a new file,

--- a/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* Enable pin forwarding to network core. The selected pins will be used by
+  * Radio Direction Finding Extension for antenna switching purposes.
+  *
+  * Note: Pay attention to assign the same GPIO pins as those provided in
+  * network core DTS overlay.
+  */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 0 0>,
+			<&gpio0 1 0>,
+			<&gpio0 2 0>,
+			<&gpio0 3 0>;
+		};
+};

--- a/samples/bluetooth/direction_finding_peripheral/README.rst
+++ b/samples/bluetooth/direction_finding_peripheral/README.rst
@@ -44,6 +44,9 @@ enabled:
   :zephyr_file:`samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.overlay`
   to a new file,
   :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
+* Make sure the same GPIO pins are assigned to Direction Finding Extension in file
+  :zephyr_file:`samples/bluetooth/direction_finding_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay`.
+  as those in the created file :file:`samples/bluetooth/hci_rpmsg/boards/nrf5340dk_nrf5340_cpunet.overlay`.
 * Copy
   :zephyr_file:`samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52833.conf`
   to a new file,

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ /* Enable pin forwarding to network core. The selected pins will be used by
+  * Radio Direction Finding Extension for antenna switching purposes.
+  *
+  * Note: Pay attention to assign the same GPIO pins as those provided in
+  * network core DTS overlay.
+  */
+&gpio_fwd {
+	dfe-gpio-if {
+		gpios = <&gpio0 0 0>,
+			<&gpio0 1 0>,
+			<&gpio0 2 0>,
+			<&gpio0 3 0>;
+		};
+};

--- a/soc/arm/nordic_nrf/common/soc_nrf_common.h
+++ b/soc/arm/nordic_nrf/common/soc_nrf_common.h
@@ -120,15 +120,23 @@
  *
  *     foo: my-node {
  *             tx-gpios = <&gpio0 4 ...>;
- *             rx-gpios = <&gpio1 5 ...>;
+ *             rx-gpios = <&gpio0 5 ...>, <&gpio1 5 ...>;
  *     };
  *
- *     NRF_DT_GPIOS_TO_PSEL(DT_NODELABEL(foo), tx_gpios) // 0 + 4 = 4
- *     NRF_DT_GPIOS_TO_PSEL(DT_NODELABEL(foo), rx_gpios) // 32 + 5 = 37
+ *     NRF_DT_GPIOS_TO_PSEL_BY_IDX(DT_NODELABEL(foo), tx_gpios, 0) // 0 + 4 = 4
+ *     NRF_DT_GPIOS_TO_PSEL_BY_IDX(DT_NODELABEL(foo), rx_gpios, 1) // 32 + 5 = 37
  */
-#define NRF_DT_GPIOS_TO_PSEL(node_id, prop)				\
-	(DT_GPIO_PIN(node_id, prop) +					\
-	 (DT_PROP_BY_PHANDLE(node_id, prop, port) << 5))
+#define NRF_DT_GPIOS_TO_PSEL_BY_IDX(node_id, prop, idx)			\
+	NRF_GPIO_PIN_MAP(						\
+		DT_PROP_BY_PHANDLE_IDX(node_id, prop, idx, port),	\
+		DT_GPIO_PIN_BY_IDX(node_id, prop, idx))
+
+
+/**
+ * @brief Equivalent to NRF_DT_GPIOS_TO_PSEL_BY_IDX(node_id, prop, 0)
+ */
+#define NRF_DT_GPIOS_TO_PSEL(node_id, prop)			\
+	NRF_DT_GPIOS_TO_PSEL_BY_IDX(node_id, prop, 0)
 
 /**
  * If the node has the property, expands to


### PR DESCRIPTION
Adds GPIO forwarding for nRF53 network core.
Adds configuration of application core to forward GPIOs in direction finding samples.