### PR TITLE
[nrf fromtree] scripts: set_assignee: handle exceptions

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -9,6 +9,7 @@ import os
 import time
 import datetime
 from github import Github, GithubException
+from github.GithubException import UnknownObjectException
 from collections import defaultdict
 
 TOP_DIR = os.path.join(os.path.dirname(__file__))
@@ -155,10 +156,13 @@ def process_pr(gh, maintainer_file, number):
             page += 1
 
         for c in collab:
-            u = gh.get_user(c)
-            if pr.user != u and gh_repo.has_in_collaborators(u):
-                if u not in existing_reviewers:
-                    reviewers.append(c)
+            try:
+                u = gh.get_user(c)
+                if pr.user != u and gh_repo.has_in_collaborators(u):
+                    if u not in existing_reviewers:
+                        reviewers.append(c)
+            except UnknownObjectException as e:
+                log(f"Can't get user '{c}', account does not exist anymore? ({e})")
 
         if reviewers:
             try:


### PR DESCRIPTION
Deal with exceptions that happen when a user does not exist on GH.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
(cherry picked from commit 60271524087bb4382c8b4db0f2e17a87e4120065)
Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>