### PR TITLE
[nrf noup] ci: clang: Use ubuntu-latest instead of zephyr_runner

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -11,7 +11,7 @@ jobs:
         with:
           access_token: ${{ github.token }}
   clang-build:
-    runs-on: zephyr_runner
+    runs-on: ubuntu-latest
     needs: clang-build-prep
     container:
       image: ghcr.io/zephyrproject-rtos/ci:v0.24.2


### PR DESCRIPTION
squash! [nrf noup] ci: clang: parallel execution

zephyr_runner is upstream's proprietary agent inaccessible outside of upstream's CI. Use ubuntu-latest instead.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>