### PR TITLE
[nrf noup] tf-m: Add implementation id Kconfig select to initial atte…

### DIFF
--- a/modules/trusted-firmware-m/Kconfig.tfm.partitions
+++ b/modules/trusted-firmware-m/Kconfig.tfm.partitions
@@ -40,6 +40,7 @@ config TFM_PARTITION_CRYPTO
 
 config TFM_PARTITION_INITIAL_ATTESTATION
 	bool "Secure partition 'Initial Attestation'"
+	select SB_IMPLEMENTATION_ID
 	default y
 	help
 	  Setting this option will cause '-DTFM_PARTITION_INITIAL_ATTESTATION'


### PR DESCRIPTION
…station

The initial attestation service requires the Implementation id stored via the bl_storage library. As the implementation id is not needed by default and has no dependencies select is used.

As this relies on the bl_storage library of NSIB, which is a nrf only component noup commit is chosen

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>