### PR TITLE
[nrf noup] Bluetooth: Mesh: Remove Experimental tag

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -4,8 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BT_MESH
-	bool "Bluetooth mesh support [EXPERIMENTAL]"
-	select EXPERIMENTAL
+	bool "Bluetooth mesh support"
 	select TINYCRYPT
 	select TINYCRYPT_AES
 	select TINYCRYPT_AES_CMAC


### PR DESCRIPTION
squash! [nrf noup] Bluetooth: update experimental for qualification

Mesh is no longer Experimental, as it has been ready
for production since v1.7.1. Experimantal status should
not be shown while building with mesh.

Signed-off-by: Ingar Kulbrandstad <ingar.kulbrandstad@nordicsemi.no>