### PR TITLE
[nrf fromtree] storage/flash_map: Return -ENODEV from

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -118,7 +118,8 @@ int flash_area_check_int_sha256(const struct flash_area *fa,
  * @p ID is unknown, it will be NULL on output.
  *
  * @return  0 on success, -EACCES if the flash_map is not available ,
- * -ENOENT if @p ID is unknown.
+ * -ENOENT if @p ID is unknown, -EDEV if there is not driver attached
+ * to the area.
  */
 int flash_area_open(uint8_t id, const struct flash_area **fa);
 

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -37,7 +37,12 @@ int flash_area_open(uint8_t id, const struct flash_area **fap)
 		return -ENOENT;
 	}
 
+	if (device_get_binding(area->fa_dev_name) == NULL) {
+		return -ENODEV;
+	}
+
 	*fap = area;
+
 	return 0;
 }
 


### PR DESCRIPTION
... flash_area_open

The commit adds check, to flash_area_open, whether there is any
device driver attached and returns -ENODEV if there isn't any.
This works around a problem where flash_area_open succeeds but
consecutive read/write causes crash.
It is enough to check the condition, and return error, here as
the flash_area_open has to precede, and be checked for success,
any read/write operations so

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/45634

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>
(cherry picked from commit aa5d20aaefa267360e24839fddb46811a03ca57c)