### PR TITLE
[nrf noup] wifi_stats: Use nRF Wi-Fi management

### DIFF
--- a/subsys/net/ip/Kconfig.stats
+++ b/subsys/net/ip/Kconfig.stats
@@ -127,7 +127,7 @@ config NET_STATISTICS_POWER_MANAGEMENT
 
 config NET_STATISTICS_WIFI
 	bool "Wi-Fi statistics"
-	depends on NET_L2_WIFI_MGMT
+	depends on NET_L2_WIFI_MGMT || NET_L2_NRF_WIFI_MGMT
 	default y
 	help
 	  Keep track of Wi-Fi related statistics. Note that this


### PR DESCRIPTION
Until we merge with Zephyr's Wi-Fi management, use nRF Wi-Fi
management for Wi-Fi stats.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>