### PR TITLE
[nrf noup] Bluetooth: BT_L2CAP_ECRED is no longer experimental

### DIFF
--- a/subsys/bluetooth/host/Kconfig.l2cap
+++ b/subsys/bluetooth/host/Kconfig.l2cap
@@ -49,7 +49,6 @@ config BT_L2CAP_DYNAMIC_CHANNEL
 
 config BT_L2CAP_ECRED
 	bool "L2CAP Enhanced Credit Based Flow Control support [EXPERIMENTAL]"
-	select EXPERIMENTAL
 	depends on BT_L2CAP_DYNAMIC_CHANNEL
 	help
 	  This option enables support for LE Connection oriented Channels with


### PR DESCRIPTION
BT_L2CAP_ECRED is not marked as experimental upstream and we qualify it
downstream.

To be squashed with 1e8c632358761d97cf2d659eb9fdc316b4558547 in the next
upmerge.

Signed-off-by: Herman Berget <herman.berget@nordicsemi.no>