### PR TITLE
[nrf noup] tfm: Enable bootloaders in TF-M regression tests

### DIFF
--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -24,3 +24,12 @@ tests:
 
   sample.tfm.regression_ipc_lvl2:
     timeout: 200
+
+  # Regression tests are too large for bootloaders to be enabled.
+  # Run S and NS test suites separately.
+  sample.tfm.regression.bootloaders_s:
+    extra_args: CONFIG_BOOTLOADER_MCUBOOT=y CONFIG_SECURE_BOOT=y CONFIG_TFM_REGRESSION_NS=n
+    timeout: 200
+  sample.tfm.regression.bootloaders_ns:
+    extra_args: CONFIG_BOOTLOADER_MCUBOOT=y CONFIG_SECURE_BOOT=y CONFIG_TFM_REGRESSION_S=n
+    timeout: 200


### PR DESCRIPTION
Enable bootloaders in the TF-M regression test suite. Run NS and S test cases separately as there is not enough flash.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>