### PR TITLE
[nrf fromtree] dts: arm: nordic: nrf5340: clean up ipc in dts

### DIFF
--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -97,6 +97,11 @@
 			};
 		};
 	};
+
+	/* Default IPC description */
+	ipc {
+		#include "nrf5340_cpuapp_ipc.dtsi"
+	};
 };
 
 &nvic {

--- a/dts/arm/nordic/nrf5340_cpuapp_ipc.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_ipc.dtsi
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ipc0: ipc0 {
+	compatible = "zephyr,ipc-openamp-static-vrings";
+	memory-region = <&sram0_shared>;
+	mboxes = <&mbox 0>, <&mbox 1>;
+	mbox-names = "tx", "rx";
+	role = "host";
+	status = "okay";
+};

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -416,15 +416,6 @@ i2s0: i2s@28000 {
 	label = "I2S_0";
 };
 
-ipc0: ipc0 {
-	compatible = "zephyr,ipc-openamp-static-vrings";
-	memory-region = <&sram0_shared>;
-	mboxes = <&mbox 0>, <&mbox 1>;
-	mbox-names = "tx", "rx";
-	role = "host";
-	status = "okay";
-};
-
 mbox: ipc: mbox@2a000 {
 	compatible = "nordic,mbox-nrf-ipc", "nordic,nrf-ipc";
 	reg = <0x2a000 0x1000>;

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -57,6 +57,11 @@
 		label = "CRYPTOCELL_SW";
 		status = "okay";
 	};
+
+	/* Default IPC description */
+	ipc {
+		#include "nrf5340_cpuapp_ipc.dtsi"
+	};
 };
 
 &nvic {

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -153,15 +153,6 @@
 			label = "RTC_0";
 		};
 
-		ipc0: ipc0 {
-			compatible = "zephyr,ipc-openamp-static-vrings";
-			memory-region = <&sram0_shared>;
-			mboxes = <&mbox 0>, <&mbox 1>;
-			mbox-names = "rx", "tx";
-			role = "remote";
-			status = "okay";
-		};
-
 		mbox: ipc: mbox@41012000 {
 			compatible = "nordic,mbox-nrf-ipc", "nordic,nrf-ipc";
 			reg = <0x41012000 0x1000>;
@@ -327,6 +318,18 @@
 			label = "GPIO_1";
 			status = "disabled";
 			port = <1>;
+		};
+	};
+
+	/* Default IPC description */
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-openamp-static-vrings";
+			memory-region = <&sram0_shared>;
+			mboxes = <&mbox 0>, <&mbox 1>;
+			mbox-names = "rx", "tx";
+			role = "remote";
+			status = "okay";
 		};
 	};
 };

--- a/samples/subsys/ipc/ipc_service/icmsg/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &ipc0;
-
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
@@ -23,12 +21,16 @@
 		};
 	};
 
-	ipc0: ipc0 {
-		compatible = "zephyr,ipc-icmsg";
-		tx-region = <&sram_tx>;
-		rx-region = <&sram_rx>;
-		mboxes = <&mbox 0>, <&mbox 1>;
-		mbox-names = "tx", "rx";
-		status = "okay";
+	ipc {
+		/delete-node/ ipc0;
+
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&mbox 0>, <&mbox 1>;
+			mbox-names = "tx", "rx";
+			status = "okay";
+		};
 	};
 };

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &ipc0;
-
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
@@ -23,12 +21,16 @@
 		};
 	};
 
-	ipc0: ipc0 {
-		compatible = "zephyr,ipc-icmsg";
-		tx-region = <&sram_tx>;
-		rx-region = <&sram_rx>;
-		mboxes = <&mbox 0>, <&mbox 1>;
-		mbox-names = "rx", "tx";
-		status = "okay";
+	ipc {
+		/delete-node/ ipc0;
+
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&mbox 0>, <&mbox 1>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
 	};
 };

--- a/samples/subsys/ipc/ipc_service/static_vrings/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -11,12 +11,6 @@
 		/delete-property/ zephyr,ipc_shm;
 	};
 
-	soc {
-		peripheral@50000000 {
-			/delete-node/ ipc0;
-		};
-	};
-
 	reserved-memory {
 		/delete-node/ memory@20070000;
 
@@ -29,22 +23,26 @@
 		};
 	};
 
-	ipc0: ipc0 {
-		compatible = "zephyr,ipc-openamp-static-vrings";
-		memory-region = <&sram_ipc0>;
-		mboxes = <&mbox 0>, <&mbox 1>;
-		mbox-names = "tx", "rx";
-		role = "host";
-		status = "okay";
-	};
+	ipc {
+		/delete-node/ ipc0;
 
-	ipc1: ipc1 {
-		compatible = "zephyr,ipc-openamp-static-vrings";
-		memory-region = <&sram_ipc1>;
-		mboxes = <&mbox 2>, <&mbox 3>;
-		mbox-names = "tx", "rx";
-		role = "host";
-		zephyr,priority = <1 PRIO_COOP>;
-		status = "okay";
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-openamp-static-vrings";
+			memory-region = <&sram_ipc0>;
+			mboxes = <&mbox 0>, <&mbox 1>;
+			mbox-names = "tx", "rx";
+			role = "host";
+			status = "okay";
+		};
+
+		ipc1: ipc1 {
+			compatible = "zephyr,ipc-openamp-static-vrings";
+			memory-region = <&sram_ipc1>;
+			mboxes = <&mbox 2>, <&mbox 3>;
+			mbox-names = "tx", "rx";
+			role = "host";
+			zephyr,priority = <1 PRIO_COOP>;
+			status = "okay";
+		};
 	};
 };

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -11,10 +11,6 @@
 		/delete-property/ zephyr,ipc_shm;
 	};
 
-	soc {
-		/delete-node/ ipc0;
-	};
-
 	reserved-memory {
 		/delete-node/ memory@20070000;
 
@@ -27,22 +23,26 @@
 		};
 	};
 
-	ipc0: ipc0 {
-		compatible = "zephyr,ipc-openamp-static-vrings";
-		memory-region = <&sram_ipc0>;
-		mboxes = <&mbox 0>, <&mbox 1>;
-		mbox-names = "rx", "tx";
-		role = "remote";
-		status = "okay";
-	};
+	ipc {
+		/delete-node/ ipc0;
 
-	ipc1: ipc1 {
-		compatible = "zephyr,ipc-openamp-static-vrings";
-		memory-region = <&sram_ipc1>;
-		mboxes = <&mbox 2>, <&mbox 3>;
-		mbox-names = "rx", "tx";
-		role = "remote";
-		zephyr,priority = <2 PRIO_PREEMPT>;
-		status = "okay";
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-openamp-static-vrings";
+			memory-region = <&sram_ipc0>;
+			mboxes = <&mbox 0>, <&mbox 1>;
+			mbox-names = "rx", "tx";
+			role = "remote";
+			status = "okay";
+		};
+
+		ipc1: ipc1 {
+			compatible = "zephyr,ipc-openamp-static-vrings";
+			memory-region = <&sram_ipc1>;
+			mboxes = <&mbox 2>, <&mbox 3>;
+			mbox-names = "rx", "tx";
+			role = "remote";
+			zephyr,priority = <2 PRIO_PREEMPT>;
+			status = "okay";
+		};
 	};
 };


### PR DESCRIPTION
Cleaned up the IPC configuration for nRF5340 SoC in Device Tree. This
change fixes the (simple_bus_reg) warning about the missing or empty
reg/ranges property.

This is a follow-up to commit cf6a58d.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>
(cherry picked from commit d550320af6adf16807105ef631d48fa45031d04d)