### PR TITLE
[nrf fromlist] TF-M: Add option to enable SFN model 

### DIFF
--- a/boards/arm/bl5340_dvk/Kconfig
+++ b/boards/arm/bl5340_dvk/Kconfig
@@ -39,6 +39,8 @@ config BT_HCI_VS
 
 config BOARD_ENABLE_CPUNET
 	bool "NRF53 Network MCU"
+	select SOC_NRF_GPIO_FORWARDER_FOR_NRF5340 if \
+		$(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_GPIO_FORWARDER))
 	help
 	  This option enables releasing the Network 'force off' signal, which
 	  as a consequence will power up the Network MCU during system boot.

--- a/boards/arm/nrf5340dk_nrf5340/Kconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig
@@ -22,6 +22,8 @@ config BOARD_ENABLE_DCDC_HV
 
 config BOARD_ENABLE_CPUNET
 	bool "NRF53 Network MCU"
+	select SOC_NRF_GPIO_FORWARDER_FOR_NRF5340 if \
+		$(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_GPIO_FORWARDER))
 	help
 	  This option enables releasing the Network 'force off' signal, which
 	  as a consequence will power up the Network MCU during system boot.

--- a/boards/arm/thingy53_nrf5340/Kconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig
@@ -34,6 +34,8 @@ config BOARD_ENABLE_DCDC_HV
 
 config BOARD_ENABLE_CPUNET
 	bool "NRF53 Network MCU"
+	select SOC_NRF_GPIO_FORWARDER_FOR_NRF5340 if \
+		$(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_GPIO_FORWARDER))
 	help
 	  This option enables releasing the Network 'force off' signal, which
 	  as a consequence will power up the Network MCU during system boot.

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -31,12 +31,17 @@ set(TFM_CRYPTO_MODULES
 
 
 if (CONFIG_BUILD_WITH_TFM)
-  if (CONFIG_TFM_IPC)
+  if (CONFIG_TFM_LIBRARY)
+    list(APPEND TFM_CMAKE_ARGS -DTFM_LIB_MODEL=ON)
+  else()
     list(APPEND TFM_CMAKE_ARGS -DTFM_LIB_MODEL=OFF)
     # PSA API awareness for the Non-Secure application
     target_compile_definitions(app PRIVATE "TFM_PSA_API")
-  else()
-    list(APPEND TFM_CMAKE_ARGS -DTFM_LIB_MODEL=ON)
+    if (CONFIG_TFM_SFN)
+      list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_SPM_BACKEND="SFN")
+    else() # CONFIG_TFM_IPC
+      list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_SPM_BACKEND="IPC")
+    endif()
   endif()
   if (CONFIG_TFM_REGRESSION_S)
     list(APPEND TFM_CMAKE_ARGS -DTEST_S=ON)
@@ -372,7 +377,7 @@ if (CONFIG_BUILD_WITH_TFM)
   endif()
 
   if(NOT CONFIG_TFM_BUILD_NS)
-    if(CONFIG_TFM_IPC)
+    if(CONFIG_TFM_IPC OR CONFIG_TFM_SFN)
       zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_PLATFORM                 ${TFM_INTERFACE_SOURCE_DIR}/tfm_platform_ipc_api.c)
       zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_PROTECTED_STORAGE        ${TFM_INTERFACE_SOURCE_DIR}/tfm_ps_ipc_api.c)
       zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_INTERNAL_TRUSTED_STORAGE ${TFM_INTERFACE_SOURCE_DIR}/tfm_its_ipc_api.c)

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -276,14 +276,50 @@ config TFM_MCUBOOT_DATA_SHARING
 
 endif # TFM_BL2
 
-config TFM_IPC
-	bool "IPC" if TFM_PROFILE_TYPE_NOT_SET
-	default y if (TFM_PROFILE_TYPE_MEDIUM || TFM_PROFILE_TYPE_LARGE)
+choice TFM_MODEL
+	prompt "TF-M Firmware Framework model"
+	default TFM_IPC
 	help
-	  When enabled, this option signifies that the TF-M build supports
-	  the PSA API (IPC mode) instead of the secure library mode. When
-	  TF-M Profile option is supplied, do not allow manual setting of
-	  the IPC mode, as it is determined by the profile setting.
+	  The Firmware Framework M (FF-M) provides different programming models
+	  for Secure Partitions.
+
+config TFM_LIBRARY
+	bool "Library Model"
+	help
+	  Use the library model instead of PSA API.
+
+	  The library model conforms to the PSA Firmware Framework for M (FF-M)
+	  v1.0.
+
+	  NOTE: The Library Model will be removed and replaced by the SFN model.
+
+config TFM_IPC
+	bool "IPC Model"
+	help
+	  Use the IPC Model as the SPM backend for the PSA API.
+	  The IPC model supports the IPC and SFN Partition models, and
+	  isolation levels 1, 2 and 3.
+
+	  In this model each Secure Partition processes signals in any order,
+	  and can defer responding to a message while continuing to process
+	  other signals.
+
+	  The IPC model conforms to the PSA Firmware Framework for M (FF-M)
+	  v1.1.
+
+config TFM_SFN
+	bool "SFN model"
+	help
+	  Use the SFN Model as the SPM backend for the PSA API.
+	  The SFN model supports the SFN Partition model, and isolation level 1.
+
+	  In this model each Secure Partition is made up of a collection of
+	  callback functions which implement secure services.
+
+	  The SFN model conforms to the PSA Firmware Framework for M (FF-M)
+	  v1.1.
+
+endchoice # TFM_MODEL
 
 config TFM_REGRESSION_S
 	bool "TF-M Secure Regression tests"

--- a/modules/trusted-firmware-m/Kconfig.tfm.partitions
+++ b/modules/trusted-firmware-m/Kconfig.tfm.partitions
@@ -7,6 +7,9 @@ if BUILD_WITH_TFM
 
 config TFM_PARTITION_PROTECTED_STORAGE
 	bool "Secure partition 'Protected Storage'"
+	depends on TFM_PARTITION_PLATFORM # Specfically TFM_SP_PLATFORM_NV_COUNTER service
+	depends on TFM_PARTITION_INTERNAL_TRUSTED_STORAGE
+	depends on TFM_PARTITION_CRYPTO
 	default y
 	help
 	  Setting this option will cause '-DTFM_PARTITION_PROTECTED_STORAGE'
@@ -40,6 +43,7 @@ config TFM_PARTITION_CRYPTO
 
 config TFM_PARTITION_INITIAL_ATTESTATION
 	bool "Secure partition 'Initial Attestation'"
+	depends on TFM_PARTITION_CRYPTO
 	default y
 	help
 	  Setting this option will cause '-DTFM_PARTITION_INITIAL_ATTESTATION'
@@ -52,6 +56,7 @@ config TFM_PARTITION_INITIAL_ATTESTATION
 config TFM_PARTITION_PLATFORM
 	bool "Secure partition 'Platform'"
 	default y
+	depends on !TFM_SFN # Currently using PSA Framework version 1.0
 	help
 	  Setting this option will cause '-DTFM_PARTITION_PLATFORM'
 	  to be passed to the TF-M build system. Look at 'config_default.cmake'
@@ -61,8 +66,8 @@ config TFM_PARTITION_PLATFORM
 	  repository.
 
 config TFM_PARTITION_AUDIT_LOG
-	bool "Secure partition 'Audit Log'" if !TFM_IPC
-	depends on !TFM_IPC
+	bool "Secure partition 'Audit Log'"
+	depends on TFM_LIBRARY
 	default y
 	help
 	  Setting this option will cause '-DTFM_PARTITION_AUDIT_LOG'

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -17,7 +17,7 @@ source "soc/arm/nordic_nrf/Kconfig.peripherals"
 source "soc/arm/nordic_nrf/*/Kconfig.soc"
 
 config NRF_SOC_SECURE_SUPPORTED
-	def_bool !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
+	def_bool !TRUSTED_EXECUTION_NONSECURE || (BUILD_WITH_TFM && TFM_PARTITION_PLATFORM)
 	help
 	  Hidden function to indicate that that the soc_secure functions are
 	  available.

--- a/soc/arm/nordic_nrf/common/CMakeLists.txt
+++ b/soc/arm/nordic_nrf/common/CMakeLists.txt
@@ -4,7 +4,7 @@
 zephyr_library_sources_ifdef(CONFIG_SOC_FAMILY_NRF soc_nrf_common.S)
 zephyr_include_directories(.)
 
-if (CONFIG_BUILD_WITH_TFM)
+if (CONFIG_TFM_PARTITION_PLATFORM)
   zephyr_sources(soc_secure.c)
   zephyr_library_include_directories(
     $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/install/interface/include

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -100,6 +100,7 @@ config SOC_HFXO_CAP_EXTERNAL
 
 config SOC_HFXO_CAP_INTERNAL
 	bool "Use internal load capacitors"
+	depends on NRF_SOC_SECURE_SUPPORTED
 
 endchoice
 

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -45,6 +45,12 @@ config SOC_DCDC_NRF53X_HV
 	help
 	  Enable nRF53 series System on Chip High Voltage DC/DC converter.
 
+config SOC_NRF_GPIO_FORWARDER_FOR_NRF5340
+	bool
+	depends on NRF_SOC_SECURE_SUPPORTED
+	help
+	  hidden option for including the nRF GPIO pin forwarding
+
 if !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
 
 config SOC_ENABLE_LFXO

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -51,13 +51,7 @@ extern void z_arm_nmi_init(void);
 #error "Unknown nRF53 SoC."
 #endif
 
-#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_gpio_forwarder) && \
-	defined(CONFIG_BOARD_ENABLE_CPUNET) && \
-	(!defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(CONFIG_BUILD_WITH_TFM))
-#define NRF_GPIO_FORWARDER_FOR_NRF5340_CPUAPP_ENABLED
-#endif
-
-#if defined(NRF_GPIO_FORWARDER_FOR_NRF5340_CPUAPP_ENABLED)
+#if defined(CONFIG_SOC_NRF_GPIO_FORWARDER_FOR_NRF5340)
 #define GPIOS_PSEL_BY_IDX(node_id, prop, idx) \
 	NRF_DT_GPIOS_TO_PSEL_BY_IDX(node_id, prop, idx),
 #define ALL_GPIOS_IN_NODE(node_id) \
@@ -169,7 +163,7 @@ static int nordicsemi_nrf53_init(const struct device *arg)
 	nrf_regulators_dcdcen_vddh_set(NRF_REGULATORS, true);
 #endif
 
-#if defined(NRF_GPIO_FORWARDER_FOR_NRF5340_CPUAPP_ENABLED)
+#if defined(CONFIG_SOC_NRF_GPIO_FORWARDER_FOR_NRF5340)
 	static const uint8_t forwarded_psels[] = {
 		DT_FOREACH_STATUS_OKAY(nordic_nrf_gpio_forwarder, ALL_GPIOS_IN_FORWARDER)
 	};


### PR DESCRIPTION
Add option to enable the SFN model when building TF-M.
The SFN model will eventually replace the Library model.

Change the default model to be IPC, which follows the default
configuration of TF-M.

Allow building for nRF non-secure and TF-M enabled without having the
platform partition enabled.