### PR TITLE
[nrf fromtree] Python tool version change: Breathe & Spinx

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -280,8 +280,8 @@ graphviz_dot_args = [
 # -- Linkcheck options ----------------------------------------------------
 
 extlinks = {
-    "jira": ("https://jira.zephyrproject.org/browse/%s", ""),
-    "github": ("https://github.com/zephyrproject-rtos/zephyr/issues/%s", ""),
+    "jira": ("https://jira.zephyrproject.org/browse/%s", "JIRA #%s"),
+    "github": ("https://github.com/zephyrproject-rtos/zephyr/issues/%s", "GitHub #%s"),
 }
 
 linkcheck_timeout = 30

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -163,11 +163,11 @@ struct spi_cs_control {
  * Example devicetree fragment:
  *
  * @code{.devicetree}
- *     gpio1: gpio@... { ... };
+ *     gpio1: gpio@abcd0001 { ... };
  *
- *     gpio2: gpio@... { ... };
+ *     gpio2: gpio@abcd0002 { ... };
  *
- *     spi@... {
+ *     spi@abcd0003 {
  *             compatible = "vnd,spi";
  *             cs-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>,
  *                        <&gpio2 20 GPIO_ACTIVE_LOW>;

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -1,7 +1,7 @@
 # DOC: used to generate docs
 
-breathe>=4.30,<4.33 # 4.33: disabled due to #803 and #805 issues
-sphinx~=4.0
+breathe>=4.34
+sphinx~=5.0
 sphinx_rtd_theme~=1.0
 sphinx-tabs
 sphinxcontrib-svg2pdfconverter


### PR DESCRIPTION
https://github.com/zephyrproject-rtos/zephyr/pull/48947
    Update to Sphinx 5.x, also update breathe since version 4.34 is the
    first to officially support Sphinx 5.x.
    
    Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>
    Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>
