### PR TITLE
[nrf fromlist] samples: mcumgr: smp_svr: increase dfu throughput over…

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/overlay-bt.conf
@@ -1,19 +1,32 @@
 # Allow for large Bluetooth data packets.
-CONFIG_BT_L2CAP_TX_MTU=252
-CONFIG_BT_BUF_ACL_RX_SIZE=256
+CONFIG_BT_L2CAP_TX_MTU=498
+CONFIG_BT_BUF_ACL_RX_SIZE=502
+CONFIG_BT_BUF_ACL_TX_SIZE=502
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
 
-# Enable the Bluetooth (unauthenticated) and shell mcumgr transports.
+# Enable the Bluetooth mcumgr transport (unauthenticated).
 CONFIG_MCUMGR_SMP_BT=y
 CONFIG_MCUMGR_SMP_BT_AUTHEN=n
 CONFIG_MCUMGR_SMP_BT_CONN_PARAM_CONTROL=y
+
+# Enable the Shell mcumgr transport.
 CONFIG_MCUMGR_SMP_SHELL=y
+
+# Enable the mcumgr Packet Reassembly feature over Bluetooth and its configuration dependencies.
+# MCUmgr buffer size is optimized to fit one SMP packet divided into five Bluetooth Write Commands,
+# transmitted with the maximum possible MTU value: 498 bytes.
+CONFIG_MCUMGR_SMP_REASSEMBLY_BT=y
+CONFIG_MCUMGR_BUF_SIZE=2475
+CONFIG_OS_MGMT_MCUMGR_PARAMS=y
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=4096
 
 # Enable the LittleFS file system.
 CONFIG_FILE_SYSTEM=y
 CONFIG_FILE_SYSTEM_LITTLEFS=y
 
-# Add 256 bytes to accommodate upload command (lfs_stat overflows)
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
-
 # Enable file system commands
 CONFIG_MCUMGR_CMD_FS_MGMT=y
+
+# Enable the storage erase command.
+CONFIG_MCUMGR_GRP_ZEPHYR_BASIC=y
+CONFIG_MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE=y


### PR DESCRIPTION
… Bluetooth

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/45683

Adjusted Bluetooth parameters that have an impact on MTU and DLE
negotiation during a connection.

Enabled the Packet Reassembly feature from mcumgr libraries in the SMP
Server sample with the Bluetooth transport configuration. This change
should increase the overall throughput of the DFU process over
Bluetooth.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>