### PR TITLE
[backport-v2.0][nrf fromtree] drivers: pinctrl_nrf: Fix nrf_pin_configure() implemen…

### DIFF
--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -95,8 +95,8 @@ __unused static void nrf_pin_configure(pinctrl_soc_pin_t pin,
 		input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 	}
 
-	nrf_gpio_cfg(NRF_GET_PIN(pin), dir, input, NRF_GET_PULL(pin),
-		     NRF_GET_DRIVE(pin), NRF_GPIO_PIN_NOSENSE);
+	nrf_gpio_cfg(NRF_GET_PIN(pin), dir, input, NRF_GET_PULL(pin), drive,
+		     NRF_GPIO_PIN_NOSENSE);
 }
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,


### PR DESCRIPTION
…tation

This is a follow-up to commit fd0767557439d04c4a220a9857e901d8d71498db.

The above commit was supposed to introduce overriding of the S0S1
drive setting with S0D1 for TWI/TWIM peripherals, but since it did
not properly update the `nrf_pin_configure()` function (the `drive`
parameter was only added in the function signature, but then it was
not used...), the drive setting was in fact not overridden.
This commit corrects this embarrassing oversight.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>
(cherry picked from commit 32a87215d7aa97191097357f602237f7da4a3536)