### PR TITLE
[nrf fromtree] Update clang workflow

### DIFF
--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -27,7 +27,7 @@ jobs:
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: bluetooth-test-prep
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.2
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -4,7 +4,7 @@ on: pull_request_target
 
 jobs:
   clang-build-prep:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: clang-build-prep
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.2
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -24,7 +24,7 @@ jobs:
         platform: ["native_posix"]
         subset: [1, 2, 3, 4, 5]
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         platform: ["native_posix", "qemu_x86", "unit_testing"]
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
     steps:
       - name: Apply container owner mismatch workaround

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: zephyr_runner
     needs: codecov-prep
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.2
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.2
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
 
     steps:
       - name: Apply container owner mismatch workaround

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -10,7 +10,7 @@ jobs:
   check-errno:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.2
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2
 

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-tracking-cancel
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.2
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-cancel
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.2
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: zephyr_runner
     needs: twister-build-cleanup
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.2
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject
@@ -120,7 +120,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci:v0.24.2
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -39,7 +39,7 @@ jobs:
       MATRIX_SIZE: 10
       PUSH_MATRIX_SIZE: 15
       DAILY_MATRIX_SIZE: 80
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       TESTS_PER_BUILDER: 700
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
@@ -129,7 +129,7 @@ jobs:
       matrix:
         subset: ${{fromJSON(needs.twister-build-prep.outputs.subset)}}
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.15.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       TWISTER_COMMON: ' --force-color --inline-logs -v -N -M --retry-failed 3 '
       DAILY_OPTIONS: ' -M --build-only --all'


### PR DESCRIPTION
Because the clang workflow is run on `pull_request_target`, it needs to be updated in the tree so that clang checks can be run successfully for https://github.com/nrfconnect/sdk-zephyr/pull/916 (and use `zephyr-sdk-0.15.0`). Hence the three commits included in this PR need to be cherry-picked before the upmerge.