### PR TITLE
Fixes needed for removal of flash NOP device from sdk-nrf

### DIFF
--- a/subsys/mgmt/mcumgr/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/CMakeLists.txt
@@ -22,3 +22,11 @@ if (CONFIG_FS_MGMT_CHECKSUM_HASH AND CONFIG_FS_MGMT_HASH_SHA256)
         zephyr_link_libraries(mbedTLS)
     endif()
 endif()
+
+if (CONFIG_BOOT_IMAGE_ACCESS_HOOKS)
+    zephyr_include_directories(
+        ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/bootutil/include
+        ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr/include
+    )
+    zephyr_library_sources(bootutil_hooks/nrf53_hooks.c)
+endif()

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -6,6 +6,7 @@ menuconfig MCUMGR
 	bool "mcumgr Support"
 	select NET_BUF
 	select ZCBOR
+	select BOOT_IMAGE_ACCESS_HOOKS if SOC_NRF5340_CPUAPP_QKAA
 	help
 	  This option enables the mcumgr management library.
 

--- a/subsys/mgmt/mcumgr/bootutil_hooks/nrf53_hooks.c
+++ b/subsys/mgmt/mcumgr/bootutil_hooks/nrf53_hooks.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include "bootutil/bootutil_public.h"
+
+int boot_read_swap_state_primary_slot_hook(int image_index,
+		struct boot_swap_state *state)
+{
+	if (image_index == 1) {
+		/* Pretend that primary slot of image 1 unpopulated */
+		state->magic = BOOT_MAGIC_UNSET;
+		state->swap_type = BOOT_SWAP_TYPE_NONE;
+		state->image_num = image_index;
+		state->copy_done = BOOT_FLAG_UNSET;
+		state->image_ok = BOOT_FLAG_UNSET;
+
+		/* Prevent bootutil from trying to obtain true info */
+		return 0;
+	}
+
+	return BOOT_HOOK_REGULAR;
+}


### PR DESCRIPTION
One commit: adds [nrf noup] patch to mcumgr that provides bootutil hooks, which simulate the non-accessible slot-1/primary slot.