### PR TITLE
[nrf fromlist] Replace nrfx deprecated API for new one 

### DIFF
--- a/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
+++ b/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
@@ -236,7 +236,7 @@ static int sys_clock_driver_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	/* FIXME switch to 1 MHz once this is fixed in QEMU */
-	nrf_timer_frequency_set(TIMER, NRF_TIMER_FREQ_2MHz);
+	nrf_timer_prescaler_set(TIMER, NRF_TIMER_FREQ_2MHz);
 	nrf_timer_bit_width_set(TIMER, NRF_TIMER_BIT_WIDTH_32);
 
 	IRQ_CONNECT(TIMER0_IRQn, 1, timer0_nrf_isr, 0, 0);

--- a/drivers/counter/counter_nrfx_timer.c
+++ b/drivers/counter/counter_nrfx_timer.c
@@ -291,7 +291,7 @@ static int init_timer(const struct device *dev,
 
 	nrf_timer_bit_width_set(reg, config->bit_width);
 	nrf_timer_mode_set(reg, config->mode);
-	nrf_timer_frequency_set(reg, config->freq);
+	nrf_timer_prescaler_set(reg, config->freq);
 
 	nrf_timer_cc_set(reg, TOP_CH, counter_get_max_top_value(dev));
 

--- a/drivers/display/display_nrf_led_matrix.c
+++ b/drivers/display/display_nrf_led_matrix.c
@@ -509,7 +509,7 @@ static int instance_init(const struct device *dev)
 	}
 
 	nrf_timer_bit_width_set(dev_config->timer, NRF_TIMER_BIT_WIDTH_16);
-	nrf_timer_frequency_set(dev_config->timer, TIMER_CLK_CONFIG);
+	nrf_timer_prescaler_set(dev_config->timer, TIMER_CLK_CONFIG);
 	nrf_timer_cc_set(dev_config->timer, 0, PIXEL_PERIOD);
 	nrf_timer_shorts_set(dev_config->timer,
 			     NRF_TIMER_SHORT_COMPARE0_STOP_MASK |

--- a/soc/arm/nordic_nrf/common/soc_secure.c
+++ b/soc/arm/nordic_nrf/common/soc_secure.c
@@ -12,8 +12,8 @@
 #include "tfm_platform_api.h"
 #include "tfm_ioctl_api.h"
 
-#if defined(GPIO_PIN_CNF_MCUSEL_Msk)
-void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_mcusel_t mcu)
+#if NRF_GPIO_HAS_SEL
+void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_sel_t mcu)
 {
 	uint32_t result;
 	enum tfm_platform_err_t err;
@@ -22,7 +22,7 @@ void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_mcusel_t m
 	__ASSERT(err == TFM_PLATFORM_ERR_SUCCESS, "TFM platform error (%d)", err);
 	__ASSERT(result == 0, "GPIO service error (%d)", result);
 }
-#endif /* defined(GPIO_PIN_CNF_MCUSEL_Msk) */
+#endif /* NRF_GPIO_HAS_SEL */
 
 int soc_secure_mem_read(void *dst, void *src, size_t len)
 {

--- a/soc/arm/nordic_nrf/common/soc_secure.h
+++ b/soc/arm/nordic_nrf/common/soc_secure.h
@@ -9,8 +9,8 @@
 #include <hal/nrf_ficr.h>
 
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
-#if defined(GPIO_PIN_CNF_MCUSEL_Msk)
-void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_mcusel_t mcu);
+#if NRF_GPIO_HAS_SEL
+void soc_secure_gpio_pin_mcu_select(uint32_t pin_number, nrf_gpio_pin_sel_t mcu);
 #endif
 
 int soc_secure_mem_read(void *dst, void *src, size_t len);
@@ -48,13 +48,13 @@ static inline int soc_secure_mem_read(void *dst, void *src, size_t len)
 	return 0;
 }
 
-#if defined(GPIO_PIN_CNF_MCUSEL_Msk)
+#if NRF_GPIO_HAS_SEL
 static inline void soc_secure_gpio_pin_mcu_select(uint32_t pin_number,
-						  nrf_gpio_pin_mcusel_t mcu)
+						  nrf_gpio_pin_sel_t mcu)
 {
-	nrf_gpio_pin_mcu_select(pin_number, mcu);
+	nrf_gpio_pin_control_select(pin_number, mcu);
 }
-#endif /* defined(GPIO_PIN_CNF_MCUSEL_Msk) */
+#endif /* NRF_GPIO_HAS_SEL */
 
 #if defined(CONFIG_SOC_HFXO_CAP_INTERNAL)
 static inline uint32_t soc_secure_read_xosc32mtrim(void)

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -133,8 +133,8 @@ static int nordicsemi_nrf53_init(const struct device *arg)
 	 * This is handled by the TF-M platform so we skip it when TF-M is
 	 * enabled.
 	 */
-	nrf_gpio_pin_mcu_select(PIN_XL1, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
-	nrf_gpio_pin_mcu_select(PIN_XL2, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
+	nrf_gpio_pin_control_select(PIN_XL1, NRF_GPIO_PIN_SEL_PERIPHERAL);
+	nrf_gpio_pin_control_select(PIN_XL2, NRF_GPIO_PIN_SEL_PERIPHERAL);
 #endif /* !defined(CONFIG_BUILD_WITH_TFM) */
 #endif /* defined(CONFIG_SOC_ENABLE_LFXO) */
 #if defined(CONFIG_SOC_HFXO_CAP_INTERNAL)
@@ -175,7 +175,7 @@ static int nordicsemi_nrf53_init(const struct device *arg)
 	};
 
 	for (int i = 0; i < ARRAY_SIZE(forwarded_psels); i++) {
-		soc_secure_gpio_pin_mcu_select(forwarded_psels[i], NRF_GPIO_PIN_MCUSEL_NETWORK);
+		soc_secure_gpio_pin_mcu_select(forwarded_psels[i], NRF_GPIO_PIN_SEL_NETWORK);
 	}
 
 #endif

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
@@ -35,16 +35,16 @@
 	(defined(CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP_NS) && defined(CONFIG_BUILD_WITH_TFM))
 #define DEBUG_SETUP() \
 	do { \
-		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX0, NRF_GPIO_PIN_MCUSEL_NETWORK); \
-		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX1, NRF_GPIO_PIN_MCUSEL_NETWORK); \
-		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX2, NRF_GPIO_PIN_MCUSEL_NETWORK); \
-		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX3, NRF_GPIO_PIN_MCUSEL_NETWORK); \
-		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX4, NRF_GPIO_PIN_MCUSEL_NETWORK); \
-		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX5, NRF_GPIO_PIN_MCUSEL_NETWORK); \
-		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX6, NRF_GPIO_PIN_MCUSEL_NETWORK); \
-		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX7, NRF_GPIO_PIN_MCUSEL_NETWORK); \
-		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX8, NRF_GPIO_PIN_MCUSEL_NETWORK); \
-		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX9, NRF_GPIO_PIN_MCUSEL_NETWORK); \
+		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX0, NRF_GPIO_PIN_SEL_NETWORK); \
+		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX1, NRF_GPIO_PIN_SEL_NETWORK); \
+		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX2, NRF_GPIO_PIN_SEL_NETWORK); \
+		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX3, NRF_GPIO_PIN_SEL_NETWORK); \
+		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX4, NRF_GPIO_PIN_SEL_NETWORK); \
+		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX5, NRF_GPIO_PIN_SEL_NETWORK); \
+		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX6, NRF_GPIO_PIN_SEL_NETWORK); \
+		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX7, NRF_GPIO_PIN_SEL_NETWORK); \
+		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX8, NRF_GPIO_PIN_SEL_NETWORK); \
+		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX9, NRF_GPIO_PIN_SEL_NETWORK); \
 	} while (0)
 #endif /* CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP */
 #elif defined(CONFIG_BOARD_NRF52840DK_NRF52840) || \

--- a/tests/drivers/timer/nrf_rtc_timer/src/main.c
+++ b/tests/drivers/timer/nrf_rtc_timer/src/main.c
@@ -31,7 +31,7 @@ static void init_zli_timer0(void)
 {
 	nrf_timer_mode_set(NRF_TIMER0, NRF_TIMER_MODE_TIMER);
 	nrf_timer_bit_width_set(NRF_TIMER0, NRF_TIMER_BIT_WIDTH_32);
-	nrf_timer_frequency_set(NRF_TIMER0, NRF_TIMER_FREQ_1MHz);
+	nrf_timer_prescaler_set(NRF_TIMER0, NRF_TIMER_FREQ_1MHz);
 	nrf_timer_cc_set(NRF_TIMER0, 0, 100);
 	nrf_timer_int_enable(NRF_TIMER0, NRF_TIMER_INT_COMPARE0_MASK);
 	nrf_timer_shorts_enable(NRF_TIMER0,


### PR DESCRIPTION
With the release of nrfx2.9 some API become deprecated
(see https://github.com/NordicSemiconductor/nrfx/blob/v2.9.0/CHANGELOG.md).
This PR replaces deprecated API with suggested in CHANGELOG

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/49581