### PR TITLE
[nrf fromtree] scripts: utils: add include migration script + pinctrl: nrf: prefix custom drive-mode property

### DIFF
--- a/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
@@ -100,7 +100,7 @@ child-binding:
           be defined using the NRF_PSEL utility macro that encodes the port,
           pin and function.
 
-      drive-mode:
+      nordic,drive-mode:
         type: int
         default: 0
         description: |

--- a/scripts/utils/migrate_includes.py
+++ b/scripts/utils/migrate_includes.py
@@ -1,0 +1,73 @@
+"""
+Utility script to migrate Zephyr-based projects to the new <zephyr/...> include
+prefix.
+
+Usage::
+
+    python $ZEPHYR_BASE/scripts/utils/migrate_includes.py \
+           -p path/to/zephyr-based-project
+
+Copyright (c) 2022 Nordic Semiconductor ASA
+SPDX-License-Identifier: Apache-2.0
+"""
+
+import argparse
+from pathlib import Path
+import re
+import sys
+
+
+ZEPHYR_BASE = Path(__file__).parents[2]
+
+EXTENSIONS = ("c", "cpp", "h", "dts", "dtsi", "rst", "S", "overlay", "ld")
+
+
+def update_includes(project, dry_run):
+    for p in project.glob("**/*"):
+        if not p.is_file() or not p.suffix or p.suffix[1:] not in EXTENSIONS:
+            continue
+
+        try:
+            with open(p) as f:
+                lines = f.readlines()
+        except UnicodeDecodeError:
+            print(f"File with invalid encoding: {p}, skipping", file=sys.stderr)
+            continue
+
+        content = ""
+        migrate = False
+        for line in lines:
+            m = re.match(r"^(.*)#include <(.*\.h)>(.*)$", line)
+            if (
+                m
+                and not m.group(2).startswith("zephyr/")
+                and (ZEPHYR_BASE / "include" / "zephyr" / m.group(2)).exists()
+            ):
+                content += (
+                    m.group(1)
+                    + "#include <zephyr/"
+                    + m.group(2)
+                    + ">"
+                    + m.group(3)
+                    + "\n"
+                )
+                migrate = True
+            else:
+                content += line
+
+        if migrate:
+            print(f"Updating {p}{' (dry run)' if dry_run else ''}")
+            if not dry_run:
+                with open(p, "w") as f:
+                    f.write(content)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-p", "--project", type=Path, required=True, help="Zephyr-based project path"
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Dry run")
+    args = parser.parse_args()
+
+    update_includes(args.project, args.dry_run)

--- a/soc/arm/nordic_nrf/common/pinctrl_soc.h
+++ b/soc/arm/nordic_nrf/common/pinctrl_soc.h
@@ -36,7 +36,7 @@ typedef uint32_t pinctrl_soc_pin_t;
 	(DT_PROP_BY_IDX(node_id, prop, idx) |				       \
 	 ((NRF_PULL_DOWN * DT_PROP(node_id, bias_pull_down)) << NRF_PULL_POS) |\
 	 ((NRF_PULL_UP * DT_PROP(node_id, bias_pull_up)) << NRF_PULL_POS) |    \
-	 (DT_PROP(node_id, drive_mode) << NRF_DRIVE_POS) |		       \
+	 (DT_PROP(node_id, nordic_drive_mode) << NRF_DRIVE_POS) |	       \
 	 ((NRF_LP_ENABLE * DT_PROP(node_id, low_power_enable)) << NRF_LP_POS) |\
 	 (DT_PROP(node_id, nordic_invert) << NRF_INVERT_POS)		       \
 	),

--- a/tests/drivers/pinctrl/nrf/app.overlay
+++ b/tests/drivers/pinctrl/nrf/app.overlay
@@ -23,7 +23,7 @@
 		};
 		group2 {
 			psels = <NRF_PSEL(UART_RX, 0, 3)>;
-			drive-mode = <NRF_DRIVE_H0S1>;
+			nordic,drive-mode = <NRF_DRIVE_H0S1>;
 		};
 		group3 {
 			psels = <NRF_PSEL(UART_RX, 0, 4)>;


### PR DESCRIPTION
All includes are now prefixed with <zephyr/...>, even though the old
include paths can still be used when CONFIG_LEGACY_INCLUDE_PATH=y, an
option still enabled by default. Migrating large projects can be tedious
and time consuming. This patch provides a script that can be used to
migrate any Zephyr-based project to the new include path. It is used
like this:

  python $ZEPHYR_BASE/scripts/utils/migrate_includes.py \
         -p path/to/zephyr-based-project

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
(cherry picked from commit 0d18e911fc19f5bdd8da2b778735cedcb1339ac5)

The drive-mode property is nRF specific, so prefix it with nordic,,
same as the nordic,invert property.

Signed-off-by: Gerard Marull-Paretas [gerard.marull@nordicsemi.no](mailto:gerard.marull@nordicsemi.no)
(cherry picked from commit 9678bd697023eed51102c8465db2f7d12380aa6a)