### PR TITLE
Fixed a wrong pin parameter

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -125,7 +125,7 @@ static int gpio_nrfx_pin_configure(const struct device *port, gpio_pin_t pin,
 		.trigger = NRFX_GPIOTE_TRIGGER_NONE
 	};
 
-	err = nrfx_gpiote_channel_get(pin, &ch);
+	err = nrfx_gpiote_channel_get(abs_pin, &ch);
 	free_ch = (err == NRFX_SUCCESS);
 
 	/* Remove previously configured trigger when pin is reconfigured. */


### PR DESCRIPTION
nrfx_gpiote_channel_get() used the relative pin of a port in the past: nrfx_gpiote_channel_get(pin, &ch). Now it changed to abs pin: nrfx_gpiote_channel_get(abs_pin, &ch). 

The old code would have issue if the same position of another port is configured too. For example, P0.04 and P1.04 are used for the gpiote interrupts together. The latter will free the previous one's GPIOTE channel. As a result, the previous gpiote interrupt would not work any more. The fix uses the abs pin to avoid this issue
