### PR TITLE
[nrf fromtree] Bluetooth: Mesh: Use mesh settings API only if setting...

### DIFF
--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -728,9 +728,8 @@ void bt_mesh_cdb_clear(void)
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		update_cdb_net_settings();
+		bt_mesh_settings_store_pending();
 	}
-
-	bt_mesh_settings_store_pending();
 }
 
 void bt_mesh_cdb_iv_update(uint32_t iv_index, bool iv_update)


### PR DESCRIPTION
s are enabled

Don't call bt_mesh_settings_store_pending if CONFIG_BT_SETTINGS is not
enabled.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>
(cherry picked from commit 1659ac43921634d7516d0af02631877c095344dc)
Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>