### PR TITLE
[nrf fromtree] ADXL362: Add DTS properties for low-power modes

### DIFF
--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -132,24 +132,6 @@ static int adxl362_software_reset(const struct device *dev)
 			       ADXL362_REG_SOFT_RESET, 1);
 }
 
-static int adxl362_set_power_mode(const struct device *dev, uint8_t mode)
-{
-	uint8_t old_power_ctl;
-	uint8_t new_power_ctl;
-	int ret;
-
-	ret = adxl362_get_reg(dev, &old_power_ctl, ADXL362_REG_POWER_CTL, 1);
-	if (ret) {
-		return ret;
-	}
-
-	new_power_ctl = old_power_ctl & ~ADXL362_POWER_CTL_MEASURE(0x3);
-	new_power_ctl = new_power_ctl |
-		      (mode *
-		       ADXL362_POWER_CTL_MEASURE(ADXL362_MEASURE_ON));
-	return adxl362_set_reg(dev, new_power_ctl, ADXL362_REG_POWER_CTL, 1);
-}
-
 #if defined(CONFIG_ADXL362_ACCEL_ODR_RUNTIME)
 /*
  * Output data rate map with allowed frequencies:
@@ -619,6 +601,7 @@ static const struct sensor_driver_api adxl362_api_funcs = {
 
 static int adxl362_chip_init(const struct device *dev)
 {
+	const struct adxl362_config *config = dev->config;
 	int ret;
 
 	/* Configures activity detection.
@@ -696,8 +679,9 @@ static int adxl362_chip_init(const struct device *dev)
 		return ret;
 	}
 
-	/* Places the device into measure mode. */
-	ret = adxl362_set_power_mode(dev, 1);
+	/* Places the device into measure mode, enable wakeup mode and autosleep if desired. */
+	LOG_DBG("setting pwrctl: 0x%02x", config->power_ctl);
+	ret = adxl362_set_reg(dev, config->power_ctl, ADXL362_REG_POWER_CTL, 1);
 	if (ret) {
 		return ret;
 	}
@@ -735,7 +719,7 @@ static int adxl362_init(const struct device *dev)
 
 	adxl362_get_reg(dev, &value, ADXL362_REG_PARTID, 1);
 	if (value != ADXL362_PART_ID) {
-		LOG_ERR("Failed: %d\n", value);
+		LOG_ERR("wrong part_id: %d\n", value);
 		return -ENODEV;
 	}
 
@@ -762,6 +746,9 @@ static int adxl362_init(const struct device *dev)
 
 static const struct adxl362_config adxl362_config = {
 	.bus = SPI_DT_SPEC_INST_GET(0, SPI_WORD_SET(8) | SPI_TRANSFER_MSB, 0),
+	.power_ctl = ADXL362_POWER_CTL_MEASURE(ADXL362_MEASURE_ON) |
+		(DT_INST_PROP(0, wakeup_mode) * ADXL362_POWER_CTL_WAKEUP) |
+		(DT_INST_PROP(0, autosleep) * ADXL362_POWER_CTL_AUTOSLEEP),
 #if defined(CONFIG_ADXL362_TRIGGER)
 	.interrupt = GPIO_DT_SPEC_INST_GET(0, int1_gpios),
 #endif

--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -177,6 +177,7 @@ struct adxl362_config {
 	uint8_t int1_config;
 	uint8_t int2_config;
 #endif
+	uint8_t power_ctl;
 };
 
 struct adxl362_data {

--- a/dts/bindings/sensor/adi,adxl362.yaml
+++ b/dts/bindings/sensor/adi,adxl362.yaml
@@ -15,3 +15,16 @@ properties:
         The INT1 signal defaults to active high as produced by the
         sensor.  The property value should ensure the flags properly
         describe the signal that is presented to the driver.
+
+    wakeup-mode:
+      type: boolean
+      description: |
+        This mode is intended for extremely low power consumption,
+        checking for motion only about six times a second.
+
+    autosleep:
+      type: boolean
+      description: |
+        Enter Wake-Up mode when inactivity is detected,
+        reenter Measurement mode when activity is detected.
+        Only applies for Linked and Loop mode, ignored otherwise.


### PR DESCRIPTION
This patch adds DTS properties for using wake-up mode
and the autosleep function to the ADXL362 driver.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>
(cherry picked from commit 3530fc088bd39ed67c00606cc40d9da4b8a6abdb)