### PR TITLE
[nrf noup] ci: clang: Remove incorrect zephyr path

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -100,7 +100,6 @@ jobs:
           ccache -M 10G -s
 
       - name: Build test plan with Twister
-        working-directory: ./zephyr
         id: twister_test_plan
         run: |
           export ZEPHYR_BASE=${PWD}


### PR DESCRIPTION
squash! [nrf noup] ci: clang: parallel execution

The fix for zephyr path is no longer needed after
37160d6e3bd733e42b403aeb8016def5806b6458 was reverted and is causing failures.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>