### PR TITLE
[nrf noup] bluetooth: increase discaradable buffer size

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -136,11 +136,13 @@ config BT_BUF_EVT_RX_COUNT
 
 config BT_BUF_EVT_DISCARDABLE_SIZE
 	int "Maximum supported discardable HCI Event buffer length"
-	range 43 255
+	range 43 255 if !BT_EXT_ADV
+	range 58 255 if BT_EXT_ADV
 	# LE Extended Advertising Report event
 	default 255 if BT_BREDR
 	# Le Advertising Report event
-	default 43
+	default 43 if !BT_EXT_ADV
+	default 58 if BT_EXT_ADV
 	help
 	  Maximum support discardable HCI event size of buffers in the separate
 	  discardable event buffer pool. This value does not include the


### PR DESCRIPTION
Make discaradable buffer size fit extended adv reports that has only received legacy adv pdus.

This is needed since this PR is https://github.com/nrfconnect/sdk-nrf/pull/9072 will mark extneded adv reports with legacy data in them discardable.

Fixes #51650

Signed-off-by: Martin Tverdal <martin.tverdal@nordicsemi.no>