### PR TITLE
[nrf fromtree] Bluetooth: Mesh: Health_cli: Fix async cmd rsp

### DIFF
--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -487,7 +487,7 @@ int bt_mesh_health_cli_fault_clear(struct bt_mesh_health_cli *cli, struct bt_mes
 	net_buf_simple_add_le16(&msg, cid);
 
 	return model_ackd_send(cli->model, ctx, &msg,
-			       (!test_id && (!faults || !fault_count)) ? &cli->ack_ctx : NULL,
+			       (!test_id && (!faults || !fault_count)) ? NULL : &cli->ack_ctx,
 			       OP_HEALTH_FAULT_STATUS, &param);
 }
 
@@ -518,7 +518,7 @@ int bt_mesh_health_cli_fault_get(struct bt_mesh_health_cli *cli, struct bt_mesh_
 	net_buf_simple_add_le16(&msg, cid);
 
 	return model_ackd_send(cli->model, ctx, &msg,
-			       (!test_id && (!faults || !fault_count)) ? &cli->ack_ctx : NULL,
+			       (!test_id && (!faults || !fault_count)) ? NULL : &cli->ack_ctx,
 			       OP_HEALTH_FAULT_STATUS, &param);
 }
 


### PR DESCRIPTION
Swaps response scheme for Fault_get & Fault_clear command so that it
aligns with description of the documentation.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>
(cherry picked from 348d9771241bf3eaade1a4cd69ea6009ba334346)
Signed-off-by: Alperen Sener <alperen.sener@nordicsemi.no>