### PR TITLE
[backport-v2.1][nrf fromtree] twister: fix bug retrieving subtests

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -96,7 +96,7 @@ class TestPlan:
         sub_tests = self.options.sub_test
         if sub_tests:
             for subtest in sub_tests:
-                _subtests = self.get_testcase(subtest)
+                _subtests = self.get_testsuite(subtest)
                 for _subtest in _subtests:
                     self.run_individual_testsuite.append(_subtest.name)
 
@@ -377,7 +377,7 @@ class TestPlan:
         testcases = []
         for _, ts in self.testsuites.items():
             for case in ts.testcases:
-                testcases.append(case)
+                testcases.append(case.name)
 
         return testcases
 
@@ -778,7 +778,7 @@ class TestPlan:
         results = []
         for _, ts in self.testsuites.items():
             for case in ts.testcases:
-                if case == identifier:
+                if case.name == identifier:
                     results.append(ts)
         return results
 

--- a/scripts/tests/twister/test_testplan_class.py
+++ b/scripts/tests/twister/test_testplan_class.py
@@ -76,7 +76,7 @@ def test_get_all_testsuites(class_env, all_testsuites_dict):
                       'test_c.check_2', 'test_d.check_1.unit_1a',
                       'test_d.check_1.unit_1b']
     tests = plan.get_all_tests()
-    result = [c.name for c in tests]
+    result = [c for c in tests]
     assert len(plan.get_all_tests()) == len(expected_tests)
     assert sorted(result) == sorted(expected_tests)
 


### PR DESCRIPTION
During the recent overhaul, some code was left retrieving cases the old way.

Fixes #48897

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>
(cherry picked from commit f28a8d224098e3fcbccd9ef5e6597502d81a1526)