### PR TITLE
[nrf fromlist] doc/releases/3.1: Add notes on MCUMGR to zcbor

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -208,6 +208,13 @@ Libraries / Subsystems
 
 * Management
 
+  * MCUMGR has been migrated from using TinyCBOR, for CBOR encoding, to zcbor.
+  * MCUMGR :kconfig:option:`CONFIG_FS_MGMT_UL_CHUNK_SIZE` and
+    :kconfig:option:`CONFIG_IMG_MGMT_UL_CHUNK_SIZE` have been deprecated as,
+    with the introduction of zcbor, it is no longer needed to use an intermediate
+    buffer to copy data out of CBOR encoded buffer. The file/image chunk size
+    is now limited by :kconfig:option:`CONFIG_MCUMGR_BUF_SIZE` minus all the
+    other command required variables.
   * Added support for MCUMGR Parameters command, which can be used to obtain
     MCUMGR parameters; :kconfig:option:`CONFIG_OS_MGMT_MCUMGR_PARAMS` enables
     the command.


### PR DESCRIPTION
... transition

The commit adds release notes on MCUMGR transition from TinyCBOR
to zcbor, and deprecation of several Kconfig options that are
no longer needed.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>
(cherry picked from commit 1efc400474a5237bac6e64232d33ed00cca7fbb1)