### PR TITLE
[nrf fromtree] pinctrl: nrf: prefix custom drive-mode property

### DIFF
--- a/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
@@ -100,7 +100,7 @@ child-binding:
           be defined using the NRF_PSEL utility macro that encodes the port,
           pin and function.
 
-      drive-mode:
+      nordic,drive-mode:
         type: int
         default: 0
         description: |

--- a/soc/arm/nordic_nrf/common/pinctrl_soc.h
+++ b/soc/arm/nordic_nrf/common/pinctrl_soc.h
@@ -36,7 +36,7 @@ typedef uint32_t pinctrl_soc_pin_t;
 	(DT_PROP_BY_IDX(node_id, prop, idx) |				       \
 	 ((NRF_PULL_DOWN * DT_PROP(node_id, bias_pull_down)) << NRF_PULL_POS) |\
 	 ((NRF_PULL_UP * DT_PROP(node_id, bias_pull_up)) << NRF_PULL_POS) |    \
-	 (DT_PROP(node_id, drive_mode) << NRF_DRIVE_POS) |		       \
+	 (DT_PROP(node_id, nordic_drive_mode) << NRF_DRIVE_POS) |	       \
 	 ((NRF_LP_ENABLE * DT_PROP(node_id, low_power_enable)) << NRF_LP_POS) |\
 	 (DT_PROP(node_id, nordic_invert) << NRF_INVERT_POS)		       \
 	),

--- a/tests/drivers/pinctrl/nrf/app.overlay
+++ b/tests/drivers/pinctrl/nrf/app.overlay
@@ -23,7 +23,7 @@
 		};
 		group2 {
 			psels = <NRF_PSEL(UART_RX, 0, 3)>;
-			drive-mode = <NRF_DRIVE_H0S1>;
+			nordic,drive-mode = <NRF_DRIVE_H0S1>;
 		};
 		group3 {
 			psels = <NRF_PSEL(UART_RX, 0, 4)>;


### PR DESCRIPTION
The drive-mode property is nRF specific, so prefix it with `nordic,`,
same as the `nordic,invert` property.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
(cherry picked from commit 9678bd697023eed51102c8465db2f7d12380aa6a)