### PR TITLE
Update mcumgr with latest zephyr additions and Bluetooth transport issues

### DIFF
--- a/include/zephyr/mgmt/mcumgr/smp.h
+++ b/include/zephyr/mgmt/mcumgr/smp.h
@@ -173,12 +173,12 @@ void zephyr_smp_transport_init(struct zephyr_smp_transport *smpt,
 
 /**
  * @brief	Used to remove queued requests for an SMP transport that are no longer valid. A
- *		``smp_transport_clear_check_fn`` function must be registered for this to function.
- *		If the ``smp_transport_clear_check_fn`` function returns false during a callback,
- *		the queried command will classed as invalid and dropped.
+ *		``smp_transport_query_valid_check_fn`` function must be registered for this to
+ *		function. If the ``smp_transport_query_valid_check_fn`` function returns false
+ *		during a callback, the queried command will classed as invalid and dropped.
  *
  * @param zst	The transport to use.
- * @param arg	Argument provided to callback ``smp_transport_clear_check_fn`` function.
+ * @param arg	Argument provided to callback ``smp_transport_query_valid_check_fn`` function.
  */
 void smp_rx_remove_invalid(struct smp_transport *zst, void *arg);
 

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -71,7 +71,7 @@ struct img_mgmt_upload_req {
 	struct zcbor_string img_data;
 	struct zcbor_string data_sha;
 	bool upgrade;			/* Only allow greater version numbers. */
-} __packed;
+};
 
 /** Global state for upload in progress. */
 struct img_mgmt_state {
@@ -84,7 +84,7 @@ struct img_mgmt_state {
 	/** Hash of image data; used for resumption of a partial upload. */
 	uint8_t data_sha_len;
 	uint8_t data_sha[IMG_MGMT_DATA_SHA_LEN];
-} __packed;
+};
 
 /** Describes what to do during processing of an upload request. */
 struct img_mgmt_upload_action {
@@ -102,7 +102,7 @@ struct img_mgmt_upload_action {
 	/** "rsn" string to be sent as explanation for "rc" code */
 	const char *rc_rsn;
 #endif
-} __packed;
+};
 
 /**
  * @brief Registers the image management command handler group.

--- a/subsys/mgmt/mcumgr/transport/Kconfig
+++ b/subsys/mgmt/mcumgr/transport/Kconfig
@@ -30,13 +30,15 @@ config MCUMGR_BUF_USER_DATA_SIZE
 	int "Size of mcumgr buffer user data"
 	default 24 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV6
 	default 8 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV4
+	default 5 if MCUMGR_SMP_BT
 	default 4
 	help
 	  The size, in bytes, of user data to allocate for each mcumgr buffer.
 
 	  Different mcumgr transports impose different requirements for this
-	  setting. A value of 4 is sufficient for UART, shell, and bluetooth.
-	  For UDP, the userdata must be large enough to hold a IPv4/IPv6 address.
+	  setting. A value of 4 is sufficient for UART and shell, a value of 5
+	  is sufficient for Bluetooth. For UDP, the userdata must be large
+	  enough to hold a IPv4/IPv6 address.
 
 rsource "Kconfig.dummy"
 

--- a/subsys/mgmt/mcumgr/transport/Kconfig
+++ b/subsys/mgmt/mcumgr/transport/Kconfig
@@ -30,13 +30,13 @@ config MCUMGR_BUF_USER_DATA_SIZE
 	int "Size of mcumgr buffer user data"
 	default 24 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV6
 	default 8 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV4
-	default 5 if MCUMGR_SMP_BT
+	default 8 if MCUMGR_SMP_BT
 	default 4
 	help
 	  The size, in bytes, of user data to allocate for each mcumgr buffer.
 
 	  Different mcumgr transports impose different requirements for this
-	  setting. A value of 4 is sufficient for UART and shell, a value of 5
+	  setting. A value of 4 is sufficient for UART and shell, a value of 8
 	  is sufficient for Bluetooth. For UDP, the userdata must be large
 	  enough to hold a IPv4/IPv6 address.
 

--- a/subsys/mgmt/mcumgr/transport/smp_dummy.c
+++ b/subsys/mgmt/mcumgr/transport/smp_dummy.c
@@ -190,7 +190,7 @@ static int smp_dummy_init(const struct device *dev)
 	k_sem_init(&smp_data_ready_sem, 0, 1);
 
 	smp_transport_init(&smp_dummy_transport, smp_dummy_tx_pkt_int,
-			   smp_dummy_get_mtu, NULL, NULL);
+			   smp_dummy_get_mtu, NULL, NULL, NULL);
 	dummy_mgumgr_recv_cb = smp_dummy_rx_frag;
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/smp_shell.c
+++ b/subsys/mgmt/mcumgr/transport/smp_shell.c
@@ -191,7 +191,7 @@ static int smp_shell_tx_pkt(struct net_buf *nb)
 int smp_shell_init(void)
 {
 	smp_transport_init(&smp_shell_transport, smp_shell_tx_pkt,
-			   smp_shell_get_mtu, NULL, NULL);
+			   smp_shell_get_mtu, NULL, NULL, NULL);
 
 	return 0;
 }

--- a/subsys/mgmt/mcumgr/transport/smp_uart.c
+++ b/subsys/mgmt/mcumgr/transport/smp_uart.c
@@ -94,7 +94,7 @@ static int smp_uart_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	smp_transport_init(&smp_uart_transport, smp_uart_tx_pkt,
-			   smp_uart_get_mtu, NULL, NULL);
+			   smp_uart_get_mtu, NULL, NULL, NULL);
 	uart_mcumgr_register(smp_uart_rx_frag);
 
 	return 0;

--- a/subsys/mgmt/mcumgr/transport/smp_udp.c
+++ b/subsys/mgmt/mcumgr/transport/smp_udp.c
@@ -166,13 +166,13 @@ static int smp_udp_init(const struct device *dev)
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV4
 	smp_transport_init(&configs.ipv4.smp_transport,
 			   smp_udp4_tx, smp_udp_get_mtu,
-			   smp_udp_ud_copy, NULL);
+			   smp_udp_ud_copy, NULL, NULL);
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_UDP_IPV6
 	smp_transport_init(&configs.ipv6.smp_transport,
 			   smp_udp6_tx, smp_udp_get_mtu,
-			   smp_udp_ud_copy, NULL);
+			   smp_udp_ud_copy, NULL, NULL);
 #endif
 
 	return MGMT_ERR_EOK;


### PR DESCRIPTION
Fixes issues with the Bluetooth mcumgr transport which have resulted in issues in matter samples and deadlocks. Have pulled in all previous mcumgr changes to prevent merge issues.