### PR TITLE
ci: change secret used by manifest action

### DIFF
--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@2f1ad2908599d4fe747f886f9d733dd7eebae4ef
         with:
-          github-token: ${{ secrets.ZB_GITHUB_TOKEN }}
+          github-token: ${{ secrets.NCS_GITHUB_TOKEN }}
           manifest-path: 'west.yml'
           checkout-path: 'zephyrproject/zephyr'
           label-prefix: 'manifest-'


### PR DESCRIPTION
using NCS_GITHUB_TOKEN provides extra permissions over GITHUB_TOKEN

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>