### PR TITLE
subsys: nvs: Increased default NVS cache size to 512 B.

### DIFF
--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -19,7 +19,7 @@ config NVS_LOOKUP_CACHE
 
 config NVS_LOOKUP_CACHE_SIZE
 	int "Non-volatile Storage lookup cache size"
-	default 128
+	default 512
 	range 1 65536
 	depends on NVS_LOOKUP_CACHE
 	help


### PR DESCRIPTION
The default cache size is 128, what results in plenty of conflicts
in positions calculated by the CRC8 algorithm. It is solved by
increasing cache size, as it changes used algorithm to CRC16
and reduces number of conflicts.

Signed-off-by: Kamil Kasperczyk <kamil.kasperczyk@nordicsemi.no>

Commit is [nrf noup], as it modifies the code that was not yet merged to the upstream Zephyr and open PR cannot be modified due to owner vacation: https://github.com/zephyrproject-rtos/zephyr/pull/45769