### PR TITLE
[nrf noup] net: ip: Fix nRF Wi-Fi management events

### DIFF
--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -24,7 +24,7 @@
  * NOTE: Update comments here and calculate which struct occupies max size.
  */
 
-#ifdef CONFIG_NET_L2_WIFI_MGMT
+#if defined(CONFIG_NET_L2_WIFI_MGMT) || defined(CONFIG_NET_L2_NRF_WIFI_MGMT)
 
 #include <zephyr/net/wifi_mgmt.h>
 #define NET_EVENT_INFO_MAX_SIZE sizeof(struct wifi_scan_result)


### PR DESCRIPTION
When using nRF Wi-Fi management it uses the net management events with information, but the size of the events is not enough to hold the Wi-Fi events as the proper size is defined only for Zephyr's Wi-Fi management.

Use the proper size for both nRF and Zephyr's Wi-Fi management.

Note: If CONFIG_NET_DHCPV4 is enabled, then this works, as size is now large enough for Wi-Fi management events.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>