### PR TITLE
[nrf noup] samples: mgmt: mcumgr: add hci_rpmsg child image config

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/child_image/hci_rpmsg.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/child_image/hci_rpmsg.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+CONFIG_BT_MAX_CONN=2
+CONFIG_BT_BUF_ACL_RX_SIZE=502
+CONFIG_BT_BUF_ACL_TX_SIZE=502
+CONFIG_BT_CTLR_DATA_LENGTH_MAX=251


### PR DESCRIPTION
Added a configuration file for the HCI RPMsg child image that is necessary
for multi-core targets.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>