### PR TITLE
[nrf fromtree] drivers: uart_nrfx_uarte: Fix double Rx buffer releasing

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -854,8 +854,7 @@ static void notify_uart_rx_rdy(const struct device *dev, size_t len)
 	user_callback(dev, &evt);
 }
 
-static void notify_rx_buf_release(const struct device *dev,
-				  uint8_t **buf, bool clear)
+static void rx_buf_release(const struct device *dev, uint8_t **buf)
 {
 	if (*buf) {
 		struct uart_event evt = {
@@ -864,9 +863,7 @@ static void notify_rx_buf_release(const struct device *dev,
 		};
 
 		user_callback(dev, &evt);
-		if (clear) {
-			*buf = NULL;
-		}
+		*buf = NULL;
 	}
 }
 
@@ -927,8 +924,7 @@ static int uarte_nrfx_rx_enable(const struct device *dev, uint8_t *buf,
 			if (!len) {
 				data->async->rx_flush_cnt -= cpy_len;
 				notify_uart_rx_rdy(dev, cpy_len);
-				notify_rx_buf_release(dev, &data->async->rx_buf,
-						      true);
+				rx_buf_release(dev, &data->async->rx_buf);
 				notify_rx_disable(dev);
 				return 0;
 			}
@@ -1194,7 +1190,7 @@ static void endrx_isr(const struct device *dev)
 		return;
 	}
 
-	notify_rx_buf_release(dev, &data->async->rx_buf, false);
+	rx_buf_release(dev, &data->async->rx_buf);
 
 	/* If there is a next buffer, then STARTRX will have already been
 	 * invoked by the short (the next buffer will be filling up already)
@@ -1327,8 +1323,8 @@ static void rxto_isr(const struct device *dev)
 	const struct uarte_nrfx_config *config = dev->config;
 	struct uarte_nrfx_data *data = dev->data;
 
-	notify_rx_buf_release(dev, &data->async->rx_buf, true);
-	notify_rx_buf_release(dev, &data->async->rx_next_buf, true);
+	rx_buf_release(dev, &data->async->rx_buf);
+	rx_buf_release(dev, &data->async->rx_next_buf);
 
 	/* If the rx_enabled flag is still set at this point, it means that
 	 * RX is being disabled because all provided RX buffers have been


### PR DESCRIPTION
Fixes a case for the asynchronous UART API where
only single buffer was attached to the UART, after
filling this buffer release event was trigger first
time and after disabling UART the release event was
triggered again for the same buffer.

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>
(cherry picked from commit ba6d9139bbbda3211e0c1f65f4ccca0719f17fa5)