### PR TITLE
[nrf fromlist] logging: Fix cbprintf package alignement

### DIFF
--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -75,16 +75,22 @@ struct log_msg2_hdr {
 	const void *source;
 	log_timestamp_t timestamp;
 #endif
-#if defined(__xtensa__) && !defined(CONFIG_LOG_TIMESTAMP_64BIT)
-	/* xtensa requires that cbprintf package that follows the header is
-	 * aligned to 16 bytes. Adding padding when necessary.
-	 */
-	uint32_t padding;
-#endif
 };
+
+/* Messages are aligned to alignment required by cbprintf package. */
+#define Z_LOG_MSG2_ALIGNMENT CBPRINTF_PACKAGE_ALIGNMENT
+
+#define Z_LOG_MSG2_PADDING \
+	((sizeof(struct log_msg2_hdr) % Z_LOG_MSG2_ALIGNMENT) > 0 ? \
+	(Z_LOG_MSG2_ALIGNMENT - (sizeof(struct log_msg2_hdr) % Z_LOG_MSG2_ALIGNMENT)) : \
+		0)
 
 struct log_msg2 {
 	struct log_msg2_hdr hdr;
+	/* Adding padding to ensure that cbprintf package that follows is
+	 * properly aligned.
+	 */
+	uint8_t padding[Z_LOG_MSG2_PADDING];
 	uint8_t data[];
 };
 
@@ -131,9 +137,6 @@ enum z_log_msg2_mode {
 	.data_len = _dlen, \
 	.reserved = 0, \
 }
-
-/* Messages are aligned to alignment required by cbprintf package. */
-#define Z_LOG_MSG2_ALIGNMENT CBPRINTF_PACKAGE_ALIGNMENT
 
 #ifdef CONFIG_LOG2_USE_VLA
 #define Z_LOG_MSG2_ON_STACK_ALLOC(ptr, len) \
@@ -182,10 +185,10 @@ enum z_log_msg2_mode {
 #endif /* Z_LOG_MSG2_USE_VLA */
 
 #define Z_LOG_MSG2_ALIGN_OFFSET \
-	sizeof(struct log_msg2_hdr)
+	offsetof(struct log_msg2, data)
 
 #define Z_LOG_MSG2_LEN(pkg_len, data_len) \
-	(sizeof(struct log_msg2_hdr) + pkg_len + (data_len))
+	(offsetof(struct log_msg2, data) + pkg_len + (data_len))
 
 #define Z_LOG_MSG2_ALIGNED_WLEN(pkg_len, data_len) \
 	ceiling_fraction(ROUND_UP(Z_LOG_MSG2_LEN(pkg_len, data_len), \

--- a/tests/subsys/logging/log_msg2/src/main.c
+++ b/tests/subsys/logging/log_msg2/src/main.c
@@ -370,7 +370,7 @@ void test_mode_size_plain_string(void)
 	 *
 	 * Message size is rounded up to the required alignment.
 	 */
-	exp_len = sizeof(struct log_msg2_hdr) +
+	exp_len = offsetof(struct log_msg2, data) +
 			 /* package */2 * sizeof(const char *);
 	if (mode == Z_LOG_MSG2_MODE_RUNTIME && TEST_LOG_MSG2_RW_STRINGS) {
 		exp_len += 2 + strlen("test str");
@@ -404,7 +404,7 @@ void test_mode_size_data_only(void)
 	 *
 	 * Message size is rounded up to the required alignment.
 	 */
-	exp_len = sizeof(struct log_msg2_hdr) + sizeof(data);
+	exp_len = offsetof(struct log_msg2, data) + sizeof(data);
 	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
 	get_msg_validate_length(exp_len);
 }
@@ -432,7 +432,7 @@ void test_mode_size_plain_str_data(void)
 	 *
 	 * Message size is rounded up to the required alignment.
 	 */
-	exp_len = sizeof(struct log_msg2_hdr) + sizeof(data) +
+	exp_len = offsetof(struct log_msg2, data) + sizeof(data) +
 		  /* package */2 * sizeof(char *);
 	if (mode == Z_LOG_MSG2_MODE_RUNTIME && TEST_LOG_MSG2_RW_STRINGS) {
 		exp_len += 2 + strlen("test str");
@@ -469,7 +469,7 @@ void test_mode_size_str_with_strings(void)
 	 *
 	 * Message size is rounded up to the required alignment.
 	 */
-	exp_len = sizeof(struct log_msg2_hdr) +
+	exp_len = offsetof(struct log_msg2, data) +
 			 /* package */3 * sizeof(const char *);
 	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
 
@@ -509,7 +509,7 @@ void test_mode_size_str_with_2strings(void)
 	 *
 	 * Message size is rounded up to the required alignment.
 	 */
-	exp_len = sizeof(struct log_msg2_hdr) +
+	exp_len = offsetof(struct log_msg2, data) +
 			 /* package */4 * sizeof(const char *);
 	if (TEST_LOG_MSG2_RW_STRINGS) {
 		exp_len += strlen("sufix") + 2 /* null + header */ +
@@ -535,7 +535,7 @@ void test_saturate(void)
 	}
 
 	uint32_t exp_len =
-		ROUND_UP(sizeof(struct log_msg2_hdr) + 2 * sizeof(void *),
+		ROUND_UP(offsetof(struct log_msg2, data) + 2 * sizeof(void *),
 			 Z_LOG_MSG2_ALIGNMENT);
 	uint32_t exp_capacity = (CONFIG_LOG_BUFFER_SIZE - 1) / exp_len;
 	int mode;


### PR DESCRIPTION
Fix alignment fo the cbprintf package withing the log message.
Aligning tests to pass.

Cherry-pick from upstream PR #44784.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>