### PR TITLE
drivers: timer: Add function to force exit idle.

### DIFF
--- a/doc/kernel/services/interrupts.rst
+++ b/doc/kernel/services/interrupts.rst
@@ -185,6 +185,7 @@ APIs inside a zero-latency interrupt context is responsible for directly
 verifying correct behavior). Zero-latency interrupts may not modify any data
 inspected by kernel APIs invoked from normal Zephyr contexts and shall not
 generate exceptions that need to be handled synchronously (e.g. kernel panic).
+Macro ISR_DIRECT_PM should not be used with zero-latency interrupts.
 
 .. important::
     Zero-latency interrupts are supported on an architecture-specific basis.

--- a/drivers/timer/cortex_m_systick.c
+++ b/drivers/timer/cortex_m_systick.c
@@ -261,6 +261,11 @@ void sys_clock_idle_exit(void)
 	}
 }
 
+void sys_clock_zli_idle_exit(void)
+{
+	SysTick->CTRL |= SysTick_CTRL_ENABLE_Msk;
+}
+
 void sys_clock_disable(void)
 {
 	SysTick->CTRL &= ~SysTick_CTRL_ENABLE_Msk;

--- a/drivers/timer/sys_clock_init.c
+++ b/drivers/timer/sys_clock_init.c
@@ -25,3 +25,7 @@ void __weak sys_clock_set_timeout(int32_t ticks, bool idle)
 void __weak sys_clock_idle_exit(void)
 {
 }
+
+void __weak sys_clock_zli_idle_exit(void)
+{
+}


### PR DESCRIPTION
When using with ZLI, we just want to force out of idle at the end of ISR.

Signed-off-by: Azizah Ibrahim <azizah.ibrahim@nordicsemi.no>