### PR TITLE
[nrf fromtree] drivers: clock_control: nrf_calibration: drop workaround

### DIFF
--- a/drivers/clock_control/nrf_clock_calibration.c
+++ b/drivers/clock_control/nrf_clock_calibration.c
@@ -107,11 +107,6 @@ static void cal_lf_callback(struct onoff_manager *mgr,
 /* Start actual HW calibration assuming that HFCLK XTAL is on. */
 static void start_hw_cal(void)
 {
-	/* Workaround for Errata 192 */
-	if (IS_ENABLED(CONFIG_SOC_SERIES_NRF52X)) {
-		*(volatile uint32_t *)0x40000C34 = 0x00000002;
-	}
-
 	nrfx_clock_calibration_start();
 	calib_skip_cnt = CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP;
 }


### PR DESCRIPTION
Workaround for errata 192 is unnecessary as it is applied within
nrfx_clock_calibration_start().

Fixes #43930

Cherry picked from 2a4144d06.
Ref. NCSIDB-734.

Signed-off-by: Xudong Zheng <7pkvm5aw@slicealias.com>
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>