### PR TITLE
[nrf noup] storage: remove flash_map out of tree patch

### DIFF
--- a/include/storage/flash_map.h
+++ b/include/storage/flash_map.h
@@ -256,10 +256,6 @@ const struct device *flash_area_get_device(const struct flash_area *fa);
  */
 uint8_t flash_area_erased_val(const struct flash_area *fa);
 
-#if USE_PARTITION_MANAGER
-#include <flash_map_pm.h>
-#else
-
 #define FLASH_AREA_LABEL_EXISTS(label) \
 	DT_HAS_FIXED_PARTITION_LABEL(label)
 
@@ -285,8 +281,6 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
 #define FLASH_AREA_DEVICE(label) \
 	DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(DT_NODE_BY_FIXED_PARTITION_LABEL(label)))
 
-
-#endif /* USE_PARTITION_MANAGER */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Remove flash_map out of tree patch.

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>