### PR TITLE
[nrf fromtree] ADXL362: add dynamic inact time setting

### DIFF
--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -321,6 +321,12 @@ static int adxl362_attr_set(const struct device *dev,
 	case SENSOR_ATTR_UPPER_THRESH:
 	case SENSOR_ATTR_LOWER_THRESH:
 		return adxl362_attr_set_thresh(dev, chan, attr, val);
+	case SENSOR_ATTR_HYSTERESIS:
+	{
+		uint16_t timeout = val->val1;
+
+		return adxl362_set_reg(dev, (timeout & 0x7FF), ADXL362_REG_TIME_INACT_L, 2);
+	}
 	default:
 		/* Do nothing */
 		break;


### PR DESCRIPTION
This patch extends the adxl362 driver by adding an option
to change the inactivity detection timeout at runtime.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>
(cherry picked from commit 3d2b04c9a8a76b7e30dbb4e536821a89760f199a)