### PR TITLE
[nrf fromlist] bluetooth: host: Fix reading current PHY when using ex…

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -967,16 +967,9 @@ static bool skip_auto_phy_update_on_conn_establishment(struct bt_conn *conn)
 	if (IS_ENABLED(CONFIG_BT_AUTO_PHY_UPDATE) &&
 	    IS_ENABLED(CONFIG_BT_EXT_ADV) &&
 	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
-		int err;
-
-		err = hci_le_read_phy(conn);
-		if (err) {
-			BT_WARN("Failed to read PHY (%d)", err);
-		} else {
-			if (conn->le.phy.tx_phy == BT_HCI_LE_PHY_2M &&
-			    conn->le.phy.rx_phy == BT_HCI_LE_PHY_2M) {
-				return true;
-			}
+		if (conn->le.phy.tx_phy == BT_HCI_LE_PHY_2M &&
+		    conn->le.phy.rx_phy == BT_HCI_LE_PHY_2M) {
+			return true;
 		}
 	}
 #else
@@ -1331,6 +1324,18 @@ void bt_hci_le_enh_conn_complete(struct bt_hci_evt_le_enh_conn_complete *evt)
 					&bt_dev.id_addr[conn->id]);
 		}
 	}
+
+#if defined(CONFIG_BT_USER_PHY_UPDATE)
+	if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
+	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+		int err;
+
+		err = hci_le_read_phy(conn);
+		if (err) {
+			BT_WARN("Failed to read PHY (%d)", err);
+		}
+	}
+#endif /* defined(CONFIG_BT_USER_PHY_UPDATE) */
 
 	bt_conn_set_state(conn, BT_CONN_CONNECTED);
 


### PR DESCRIPTION
…tended advertising

The current PHY is read only when automatic PHY
update procedure is enabled, 2M PHY is supported and
extended advertising is enabled and this is done after
application is notified about connection. This leads
to invalid connection info PHY data which always returns
1M PHY because when using extended advertising the connection
can be established on different PHY and host does not read
this value from the controller in most cases. In order to
have a current PHY value updated we need to read it in
connection complete event before the user application
is notified about connection.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/46113

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>