### PR TITLE
net: wifi: Add support for WPA supplicant

### DIFF
--- a/subsys/net/ip/Kconfig.stats
+++ b/subsys/net/ip/Kconfig.stats
@@ -127,7 +127,7 @@ config NET_STATISTICS_POWER_MANAGEMENT
 
 config NET_STATISTICS_WIFI
 	bool "Wi-Fi statistics"
-	depends on NET_L2_WIFI_MGMT || NET_L2_NRF_WIFI_MGMT
+	depends on NET_L2_WIFI_MGMT
 	default y
 	help
 	  Keep track of Wi-Fi related statistics. Note that this

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -24,7 +24,7 @@
  * NOTE: Update comments here and calculate which struct occupies max size.
  */
 
-#if defined(CONFIG_NET_L2_WIFI_MGMT) || defined(CONFIG_NET_L2_NRF_WIFI_MGMT)
+#if defined(CONFIG_NET_L2_WIFI_MGMT)
 
 #include <zephyr/net/wifi_mgmt.h>
 #define NET_EVENT_INFO_MAX_SIZE sizeof(struct wifi_scan_result)

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -12,6 +12,9 @@ LOG_MODULE_REGISTER(net_wifi_mgmt, CONFIG_NET_L2_WIFI_MGMT_LOG_LEVEL);
 #include <zephyr/net/net_core.h>
 #include <zephyr/net/net_if.h>
 #include <zephyr/net/wifi_mgmt.h>
+#ifdef CONFIG_WPA_SUPP
+#include "supp_api.h"
+#endif
 
 static int wifi_connect(uint32_t mgmt_request, struct net_if *iface,
 			void *data, size_t len)
@@ -19,12 +22,15 @@ static int wifi_connect(uint32_t mgmt_request, struct net_if *iface,
 	struct wifi_connect_req_params *params =
 		(struct wifi_connect_req_params *)data;
 	const struct device *dev = net_if_get_device(iface);
+#ifndef CONFIG_WPA_SUPP
 	struct net_wifi_mgmt_offload *off_api =
 		(struct net_wifi_mgmt_offload *) dev->api;
+
 
 	if (off_api == NULL || off_api->connect == NULL) {
 		return -ENOTSUP;
 	}
+#endif /* CONFIG_WPA_SUPP */
 
 	LOG_HEXDUMP_DBG(params->ssid, params->ssid_length, "ssid");
 	LOG_HEXDUMP_DBG(params->psk, params->psk_length, "psk");
@@ -48,8 +54,11 @@ static int wifi_connect(uint32_t mgmt_request, struct net_if *iface,
 	    !params->ssid) {
 		return -EINVAL;
 	}
-
+#ifdef CONFIG_WPA_SUPP
+	return zephyr_supp_connect(dev, params);
+#else
 	return off_api->connect(dev, params);
+#endif /* CONFIG_WPA_SUPP */
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_CONNECT, wifi_connect);
@@ -97,6 +106,10 @@ static int wifi_disconnect(uint32_t mgmt_request, struct net_if *iface,
 			   void *data, size_t len)
 {
 	const struct device *dev = net_if_get_device(iface);
+
+#ifdef CONFIG_WPA_SUPP
+	return zephyr_supp_disconnect(dev);
+#else
 	struct net_wifi_mgmt_offload *off_api =
 		(struct net_wifi_mgmt_offload *) dev->api;
 
@@ -105,6 +118,7 @@ static int wifi_disconnect(uint32_t mgmt_request, struct net_if *iface,
 	}
 
 	return off_api->disconnect(dev);
+#endif /* CONFIG_WPA_SUPP */
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_DISCONNECT, wifi_disconnect);
@@ -168,27 +182,25 @@ NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_DISABLE, wifi_ap_disable);
 static int wifi_iface_status(uint32_t mgmt_request, struct net_if *iface,
 			  void *data, size_t len)
 {
-	int ret;
 	const struct device *dev = net_if_get_device(iface);
-	struct net_wifi_mgmt_offload *off_api =
-		(struct net_wifi_mgmt_offload *) dev->api;
 	struct wifi_iface_status *status = data;
-
-	if (off_api == NULL || off_api->iface_status == NULL) {
-		return -ENOTSUP;
-	}
 
 	if (!data || len != sizeof(*status)) {
 		return -EINVAL;
 	}
 
-	ret = off_api->iface_status(dev, status);
+#ifdef CONFIG_WPA_SUPP
+	return zephyr_supp_status(dev, status);
+#else
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->api;
 
-	if (ret) {
-		return ret;
+	if (off_api == NULL || off_api->iface_status == NULL) {
+		return -ENOTSUP;
 	}
 
-	return 0;
+	return off_api->iface_status(dev, status);
+#endif /* CONFIG_WPA_SUPP */
 }
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_IFACE_STATUS, wifi_iface_status);
 
@@ -204,7 +216,6 @@ void wifi_mgmt_raise_iface_status_event(struct net_if *iface,
 static int wifi_iface_stats(uint32_t mgmt_request, struct net_if *iface,
 			  void *data, size_t len)
 {
-	int ret;
 	const struct device *dev = net_if_get_device(iface);
 	struct net_wifi_mgmt_offload *off_api =
 		(struct net_wifi_mgmt_offload *) dev->api;
@@ -218,13 +229,7 @@ static int wifi_iface_stats(uint32_t mgmt_request, struct net_if *iface,
 		return -EINVAL;
 	}
 
-	ret = off_api->get_stats(dev, stats);
-
-	if (ret) {
-		return ret;
-	}
-
-	return 0;
+	return off_api->get_stats(dev, stats);
 }
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_STATS_GET_WIFI, wifi_iface_stats);
 #endif /* CONFIG_NET_STATISTICS_WIFI */


### PR DESCRIPTION
If WPA supplicant is enabled at build time, then use the WPA supplicant APIs, else use offload driver APIs.