### PR TITLE
[nrf noup] wifi_mgmt: Add support for non-offload TCP/IP

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -1088,7 +1088,7 @@ static void esp_iface_init(struct net_if *iface)
 }
 
 static const struct net_wifi_mgmt_offload esp_api = {
-	.iface_api.init = esp_iface_init,
+	.eth_api.iface_api.init = esp_iface_init,
 	.scan		= esp_mgmt_scan,
 	.connect	= esp_mgmt_connect,
 	.disconnect	= esp_mgmt_disconnect,

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -679,7 +679,7 @@ static int eswifi_init(const struct device *dev)
 }
 
 static const struct net_wifi_mgmt_offload eswifi_offload_api = {
-	.iface_api.init = eswifi_iface_init,
+	.eth_api.iface_api.init = eswifi_iface_init,
 	.scan		= eswifi_mgmt_scan,
 	.connect	= eswifi_mgmt_connect,
 	.disconnect	= eswifi_mgmt_disconnect,

--- a/drivers/wifi/simplelink/simplelink.c
+++ b/drivers/wifi/simplelink/simplelink.c
@@ -264,7 +264,7 @@ static void simplelink_iface_init(struct net_if *iface)
 }
 
 static const struct net_wifi_mgmt_offload simplelink_api = {
-	.iface_api.init = simplelink_iface_init,
+	.eth_api.iface_api.init = simplelink_iface_init,
 	.scan		= simplelink_mgmt_scan,
 	.connect	= simplelink_mgmt_connect,
 	.disconnect	= simplelink_mgmt_disconnect,

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -1100,7 +1100,7 @@ static void winc1500_iface_init(struct net_if *iface)
 }
 
 static const struct net_wifi_mgmt_offload winc1500_api = {
-	.iface_api.init = winc1500_iface_init,
+	.eth_api.iface_api.init = winc1500_iface_init,
 	.scan		= winc1500_mgmt_scan,
 	.connect	= winc1500_mgmt_connect,
 	.disconnect	= winc1500_mgmt_disconnect,

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -12,6 +12,7 @@
 #ifndef ZEPHYR_INCLUDE_NET_WIFI_MGMT_H_
 #define ZEPHYR_INCLUDE_NET_WIFI_MGMT_H_
 
+#include <zephyr/net/ethernet.h>
 #include <zephyr/net/net_mgmt.h>
 #include <zephyr/net/wifi.h>
 
@@ -118,12 +119,12 @@ typedef void (*scan_result_cb_t)(struct net_if *iface, int status,
 
 struct net_wifi_mgmt_offload {
 	/**
-	 * Mandatory to get in first position.
-	 * A network device should indeed provide a pointer on such
-	 * net_if_api structure. So we make current structure pointer
-	 * that can be casted to a net_if_api structure pointer.
-	 */
-	struct net_if_api iface_api;
+	* Mandatory to get in first position.
+	* A network device should indeed provide a pointer on such
+	* ethernet_api structure. So we make current structure pointer
+	* that can be casted to a ethernet_api structure pointer.
+	*/
+	struct ethernet_api eth_api;
 
 	/* cb parameter is the cb that should be called for each
 	 * result by the driver. The wifi mgmt part will take care of
@@ -141,7 +142,7 @@ struct net_wifi_mgmt_offload {
 /* Make sure that the network interface API is properly setup inside
  * Wifi mgmt offload API struct (it is the first one).
  */
-BUILD_ASSERT(offsetof(struct net_wifi_mgmt_offload, iface_api) == 0);
+BUILD_ASSERT(offsetof(struct net_wifi_mgmt_offload, eth_api) == 0);
 
 #ifdef CONFIG_WIFI_OFFLOAD
 


### PR DESCRIPTION
Wi-Fi offload has two parts control and data, when wifi_mgmt is used
for control the data part if assumed to be offloaded (WIFI/NET_OFFLOAD),
but some drivers do not support that assumption.

Extend the wifi_mgmt to take in a full Ethernet APIs so that wifi_mgmt
can be used with native TCP/IP stack.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>