### PR TITLE
[nrf noup] boards: Enable TF-M by default for Actinius NS boards

### DIFF
--- a/boards/arm/actinius_icarus/Kconfig.defconfig
+++ b/boards/arm/actinius_icarus/Kconfig.defconfig
@@ -8,6 +8,21 @@ if BOARD_ACTINIUS_ICARUS || BOARD_ACTINIUS_ICARUS_NS
 config BOARD
 	default "actinius_icarus"
 
+# By default, if we build for a Non-Secure version of the board,
+# enable building with TF-M as the Secure Execution Environment.
+config BUILD_WITH_TFM
+	default y if BOARD_ACTINIUS_ICARUS_NS
+
+if BUILD_WITH_TFM
+
+# By default, if we build with TF-M, instruct build system to
+# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
+config TFM_FLASH_MERGED_BINARY
+	bool
+	default y
+
+endif # BUILD_WITH_TFM
+
 # For the secure version of the board the firmware is linked at the beginning
 # of the flash, or into the code-partition defined in DT if it is intended to
 # be loaded by MCUboot. If the secure firmware is to be combined with a non-

--- a/boards/arm/actinius_icarus_bee/Kconfig.defconfig
+++ b/boards/arm/actinius_icarus_bee/Kconfig.defconfig
@@ -8,6 +8,21 @@ if BOARD_ACTINIUS_ICARUS_BEE || BOARD_ACTINIUS_ICARUS_BEE_NS
 config BOARD
 	default "actinius_icarus_bee"
 
+# By default, if we build for a Non-Secure version of the board,
+# enable building with TF-M as the Secure Execution Environment.
+config BUILD_WITH_TFM
+	default y if BOARD_ACTINIUS_ICARUS_BEE_NS
+
+if BUILD_WITH_TFM
+
+# By default, if we build with TF-M, instruct build system to
+# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
+config TFM_FLASH_MERGED_BINARY
+	bool
+	default y
+
+endif # BUILD_WITH_TFM
+
 # For the secure version of the board the firmware is linked at the beginning
 # of the flash, or into the code-partition defined in DT if it is intended to
 # be loaded by MCUboot. If the secure firmware is to be combined with a non-

--- a/boards/arm/actinius_icarus_som/Kconfig.defconfig
+++ b/boards/arm/actinius_icarus_som/Kconfig.defconfig
@@ -8,6 +8,21 @@ if BOARD_ACTINIUS_ICARUS_SOM || BOARD_ACTINIUS_ICARUS_SOM_NS
 config BOARD
 	default "actinius_icarus_som"
 
+# By default, if we build for a Non-Secure version of the board,
+# enable building with TF-M as the Secure Execution Environment.
+config BUILD_WITH_TFM
+	default y if BOARD_ACTINIUS_ICARUS_SOM_NS
+
+if BUILD_WITH_TFM
+
+# By default, if we build with TF-M, instruct build system to
+# flash the combined TF-M (Secure) & Zephyr (Non Secure) image
+config TFM_FLASH_MERGED_BINARY
+	bool
+	default y
+
+endif # BUILD_WITH_TFM
+
 # For the secure version of the board the firmware is linked at the beginning
 # of the flash, or into the code-partition defined in DT if it is intended to
 # be loaded by MCUboot. If the secure firmware is to be combined with a non-


### PR DESCRIPTION
Enable TF-M by default for Actinius nrf9160-based NS boards.
This is based on https://github.com/nrfconnect/sdk-zephyr/commit/2ede29c77a7a240aca62a06831504961136c27d3 which is missing the nrf9160-based boards from Actinius. Needed for building the nrf samples from SDK v2.1.x onwards

Signed-off-by: Alex Tsamakos <alex@actinius.com>