### PR TITLE
[nrf fromlist] lib: os: cbprintf: Reduce stack usage when no optimization

### DIFF
--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -357,7 +357,15 @@ union z_cbprintf_hdr {
 /* Allocation to avoid using VLA and alloca. Alloc frees space when leaving
  * a function which can lead to increased stack usage if logging is used
  * multiple times. VLA is not always available.
+ *
+ * Use large array when optimization is off to avoid increased stack usage.
  */
+#ifdef CONFIG_NO_OPTIMIZATIONS
+#define Z_CBPRINTF_ON_STACK_ALLOC(_name, _len) \
+	__ASSERT(_len <= 32, "Too many string arguments."); \
+	uint8_t _name##_buf32[32]; \
+	_name = _name##_buf32
+#else
 #define Z_CBPRINTF_ON_STACK_ALLOC(_name, _len) \
 	__ASSERT(_len <= 32, "Too many string arguments."); \
 	uint8_t _name##_buf4[4]; \
@@ -370,6 +378,7 @@ union z_cbprintf_hdr {
 		((_len) <= 12 ? _name##_buf12 : \
 		((_len) <= 16 ? _name##_buf16 : \
 		 _name##_buf32)))
+#endif
 
 /** @brief Statically package a formatted string with arguments.
  *

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -168,6 +168,8 @@ extern "C" {
 #else
 #define Z_CBPRINTF_ARG_SIZE(v) ({\
 	__auto_type _v = (v) + 0; \
+	/* Static code analysis may complain about unused variable. */ \
+	(void)_v; \
 	size_t _arg_size = _Generic((v), \
 		float : sizeof(double), \
 		default : \
@@ -194,6 +196,9 @@ extern "C" {
 				float : (arg) + 0, \
 				default : \
 					0.0); \
+		/* Static code analysis may complain about unused variable. */ \
+		(void)_v; \
+		(void)_d; \
 		size_t arg_size = Z_CBPRINTF_ARG_SIZE(arg); \
 		size_t _wsize = arg_size / sizeof(int); \
 		z_cbprintf_wcpy((int *)buf, \


### PR DESCRIPTION
Use single fixed size on stack array instead of compile time fitting.
When compiler is optimizing it can pick smallest array but with no
optimization there is an increased stack usage.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/45575

Ref. NCSDK-15105

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>