### PR TITLE
logging: shell: Fix missing timestamp in log messages on shell backend

### DIFF
--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -6,7 +6,6 @@ if(NOT CONFIG_LOG_MODE_MINIMAL)
     log_core.c
     log_mgmt.c
     log_msg.c
-    log_output.c
   )
 
   zephyr_sources_ifdef(

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -228,6 +228,7 @@ config SHELL_LOG_BACKEND
 	bool "Shell log backend"
 	depends on LOG && !LOG_MODE_MINIMAL
 	select MPSC_PBUF
+	select LOG_OUTPUT
 	default y if LOG
 	help
 	  When enabled, backend will use the shell for logging.


### PR DESCRIPTION
Due to missing dependencies log_output module was not enabled when used with shell.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/49448

Ref. NCSDK-16574