### PR TITLE
tfm: Add option for implementation custom reset handler with TF-M

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -324,7 +324,9 @@ if (CONFIG_BUILD_WITH_TFM)
     interface/interface.c
     )
   # Non-Secure interface to request system reboot
-  zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_PLATFORM src/reboot.c)
+  if (CONFIG_TFM_PARTITION_PLATFORM AND NOT CONFIG_TFM_PARTITION_PLATFORM_CUSTOM_REBOOT)
+    zephyr_library_sources(src/reboot.c)
+  endif()
   zephyr_library_sources_ifndef(CONFIG_TFM_PSA_TEST_NONE src/zephyr_tfm_psa_test.c)
 
   zephyr_include_directories(

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -167,6 +167,15 @@ config TFM_ITS_MAX_ASSET_SIZE
 	  Maximum size (in bytes) of a single asset to be stored in Internal Trusted
 	  Storage (ITS).
 
+config TFM_PARTITION_PLATFORM_CUSTOM_REBOOT
+	bool "Use custom reboot handler"
+	depends on TFM_PARTITION_PLATFORM
+	help
+	  Do not include the default zephyr implementation of calling the TF-M
+	  platform reset service.
+	  Instead the application will have to override the weak ARM
+	  implementation of sys_arch_reset().
+
 config TFM_BL2_NOT_SUPPORTED
 	bool
 	help


### PR DESCRIPTION
Zephyr adds a custom handler that overrides the weak function
sys_arch_reset when TF-M platform partition is enabled.

This takes away the option for the application to override the weak
definition for their platform or use-case.

Add an option that control whether this default reset handling is added
to the build.

Upstream PR:
https://github.com/zephyrproject-rtos/zephyr/pull/46133

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>