### PR TITLE
[nrf fromtree] drivers: gpio: nrf: Fix pin no for getting GPIOTE channel

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -125,7 +125,7 @@ static int gpio_nrfx_pin_configure(const struct device *port, gpio_pin_t pin,
 		.trigger = NRFX_GPIOTE_TRIGGER_NONE
 	};
 
-	err = nrfx_gpiote_channel_get(pin, &ch);
+	err = nrfx_gpiote_channel_get(abs_pin, &ch);
 	free_ch = (err == NRFX_SUCCESS);
 
 	/* Remove previously configured trigger when pin is reconfigured. */


### PR DESCRIPTION
Incorrect GPIOTE channel was being freed because the pin number
being used is not the absolute pin but the pin within the port.

Origin commit: 4b3fe99b83e393777dedc4200c7209fcdf31a77f

Ref. NCSDK-15818.

Signed-off-by: Wael Barakat <waelsbarakat@gmail.com>