### PR TITLE
[nrf fromtree] Improvements to scripts/ci/check_compliance.py

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -18,11 +18,6 @@ import magic
 import shlex
 from pathlib import Path
 
-# '*' makes it italic
-EDIT_TIP = "\n\n*Tip: The bot edits this comment instead of posting a new " \
-           "one, so you can check the comment's history to see earlier " \
-           "messages.*"
-
 logger = None
 
 # This ends up as None when we're not running in a Zephyr tree

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -27,6 +27,15 @@ logger = None
 
 # This ends up as None when we're not running in a Zephyr tree
 ZEPHYR_BASE = os.environ.get('ZEPHYR_BASE')
+if not ZEPHYR_BASE:
+    # Let the user run this script as ./scripts/ci/check_compliance.py without
+    #  making them set ZEPHYR_BASE.
+    ZEPHYR_BASE = str(Path(__file__).resolve().parents[2])
+
+    # Propagate this decision to child processes.
+    os.environ['ZEPHYR_BASE'] = ZEPHYR_BASE
+
+    print(f'ZEPHYR_BASE unset, using "{ZEPHYR_BASE}"')
 
 
 def git(*args, cwd=None):

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -142,7 +142,7 @@ class ComplianceTest:
         if self.case.result:
             msg += "\n\nFailures before skip: " + self.case.result[0]._elem.text
 
-        self.case.result = Skipped(msg, "skipped")
+        self.case.result = [Skipped(msg, "skipped")]
 
         raise EndTest
 

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1074,6 +1074,8 @@ def _main(args):
 
     init_logs(args.loglevel)
 
+    logger.info(f'Running tests on commit range {COMMIT_RANGE}')
+
     if args.list:
         for testcase in ComplianceTest.__subclasses__():
             print(testcase.name)

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -736,7 +736,7 @@ class Codeowners(ComplianceTest):
             # the entire tree. 2. run the former always.
             return
 
-        logging.info("If this takes too long then cleanup and try again")
+        logger.info("If this takes too long then cleanup and try again")
         patrn2files = self.ls_owned_files(codeowners)
 
         # The way git finds Renames and Copies is not "exact science",
@@ -744,7 +744,7 @@ class Codeowners(ComplianceTest):
         # Addition instead.
         new_files = git("diff", "--name-only", "--diff-filter=ARC",
                         COMMIT_RANGE).splitlines()
-        logging.debug("New files %s", new_files)
+        logger.debug("New files %s", new_files)
 
         # Convert to pathlib.Path string representation (e.g.,
         # backslashes 'dir1\dir2\' on Windows) to be consistent
@@ -756,10 +756,10 @@ class Codeowners(ComplianceTest):
             f_is_owned = False
 
             for git_pat, owned in patrn2files.items():
-                logging.debug("Scanning %s for %s", git_pat, newf)
+                logger.debug("Scanning %s for %s", git_pat, newf)
 
                 if newf in owned:
-                    logging.info("%s matches new file %s", git_pat, newf)
+                    logger.info("%s matches new file %s", git_pat, newf)
                     f_is_owned = True
                     # Unlike github, we don't care about finding any
                     # more specific owner.
@@ -1017,9 +1017,6 @@ class Identity(ComplianceTest):
 def init_logs(cli_arg):
     # Initializes logging
 
-    # TODO: there may be a shorter version thanks to:
-    # logging.basicConfig(...)
-
     global logger
 
     level = os.environ.get('LOG_LEVEL', "WARN")
@@ -1029,9 +1026,9 @@ def init_logs(cli_arg):
 
     logger = logging.getLogger('')
     logger.addHandler(console)
-    logger.setLevel(cli_arg if cli_arg else level)
+    logger.setLevel(cli_arg or level)
 
-    logging.info("Log init completed, level=%s",
+    logger.info("Log init completed, level=%s",
                  logging.getLevelName(logger.getEffectiveLevel()))
 
 
@@ -1054,7 +1051,9 @@ def parse_args():
     parser.add_argument('-l', '--list', action="store_true",
                         help="List all checks and exit")
 
-    parser.add_argument("-v", "--loglevel", help="python logging level")
+    parser.add_argument("-v", "--loglevel", choices=['DEBUG', 'INFO', 'WARNING',
+                                                     'ERROR', 'CRITICAL'],
+                        help="python logging level")
 
     parser.add_argument('-m', '--module', action="append", default=[],
                         help="Checks to run. All checks by default.")

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1034,16 +1034,17 @@ def init_logs(cli_arg):
 
 
 def parse_args():
+
+    default_range = 'HEAD~1..HEAD'
     parser = argparse.ArgumentParser(
         description="Check for coding style and documentation warnings.")
-    parser.add_argument('-c', '--commits', default="HEAD~1..",
-                        help='''Commit range in the form: a..[b], default is
-                        HEAD~1..HEAD''')
+    parser.add_argument('-c', '--commits', default=default_range,
+                        help=f'''Commit range in the form: a..[b], default is
+                        {default_range}''')
     parser.add_argument('-r', '--repo', default=None,
                         help="GitHub repository")
     parser.add_argument('-p', '--pull-request', default=0, type=int,
                         help="Pull request number")
-    parser.add_argument('-S', '--sha', default=None, help="Commit SHA")
     parser.add_argument('-o', '--output', default="compliance.xml",
                         help='''Name of outfile in JUnit format,
                         default is ./compliance.xml''')

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1041,27 +1041,18 @@ def parse_args():
     parser.add_argument('-c', '--commits', default=default_range,
                         help=f'''Commit range in the form: a..[b], default is
                         {default_range}''')
-    parser.add_argument('-r', '--repo', default=None,
-                        help="GitHub repository")
-    parser.add_argument('-p', '--pull-request', default=0, type=int,
-                        help="Pull request number")
     parser.add_argument('-o', '--output', default="compliance.xml",
                         help='''Name of outfile in JUnit format,
                         default is ./compliance.xml''')
-
     parser.add_argument('-l', '--list', action="store_true",
                         help="List all checks and exit")
-
     parser.add_argument("-v", "--loglevel", choices=['DEBUG', 'INFO', 'WARNING',
                                                      'ERROR', 'CRITICAL'],
                         help="python logging level")
-
     parser.add_argument('-m', '--module', action="append", default=[],
                         help="Checks to run. All checks by default.")
-
     parser.add_argument('-e', '--exclude-module', action="append", default=[],
                         help="Do not run the specified checks")
-
     parser.add_argument('-j', '--previous-run', default=None,
                         help='''Pre-load JUnit results in XML format
                         from a previous run and combine with new results.''')


### PR DESCRIPTION
Merged:  https://github.com/zephyrproject-rtos/zephyr/pull/49418

nrfxlib and lwm2m teams are blocked without compliance script upgrades now. :/

- [nrf fromtree] scripts/ci/check_compliance.py: Allow to run w/ZEPHYR_BASE
- [nrf fromtree] scripts: compliance: Remove unused variable
- [nrf fromtree] scripts: compliance: Complete transition to junitparser v2
- [nrf fromtree] scripts: compliance: Clean up logging
- [nrf fromtree] scripts: compliance: Tiny cleanup for -c
- [nrf fromtree] scripts: compliance: Remove unused command-line args
- [nrf fromtree] scripts: compliance: Add commit range info output

