### PR TITLE
manifest: PSA arch tests with increased timeout

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -235,7 +235,7 @@ manifest:
       groups:
         - tee
     - name: psa-arch-tests
-      revision: a81f9da287569f169d60026916952641b233faa8
+      revision: f4fc2442b8e29e2a03d9899e46e5a3ea3df8c2c9
       path: modules/tee/tf-m/psa-arch-tests
       groups:
         - tee


### PR DESCRIPTION
This brings a change in the PSA arch tests where
we increase the timeout to 90 seconds for Nordic
devices. Since we run RSA key generation tests
this is necessary.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>
