### PR TITLE
[nrf fromtree] net: lwm2m: use zsock_ functions

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -6,7 +6,6 @@ menuconfig LWM2M
 	select COAP
 	select HTTP_PARSER_URL
 	select NET_SOCKETS
-	select NET_SOCKETS_POSIX_NAMES
 	help
 	  This option adds logic for managing OMA LWM2M data
 

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -100,7 +100,7 @@ static struct k_thread engine_thread_data;
 #define MAX_POLL_FD CONFIG_NET_SOCKETS_POLL_MAX
 
 /* Resources */
-static struct pollfd sock_fds[MAX_POLL_FD];
+static struct zsock_pollfd sock_fds[MAX_POLL_FD];
 
 static struct lwm2m_ctx *sock_ctx[MAX_POLL_FD];
 static int sock_nfds;
@@ -173,11 +173,12 @@ int lwm2m_open_socket(struct lwm2m_ctx *client_ctx)
 		/* open socket */
 
 		if (IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT) && client_ctx->use_dtls) {
-			client_ctx->sock_fd = socket(client_ctx->remote_addr.sa_family, SOCK_DGRAM,
-						     IPPROTO_DTLS_1_2);
+			client_ctx->sock_fd = zsock_socket(client_ctx->remote_addr.sa_family,
+							   SOCK_DGRAM, IPPROTO_DTLS_1_2);
 		} else {
 			client_ctx->sock_fd =
-				socket(client_ctx->remote_addr.sa_family, SOCK_DGRAM, IPPROTO_UDP);
+				zsock_socket(client_ctx->remote_addr.sa_family, SOCK_DGRAM,
+					     IPPROTO_UDP);
 		}
 
 		if (client_ctx->sock_fd < 0) {
@@ -198,7 +199,7 @@ int lwm2m_close_socket(struct lwm2m_ctx *client_ctx)
 	int ret = 0;
 
 	if (client_ctx->sock_fd >= 0) {
-		ret = close(client_ctx->sock_fd);
+		ret = zsock_close(client_ctx->sock_fd);
 		if (ret) {
 			LOG_ERR("Failed to close socket: %d", errno);
 			ret = -errno;
@@ -527,7 +528,7 @@ int lwm2m_socket_add(struct lwm2m_ctx *ctx)
 
 	sock_ctx[sock_nfds] = ctx;
 	sock_fds[sock_nfds].fd = ctx->sock_fd;
-	sock_fds[sock_nfds].events = POLLIN;
+	sock_fds[sock_nfds].events = ZSOCK_POLLIN;
 	sock_nfds++;
 
 	return 0;
@@ -608,8 +609,8 @@ static int socket_recv_message(struct lwm2m_ctx *client_ctx)
 	static struct sockaddr from_addr;
 
 	from_addr_len = sizeof(from_addr);
-	len = recvfrom(client_ctx->sock_fd, in_buf, sizeof(in_buf) - 1, 0, &from_addr,
-		       &from_addr_len);
+	len = zsock_recvfrom(client_ctx->sock_fd, in_buf, sizeof(in_buf) - 1, 0, &from_addr,
+			     &from_addr_len);
 
 	if (len < 0) {
 		if (errno == EAGAIN || errno == EWOULDBLOCK) {
@@ -650,7 +651,8 @@ static void socket_reset_pollfd_events(void)
 {
 	for (int i = 0; i < sock_nfds; ++i) {
 		sock_fds[i].events =
-			POLLIN | (sys_slist_is_empty(&sock_ctx[i]->pending_sends) ? 0 : POLLOUT);
+			ZSOCK_POLLIN |
+			(sys_slist_is_empty(&sock_ctx[i]->pending_sends) ? 0 : ZSOCK_POLLOUT);
 		sock_fds[i].revents = 0;
 	}
 }
@@ -705,7 +707,7 @@ static void socket_loop(void)
 		 * FIXME: Currently we timeout and restart poll in case fds
 		 *        were modified.
 		 */
-		rc = poll(sock_fds, sock_nfds, timeout);
+		rc = zsock_poll(sock_fds, sock_nfds, timeout);
 		if (rc < 0) {
 			LOG_ERR("Error in poll:%d", errno);
 			errno = 0;
@@ -719,8 +721,9 @@ static void socket_loop(void)
 				continue;
 			}
 
-			if ((sock_fds[i].revents & POLLERR) || (sock_fds[i].revents & POLLNVAL) ||
-			    (sock_fds[i].revents & POLLHUP)) {
+			if ((sock_fds[i].revents & ZSOCK_POLLERR) ||
+			    (sock_fds[i].revents & ZSOCK_POLLNVAL) ||
+			    (sock_fds[i].revents & ZSOCK_POLLHUP)) {
 				LOG_ERR("Poll reported a socket error, %02x.", sock_fds[i].revents);
 				if (sock_ctx[i] != NULL && sock_ctx[i]->fault_cb != NULL) {
 					sock_ctx[i]->fault_cb(EIO);
@@ -728,7 +731,7 @@ static void socket_loop(void)
 				continue;
 			}
 
-			if (sock_fds[i].revents & POLLIN) {
+			if (sock_fds[i].revents & ZSOCK_POLLIN) {
 				while (sock_ctx[i]) {
 					rc = socket_recv_message(sock_ctx[i]);
 					if (rc) {
@@ -737,7 +740,7 @@ static void socket_loop(void)
 				}
 			}
 
-			if (sock_fds[i].revents & POLLOUT) {
+			if (sock_fds[i].revents & ZSOCK_POLLOUT) {
 				socket_send_message(sock_ctx[i]);
 			}
 		}
@@ -823,8 +826,8 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 			client_ctx->tls_tag,
 		};
 
-		ret = setsockopt(client_ctx->sock_fd, SOL_TLS, TLS_SEC_TAG_LIST, tls_tag_list,
-				 sizeof(tls_tag_list));
+		ret = zsock_setsockopt(client_ctx->sock_fd, SOL_TLS, TLS_SEC_TAG_LIST, tls_tag_list,
+				       sizeof(tls_tag_list));
 		if (ret < 0) {
 			ret = -errno;
 			LOG_ERR("Failed to set TLS_SEC_TAG_LIST option: %d", ret);
@@ -834,8 +837,8 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 		if (IS_ENABLED(CONFIG_LWM2M_TLS_SESSION_CACHING)) {
 			int session_cache = TLS_SESSION_CACHE_ENABLED;
 
-			ret = setsockopt(client_ctx->sock_fd, SOL_TLS, TLS_SESSION_CACHE,
-					 &session_cache, sizeof(session_cache));
+			ret = zsock_setsockopt(client_ctx->sock_fd, SOL_TLS, TLS_SESSION_CACHE,
+					       &session_cache, sizeof(session_cache));
 			if (ret < 0) {
 				ret = -errno;
 				LOG_ERR("Failed to set TLS_SESSION_CACHE option: %d", errno);
@@ -851,8 +854,9 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 			client_ctx->desthostname[client_ctx->desthostnamelen] = '\0';
 
 			/** mbedtls ignores length */
-			ret = setsockopt(client_ctx->sock_fd, SOL_TLS, TLS_HOSTNAME,
-					 client_ctx->desthostname, client_ctx->desthostnamelen);
+			ret = zsock_setsockopt(client_ctx->sock_fd, SOL_TLS, TLS_HOSTNAME,
+					       client_ctx->desthostname,
+					       client_ctx->desthostnamelen);
 
 			/** restore character */
 			client_ctx->desthostname[client_ctx->desthostnamelen] = tmp;
@@ -873,7 +877,7 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 		return -EPROTONOSUPPORT;
 	}
 
-	if (connect(client_ctx->sock_fd, &client_ctx->remote_addr, addr_len) < 0) {
+	if (zsock_connect(client_ctx->sock_fd, &client_ctx->remote_addr, addr_len) < 0) {
 		ret = -errno;
 		LOG_ERR("Cannot connect UDP (%d)", ret);
 		goto error;
@@ -906,7 +910,7 @@ int lwm2m_socket_close(struct lwm2m_ctx *client_ctx)
 	lwm2m_socket_del(client_ctx);
 	client_ctx->sock_fd = -1;
 	if (sock_fd >= 0) {
-		return close(sock_fd);
+		return zsock_close(sock_fd);
 	}
 
 	return 0;

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -447,7 +447,7 @@ int lwm2m_send_message(struct lwm2m_message *msg)
 		coap_pending_cycle(msg->pending);
 	}
 
-	rc = send(msg->ctx->sock_fd, msg->cpkt.data, msg->cpkt.offset, 0);
+	rc = zsock_send(msg->ctx->sock_fd, msg->cpkt.data, msg->cpkt.offset, 0);
 
 	if (rc < 0) {
 		LOG_ERR("Failed to send packet, err %d", errno);
@@ -2568,7 +2568,7 @@ int lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmwa
 {
 	struct http_parser_url parser;
 #if defined(CONFIG_LWM2M_DNS_SUPPORT)
-	struct addrinfo *res, hints = {0};
+	struct zsock_addrinfo *res, hints = {0};
 #endif
 	int ret;
 	uint16_t off, len;
@@ -2653,7 +2653,7 @@ int lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmwa
 		hints.ai_family = AF_UNSPEC;
 #endif /* defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV4) */
 		hints.ai_socktype = SOCK_DGRAM;
-		ret = getaddrinfo(url + off, NULL, &hints, &res);
+		ret = zsock_getaddrinfo(url + off, NULL, &hints, &res);
 		if (ret != 0) {
 			LOG_ERR("Unable to resolve address");
 			/* DNS error codes don't align with normal errors */
@@ -2663,7 +2663,7 @@ int lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmwa
 
 		memcpy(&client_ctx->remote_addr, res->ai_addr, sizeof(client_ctx->remote_addr));
 		client_ctx->remote_addr.sa_family = res->ai_family;
-		freeaddrinfo(res);
+		zsock_freeaddrinfo(res);
 #else
 		goto cleanup;
 #endif /* CONFIG_LWM2M_DNS_SUPPORT */


### PR DESCRIPTION
Use Zephyr internal zsock_ calls to remove dependency to NET_SOCKETS_POSIX_NAMES.