### PR TITLE
[nrf fromtree] Several bug fixes related to pinctrl and updated PWM API

### DIFF
--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -89,7 +89,7 @@
 
 &sw_pwm {
 	status ="okay";
-	channel-gpios = <&gpio0 21 0>;
+	channel-gpios = <&gpio0 21 PWM_POLARITY_INVERTED>;
 	clock-prescaler = <8>;
 };
 

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
@@ -57,7 +57,7 @@
 
 &sw_pwm {
 	status ="okay";
-	channel-gpios = <&gpio0 21 0>;
+	channel-gpios = <&gpio0 21 PWM_POLARITY_INVERTED>;
 	clock-prescaler = <8>;
 };
 

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
@@ -76,6 +76,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;
@@ -84,6 +85,12 @@
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 	};
+};
+
+&sw_pwm {
+	status ="okay";
+	channel-gpios = <&gpio0 13 PWM_POLARITY_INVERTED>;
+	clock-prescaler = <8>;
 };
 
 &gpiote {

--- a/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
@@ -107,7 +107,9 @@ child-binding:
           Pin output drive mode. Available drive modes are pre-defined in
           nrf-pinctrl.h. Note that extra modes may not be available on certain
           devices. Defaults to standard mode for 0 and 1 (NRF_DRIVE_S0S1), the
-          SoC default.
+          SoC default, except for the "nordic,nrf-twi" and "nordic,nrf-twim"
+          nodes where NRF_DRIVE_S0S1 is always overridden with NRF_DRIVE_S0D1
+          (standard '0', disconnect '1').
 
       nordic,invert:
         type: boolean


### PR DESCRIPTION
*[nrf fromtree] boards: nrf: Fix sw_pwm channel definitions*

This is a follow-up to commit f301dc2382dca20c879fe2d73676fc61524e90b6.

Add missing GPIO_ACTIVE_LOW flag to sw_pwm channel definitions for
nRF51 DK and nRF51 Dongle so that the initial state of their PWM
outputs is properly set up.
Add missing sw_pwm channel definition in the nrf52833dk_nrf52820 target
that was modified in 793362ae5a9e02c94d03fbf8736cf19b473965e3 instead
of in f301dc2382dca20c879fe2d73676fc61524e90b6. Add also the pwm-led0
alias for its PWM LED so that it can be used with standard samples.

*[nrf fromtree] drivers: pinctrl_nrf: Use S0D1 drive by default for TWI/TWIM pins*

The default S0S1 drive setting is not suitable for TWI/TWIM pins.
Override it with S0D1 as for some SoCs (e.g. nRF52833) without
this the peripheral will not work properly.

*[nrf fromtree] drivers: i2c: nrfx: Fix i2c_recover_bus implementation for PINCTRL*

When PINCTRL is enabled, the SCL and SDA pin numbers are not available
in configuration structures used for nrfx drivers initialization.
In this case, these pin numbers need to be obtained from peripheral
registers.