### PR TITLE
[nrf fromlist] net: wifi_mgmt: Add support for power save configuration

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -245,4 +245,131 @@ static inline const char *wifi_link_mode_txt(enum wifi_link_mode link_mode)
 	}
 }
 
+enum wifi_ps {
+	WIFI_PS_DISABLED = 0,
+	WIFI_PS_ENABLED,
+};
+
+/**
+ * wifi_ps_txt - Get the power save setting as a text string
+ */
+static inline const char *wifi_ps_txt(enum wifi_ps ps)
+{
+	switch (ps) {
+	case WIFI_PS_DISABLED:
+		return "Power save disabled";
+	case WIFI_PS_ENABLED:
+		return "Power save enabled";
+	default:
+		return "Power save unknown";
+	}
+}
+
+enum wifi_ps_mode {
+	WIFI_PS_MODE_LEGACY = 0,
+	/* This has to be configured before connecting to the AP,
+	 * as support for ADDTS action frames is not available.
+	 */
+	WIFI_PS_MODE_WMM,
+};
+
+/**
+ * wifi_ps_mode_txt - Get the power save mode type as a text string
+ */
+static inline const char *wifi_ps_mode_txt(enum wifi_ps_mode ps_mode)
+{
+	switch (ps_mode) {
+	case WIFI_PS_MODE_LEGACY:
+		return "Legacy power save";
+	case WIFI_PS_MODE_WMM:
+		return "WMM power save";
+	default:
+		return "Power save mode unknown";
+	}
+}
+
+enum wifi_twt_operation {
+	WIFI_TWT_SETUP = 0,
+	WIFI_TWT_TEARDOWN,
+};
+
+/**
+ * wifi_twt_operation_txt - Get the TWT operation type as a text string
+ */
+static inline const char *wifi_twt_operation_txt(enum wifi_twt_operation op)
+{
+	switch (op) {
+	case WIFI_TWT_SETUP:
+		return "TWT setup";
+	case WIFI_TWT_TEARDOWN:
+		return "TWT teardown";
+	default:
+		return "TWT operation unknown";
+	}
+}
+
+enum wifi_twt_negotiation_type {
+	WIFI_TWT_INDIVIDUAL = 0,
+	WIFI_TWT_BROADCAST,
+	WIFI_TWT_WAKE_TBTT
+};
+
+/**
+ * wifi_twt_negotiation_type_txt - Get the TWT negotiation type as a text string
+ */
+static inline const char *wifi_twt_negotiation_type_txt(enum wifi_twt_negotiation_type type)
+{
+	switch (type) {
+	case WIFI_TWT_INDIVIDUAL:
+		return "TWT individual negotiation";
+	case WIFI_TWT_BROADCAST:
+		return "TWT broadcast negotiation";
+	case WIFI_TWT_WAKE_TBTT:
+		return "TWT wake TBTT negotiation";
+	default:
+		return "TWT negotiation type unknown";
+	}
+}
+
+enum wifi_twt_setup_cmd {
+	/* TWT Requests */
+	WIFI_TWT_SETUP_CMD_REQUEST = 0,
+	WIFI_TWT_SETUP_CMD_SUGGEST,
+	WIFI_TWT_SETUP_CMD_DEMAND,
+	/* TWT Responses */
+	WIFI_TWT_SETUP_CMD_GROUPING,
+	WIFI_TWT_SETUP_CMD_ACCEPT,
+	WIFI_TWT_SETUP_CMD_ALTERNATE,
+	WIFI_TWT_SETUP_CMD_DICTATE,
+	WIFI_TWT_SETUP_CMD_REJECT,
+};
+
+/**
+ * wifi_twt_setup_cmd_txt - Get the TWT setup command type as a text string
+ */
+static inline const char *wifi_twt_setup_cmd_txt(enum wifi_twt_setup_cmd cmd)
+{
+	switch (cmd) {
+	/* TWT Requests */
+	case WIFI_TWT_SETUP_CMD_REQUEST:
+		return "TWT request";
+	case WIFI_TWT_SETUP_CMD_SUGGEST:
+		return "TWT suggest";
+	case WIFI_TWT_SETUP_CMD_DEMAND:
+		return "TWT demand";
+	/* TWT Responses */
+	case WIFI_TWT_SETUP_CMD_GROUPING:
+		return "TWT grouping";
+	case WIFI_TWT_SETUP_CMD_ACCEPT:
+		return "TWT accept";
+	case WIFI_TWT_SETUP_CMD_ALTERNATE:
+		return "TWT alternate";
+	case WIFI_TWT_SETUP_CMD_DICTATE:
+		return "TWT dictate";
+	case WIFI_TWT_SETUP_CMD_REJECT:
+		return "TWT reject";
+	default:
+		return "TWT setup command unknown";
+	}
+}
 #endif /* ZEPHYR_INCLUDE_NET_WIFI_H_ */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -36,6 +36,10 @@ enum net_request_wifi_cmd {
 	NET_REQUEST_WIFI_CMD_AP_ENABLE,
 	NET_REQUEST_WIFI_CMD_AP_DISABLE,
 	NET_REQUEST_WIFI_CMD_IFACE_STATUS,
+	NET_REQUEST_WIFI_CMD_PS,
+	NET_REQUEST_WIFI_CMD_PS_MODE,
+	NET_REQUEST_WIFI_CMD_TWT,
+	NET_REQUEST_WIFI_CMD_PS_CONFIG,
 };
 
 #define NET_REQUEST_WIFI_SCAN					\
@@ -68,12 +72,33 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_AP_DISABLE);
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_IFACE_STATUS);
 
+#define NET_REQUEST_WIFI_PS				\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PS)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS);
+
+#define NET_REQUEST_WIFI_PS_MODE			\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PS_MODE)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_MODE);
+
+#define NET_REQUEST_WIFI_TWT			\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_TWT)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_TWT);
+
+#define NET_REQUEST_WIFI_PS_CONFIG				\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PS_CONFIG)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_CONFIG);
+
 enum net_event_wifi_cmd {
 	NET_EVENT_WIFI_CMD_SCAN_RESULT = 1,
 	NET_EVENT_WIFI_CMD_SCAN_DONE,
 	NET_EVENT_WIFI_CMD_CONNECT_RESULT,
 	NET_EVENT_WIFI_CMD_DISCONNECT_RESULT,
 	NET_EVENT_WIFI_CMD_IFACE_STATUS,
+	NET_EVENT_WIFI_CMD_TWT,
 };
 
 #define NET_EVENT_WIFI_SCAN_RESULT				\
@@ -91,6 +116,8 @@ enum net_event_wifi_cmd {
 #define NET_EVENT_WIFI_IFACE_STATUS						\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_IFACE_STATUS)
 
+#define NET_EVENT_WIFI_TWT					\
+	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_TWT)
 
 /* Each result is provided to the net_mgmt_event_callback
  * via its info attribute (see net_mgmt.h)
@@ -144,6 +171,66 @@ struct wifi_iface_status {
 	int rssi;
 };
 
+struct wifi_ps_params {
+	enum wifi_ps enabled;
+};
+
+struct wifi_ps_mode_params {
+	enum wifi_ps_mode mode;
+};
+
+struct wifi_twt_params {
+	enum wifi_twt_operation operation;
+	enum wifi_twt_negotiation_type negotiation_type;
+	enum wifi_twt_setup_cmd setup_cmd;
+	/* Map requests to responses */
+	uint8_t dialog_token;
+	/* Map setup with teardown */
+	uint8_t flow_id;
+	union {
+		struct {
+			/* Interval = Wake up time + Sleeping time */
+			uint32_t twt_interval_ms;
+			bool responder;
+			bool trigger;
+			bool implicit;
+			bool announce;
+			/* Wake up time */
+			uint8_t twt_wake_interval_ms;
+		} setup;
+		struct {
+			/* Only for Teardown */
+			bool teardown_all;
+		} teardown;
+	};
+};
+
+/* Flow ID is only 3 bits */
+#define WIFI_MAX_TWT_FLOWS 8
+#define WIFI_MAX_TWT_INTERVAL_MS 0x7FFFFFFF
+struct wifi_twt_flow_info {
+	/* Interval = Wake up time + Sleeping time */
+	uint32_t  twt_interval_ms;
+	/* Map requests to responses */
+	uint8_t dialog_token;
+	/* Map setup with teardown */
+	uint8_t flow_id;
+	enum wifi_twt_negotiation_type negotiation_type;
+	bool responder;
+	bool trigger;
+	bool implicit;
+	bool announce;
+	/* Wake up time */
+	uint8_t twt_wake_interval_ms;
+};
+
+struct wifi_ps_config {
+	struct wifi_twt_flow_info twt_flows[WIFI_MAX_TWT_FLOWS];
+	bool enabled;
+	enum wifi_ps_mode mode;
+	char num_twt_flows;
+};
+
 #include <zephyr/net/net_if.h>
 
 typedef void (*scan_result_cb_t)(struct net_if *iface, int status,
@@ -177,6 +264,10 @@ struct net_wifi_mgmt_offload {
 #ifdef CONFIG_NET_STATISTICS_WIFI
 	int (*get_stats)(const struct device *dev, struct net_stats_wifi *stats);
 #endif /* CONFIG_NET_STATISTICS_WIFI */
+	int (*set_power_save)(const struct device *dev, struct wifi_ps_params *params);
+	int (*set_power_save_mode)(const struct device *dev, struct wifi_ps_mode_params *params);
+	int (*set_twt)(const struct device *dev, struct wifi_twt_params *params);
+	int (*get_power_save_config)(const struct device *dev, struct wifi_ps_config *config);
 };
 
 /* Make sure that the network interface API is properly setup inside
@@ -188,6 +279,8 @@ void wifi_mgmt_raise_connect_result_event(struct net_if *iface, int status);
 void wifi_mgmt_raise_disconnect_result_event(struct net_if *iface, int status);
 void wifi_mgmt_raise_iface_status_event(struct net_if *iface,
 		struct wifi_iface_status *iface_status);
+void wifi_mgmt_raise_twt_event(struct net_if *iface,
+		struct wifi_twt_params *twt_params);
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -233,3 +233,82 @@ static int wifi_iface_stats(uint32_t mgmt_request, struct net_if *iface,
 }
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_STATS_GET_WIFI, wifi_iface_stats);
 #endif /* CONFIG_NET_STATISTICS_WIFI */
+
+static int wifi_set_power_save(uint32_t mgmt_request, struct net_if *iface,
+			  void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->api;
+	struct wifi_ps_params *ps_params = data;
+
+	if (off_api == NULL || off_api->set_power_save == NULL) {
+		return -ENOTSUP;
+	}
+
+	return off_api->set_power_save(dev, ps_params);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PS, wifi_set_power_save);
+
+static int wifi_get_power_save_config(uint32_t mgmt_request, struct net_if *iface,
+			  void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->api;
+	struct wifi_ps_config *ps_config = data;
+
+	if (off_api == NULL || off_api->get_power_save_config == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (!data || len != sizeof(*ps_config)) {
+		return -EINVAL;
+	}
+
+	return off_api->get_power_save_config(dev, ps_config);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_CONFIG, wifi_get_power_save_config);
+
+static int wifi_set_power_save_mode(uint32_t mgmt_request, struct net_if *iface,
+			  void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->api;
+	struct wifi_ps_mode_params *ps_mode_params = data;
+
+	if (off_api == NULL || off_api->set_power_save_mode == NULL) {
+		return -ENOTSUP;
+	}
+
+	return off_api->set_power_save_mode(dev, ps_mode_params);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_MODE, wifi_set_power_save_mode);
+
+static int wifi_set_twt(uint32_t mgmt_request, struct net_if *iface,
+			  void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->api;
+	struct wifi_twt_params *twt_params = data;
+
+	if (off_api == NULL || off_api->set_twt == NULL) {
+		return -ENOTSUP;
+	}
+
+	return off_api->set_twt(dev, twt_params);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_TWT, wifi_set_twt);
+
+void wifi_mgmt_raise_twt_event(struct net_if *iface, struct wifi_twt_params *twt_params)
+{
+	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_TWT,
+					iface, twt_params,
+					sizeof(struct wifi_twt_params));
+}

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -29,7 +29,8 @@ LOG_MODULE_REGISTER(net_wifi_shell, LOG_LEVEL_INF);
 #define WIFI_SHELL_MGMT_EVENTS (NET_EVENT_WIFI_SCAN_RESULT |		\
 				NET_EVENT_WIFI_SCAN_DONE |		\
 				NET_EVENT_WIFI_CONNECT_RESULT |		\
-				NET_EVENT_WIFI_DISCONNECT_RESULT)
+				NET_EVENT_WIFI_DISCONNECT_RESULT |  \
+				NET_EVENT_WIFI_TWT)
 
 static struct {
 	const struct shell *sh;
@@ -57,6 +58,24 @@ static struct net_mgmt_event_callback wifi_shell_mgmt_cb;
 			printk(fmt, ##__VA_ARGS__);			\
 		}							\
 	} while (false)
+
+static bool parse_number(const struct shell *sh, long *param, char *str, int min, int max)
+{
+	char *endptr;
+	char *str_tmp = str;
+	long num = strtol(str_tmp, &endptr, 10);
+
+	if (*endptr != '\0') {
+		print(sh, SHELL_ERROR, "Invalid number: %s", str_tmp);
+		return false;
+	}
+	if ((num) < (min) || (num) > (max)) {
+		print(sh, SHELL_WARNING, "Value out of range: %s, (%d-%d)", str_tmp, min, max);
+		return false;
+	}
+	*param = num;
+	return true;
+}
 
 static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 {
@@ -129,6 +148,24 @@ static void handle_wifi_disconnect_result(struct net_mgmt_event_callback *cb)
 	}
 }
 
+static void handle_wifi_twt_event(struct net_mgmt_event_callback *cb)
+{
+	const struct wifi_twt_params *resp =
+		(const struct wifi_twt_params *)cb->info;
+
+	print(context.sh, SHELL_NORMAL, "TWT response: %s for dialog: %d and flow: %d\n",
+	      wifi_twt_setup_cmd_txt(resp->setup_cmd), resp->dialog_token, resp->flow_id);
+
+	/* If accepted, then no need to print TWT params */
+	if (resp->setup_cmd != WIFI_TWT_SETUP_CMD_ACCEPT) {
+		print(context.sh, SHELL_NORMAL,
+		      "TWT parameters: trigger: %s wake_interval_ms: %d, interval_ms: %d\n",
+		      resp->setup.trigger ? "trigger" : "no_trigger",
+		      resp->setup.twt_wake_interval_ms,
+		      resp->setup.twt_interval_ms);
+	}
+}
+
 static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb,
 				    uint32_t mgmt_event, struct net_if *iface)
 {
@@ -144,6 +181,9 @@ static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb,
 		break;
 	case NET_EVENT_WIFI_DISCONNECT_RESULT:
 		handle_wifi_disconnect_result(cb);
+		break;
+	case NET_EVENT_WIFI_TWT:
+		handle_wifi_twt_event(cb);
 		break;
 	default:
 		break;
@@ -383,6 +423,227 @@ static int cmd_wifi_stats(const struct shell *sh, size_t argc, char *argv[])
 	return 0;
 }
 
+static int cmd_wifi_ps(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = net_if_get_default();
+	struct wifi_ps_params params = { 0 };
+
+	context.sh = sh;
+
+	if (argc > 2) {
+		shell_fprintf(sh, SHELL_WARNING, "Invalid number of arguments\n");
+		return -ENOEXEC;
+	}
+
+	if (argc == 1) {
+		struct wifi_ps_config config = { 0 };
+
+		if (net_mgmt(NET_REQUEST_WIFI_PS_CONFIG, iface,
+				&config, sizeof(config))) {
+			shell_fprintf(sh, SHELL_WARNING, "Failed to get PS config\n");
+			return -ENOEXEC;
+		}
+
+		shell_fprintf(sh, SHELL_NORMAL, "PS status: %s\n",
+				wifi_ps_mode_txt(config.enabled));
+		if (config.enabled) {
+			shell_fprintf(sh, SHELL_NORMAL, "PS mode: %s\n",
+					wifi_ps_mode_txt(config.mode));
+		}
+
+		if (config.num_twt_flows == 0) {
+			shell_fprintf(sh, SHELL_NORMAL, "No TWT flows\n");
+		} else {
+			for (int i = 0; i < config.num_twt_flows; i++) {
+				shell_fprintf(sh, SHELL_NORMAL, "TWT Dialog token: %d\n",
+					config.twt_flows[i].dialog_token);
+				shell_fprintf(sh, SHELL_NORMAL, "TWT flow ID: %d\n",
+					config.twt_flows[i].flow_id);
+				shell_fprintf(sh, SHELL_NORMAL, "TWT negotiation type: %s\n",
+					wifi_twt_negotiation_type_txt(
+					config.twt_flows[i].negotiation_type));
+				shell_fprintf(sh, SHELL_NORMAL, "TWT responder: %s\n",
+					config.twt_flows[i].responder ? "true" : "false");
+				shell_fprintf(sh, SHELL_NORMAL, "TWT implicit: %s\n",
+					config.twt_flows[i].implicit ? "true" : "false");
+				shell_fprintf(sh, SHELL_NORMAL, "TWT trigger: %s\n",
+					config.twt_flows[i].trigger ? "true" : "false");
+				shell_fprintf(sh, SHELL_NORMAL, "TWT announce: %s\n",
+					config.twt_flows[i].announce ? "true" : "false");
+				shell_fprintf(sh, SHELL_NORMAL, "TWT wake interval: %d ms\n",
+					config.twt_flows[i].twt_wake_interval_ms);
+				shell_fprintf(sh, SHELL_NORMAL, "TWT interval: %d ms\n",
+					config.twt_flows[i].twt_interval_ms);
+				shell_fprintf(sh, SHELL_NORMAL, "========================\n");
+			}
+		}
+		return 0;
+	}
+
+	if (!strncmp(argv[1], "on", 2)) {
+		params.enabled = WIFI_PS_ENABLED;
+	} else if (!strncmp(argv[1], "off", 3)) {
+		params.enabled = WIFI_PS_DISABLED;
+	} else {
+		shell_fprintf(sh, SHELL_WARNING, "Invalid argument\n");
+		return -ENOEXEC;
+	}
+
+	if (net_mgmt(NET_REQUEST_WIFI_PS, iface, &params, sizeof(params))) {
+		shell_fprintf(sh, SHELL_WARNING, "Power save %s failed\n",
+			params.enabled ? "enable" : "disable");
+		return -ENOEXEC;
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "%s\n", wifi_ps_txt(params.enabled));
+
+	return 0;
+}
+
+static int cmd_wifi_ps_mode(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = net_if_get_default();
+	struct wifi_ps_mode_params params = { 0 };
+
+	context.sh = sh;
+
+	if (argc != 2) {
+		shell_fprintf(sh, SHELL_WARNING, "Invalid number of arguments\n");
+		return -ENOEXEC;
+	}
+
+	if (!strncmp(argv[1], "legacy", 6)) {
+		params.mode = WIFI_PS_MODE_LEGACY;
+	} else if (!strncmp(argv[1], "wmm", 3)) {
+		params.mode = WIFI_PS_MODE_WMM;
+	} else {
+		shell_fprintf(sh, SHELL_WARNING, "Invalid power save mode\n");
+		return -ENOEXEC;
+	}
+
+	if (net_mgmt(NET_REQUEST_WIFI_PS_MODE, iface, &params, sizeof(params))) {
+		shell_fprintf(sh, SHELL_WARNING, "%s failed\n", wifi_ps_mode_txt(params.mode));
+		return -ENOEXEC;
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "%s\n", wifi_ps_mode_txt(params.mode));
+
+	return 0;
+}
+
+static int cmd_wifi_twt_setup(const struct shell *sh, size_t argc,
+			      char *argv[])
+{
+	struct net_if *iface = net_if_get_default();
+	struct wifi_twt_params params = { 0 };
+	long neg_type = 0;
+	long setup_cmd = 0;
+
+	context.sh = sh;
+	int idx = 1;
+
+	if (argc != 11) {
+		shell_fprintf(sh, SHELL_WARNING, "Invalid number of arguments\n");
+		return -ENOEXEC;
+	}
+
+	params.operation = WIFI_TWT_SETUP;
+	neg_type = params.negotiation_type;
+	setup_cmd = params.setup_cmd;
+	if (!parse_number(sh, &neg_type, argv[idx++], WIFI_TWT_INDIVIDUAL,
+			  WIFI_TWT_WAKE_TBTT) ||
+	    !parse_number(sh, &setup_cmd, argv[idx++], WIFI_TWT_SETUP_CMD_REQUEST,
+			  WIFI_TWT_SETUP_CMD_DEMAND) ||
+	    !parse_number(sh, (long *)&params.dialog_token, argv[idx++], 1, 255) ||
+	    !parse_number(sh, (long *)&params.flow_id, argv[idx++], 1, WIFI_MAX_TWT_FLOWS) ||
+	    !parse_number(sh, (long *)&params.setup.responder, argv[idx++], 0, 1) ||
+	    !parse_number(sh, (long *)&params.setup.trigger, argv[idx++], 0, 1) ||
+	    !parse_number(sh, (long *)&params.setup.implicit, argv[idx++], 0, 1) ||
+	    !parse_number(sh, (long *)&params.setup.announce, argv[idx++], 0, 1) ||
+	    !parse_number(sh, (long *)&params.setup.twt_wake_interval_ms, argv[idx++], 1, 255) ||
+	    !parse_number(sh, (long *)&params.setup.twt_interval_ms, argv[idx++], 1,
+			  WIFI_MAX_TWT_INTERVAL_MS))
+		return -EINVAL;
+
+	if (net_mgmt(NET_REQUEST_WIFI_TWT, iface, &params, sizeof(params))) {
+		shell_fprintf(sh, SHELL_WARNING, "%s with %s failed\n",
+			wifi_twt_operation_txt(params.operation),
+			wifi_twt_negotiation_type_txt(params.negotiation_type));
+		return -ENOEXEC;
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "TWT operation %s with dg: %d, flow_id: %d requested\n",
+		wifi_twt_operation_txt(params.operation),
+		params.dialog_token, params.flow_id);
+
+	return 0;
+}
+
+static int cmd_wifi_twt_teardown(const struct shell *sh, size_t argc,
+			      char *argv[])
+{
+	struct net_if *iface = net_if_get_default();
+	struct wifi_twt_params params = { 0 };
+	long neg_type = 0;
+	long setup_cmd = 0;
+
+	context.sh = sh;
+	int idx = 1;
+
+	if (argc != 5) {
+		shell_fprintf(sh, SHELL_WARNING, "Invalid number of arguments\n");
+		return -ENOEXEC;
+	}
+
+	params.operation = WIFI_TWT_TEARDOWN;
+	neg_type = params.negotiation_type;
+	setup_cmd = params.setup_cmd;
+
+	if (!parse_number(sh, &neg_type, argv[idx++], WIFI_TWT_INDIVIDUAL,
+			  WIFI_TWT_WAKE_TBTT) ||
+	    !parse_number(sh, &setup_cmd, argv[idx++], WIFI_TWT_SETUP_CMD_REQUEST,
+			  WIFI_TWT_SETUP_CMD_DEMAND) ||
+	    !parse_number(sh, (long *)&params.dialog_token, argv[idx++], 1, 255) ||
+	    !parse_number(sh, (long *)&params.flow_id, argv[idx++], 1, WIFI_MAX_TWT_FLOWS))
+		return -EINVAL;
+
+	if (net_mgmt(NET_REQUEST_WIFI_TWT, iface, &params, sizeof(params))) {
+		shell_fprintf(sh, SHELL_WARNING, "%s with %s failed\n",
+			wifi_twt_operation_txt(params.operation),
+			wifi_twt_negotiation_type_txt(params.negotiation_type));
+		return -ENOEXEC;
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "TWT operation %s with dg: %d, flow_id: %d requested\n",
+		wifi_twt_operation_txt(params.operation),
+		params.dialog_token, params.flow_id);
+
+	return 0;
+}
+
+static int cmd_wifi_twt_teardown_all(const struct shell *sh, size_t argc,
+			      char *argv[])
+{
+	struct net_if *iface = net_if_get_default();
+	struct wifi_twt_params params = { 0 };
+
+	context.sh = sh;
+
+	params.operation = WIFI_TWT_TEARDOWN;
+	params.teardown.teardown_all = 1;
+
+	if (net_mgmt(NET_REQUEST_WIFI_TWT, iface, &params, sizeof(params))) {
+		shell_fprintf(sh, SHELL_WARNING, "%s with %s failed\n",
+			wifi_twt_operation_txt(params.operation),
+			wifi_twt_negotiation_type_txt(params.negotiation_type));
+		return -ENOEXEC;
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "TWT operation %s all flows\n",
+		wifi_twt_operation_txt(params.operation));
+
+	return 0;
+}
 
 static int cmd_wifi_ap_enable(const struct shell *sh, size_t argc,
 			      char *argv[])
@@ -433,6 +694,23 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_ap,
 	SHELL_SUBCMD_SET_END
 );
 
+SHELL_STATIC_SUBCMD_SET_CREATE(wifi_twt_ops,
+	SHELL_CMD(setup, NULL, " Start a TWT flow:\n"
+		"<negotiation_type, 0: Individual, 1: Broadcast, 2: Wake TBTT>\n"
+		"<setup_cmd: 0: Request, 1: Suggest, 2: Demand>\n"
+		"<dialog_token> <flow_id> <responder> <trigger> <implicit> "
+		"<announce> <twt_wake_interval_ms> <twt_interval_ms>\n",
+		cmd_wifi_twt_setup),
+	SHELL_CMD(teardown, NULL, " Teardown a TWT flow:\n"
+		"<negotiation_type, 0: Individual, 1: Broadcast, 2: Wake TBTT>\n"
+		"<setup_cmd: 0: Request, 1: Suggest, 2: Demand>\n"
+		"<dialog_token> <flow_id>",
+		cmd_wifi_twt_teardown),
+	SHELL_CMD(teardown_all, NULL, " Teardown all TWT flows",
+		cmd_wifi_twt_teardown_all),
+	SHELL_SUBCMD_SET_END
+);
+
 SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 	SHELL_CMD(connect, NULL,
 		  "Connect to a Wi-Fi AP\n"
@@ -449,6 +727,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 	SHELL_CMD(scan, NULL, "Scan for Wi-Fi APs", cmd_wifi_scan),
 	SHELL_CMD(status, NULL, "Status of the Wi-Fi interface", cmd_wifi_status),
 	SHELL_CMD(statistics, NULL, "Wi-Fi interface statistics", cmd_wifi_stats),
+	SHELL_CMD(ps, NULL, "Configure Wi-Fi power save on/off, no arguments will dump config",
+		  cmd_wifi_ps),
+	SHELL_CMD(ps_mode, NULL, "Configure Wi-Fi power save mode legacy/wmm", cmd_wifi_ps_mode),
+	SHELL_CMD(twt, &wifi_twt_ops, "Manage TWT flows", NULL),
 	SHELL_CMD(ap, &wifi_cmd_ap, "Access Point mode commands", NULL),
 	SHELL_SUBCMD_SET_END
 );


### PR DESCRIPTION
Add support for configuring power-save in Wi-Fi chipsets, supports Legacy, WMM and TWT.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>
(cherry picked from commit e7bd2e4af8916bffe05e64a8c1f16f748997f4ba)