### PR TITLE
[nrf noup] boards: thingy53_nrf5340: Add common partition map

### DIFF
--- a/boards/arm/thingy53_nrf5340/pm_static_thingy53_nrf5340_cpuapp.yml
+++ b/boards/arm/thingy53_nrf5340/pm_static_thingy53_nrf5340_cpuapp.yml
@@ -1,0 +1,55 @@
+app:
+  address: 0x10200
+  region: flash_primary
+  size: 0xdfe00
+mcuboot:
+  address: 0x0
+  region: flash_primary
+  size: 0x10000
+mcuboot_pad:
+  address: 0x10000
+  region: flash_primary
+  size: 0x200
+mcuboot_primary:
+  address: 0x10000
+  orig_span: &id001
+  - mcuboot_pad
+  - app
+  region: flash_primary
+  size: 0xe0000
+  span: *id001
+mcuboot_primary_app:
+  address: 0x10200
+  orig_span: &id002
+  - app
+  region: flash_primary
+  size: 0xdfe00
+  span: *id002
+settings_storage:
+  address: 0xf0000
+  region: flash_primary
+  size: 0x10000
+mcuboot_primary_1:
+  address: 0x0
+  size: 0x40000
+  device: flash_ctrl
+  region: ram_flash
+mcuboot_secondary:
+  address: 0x00000
+  size: 0xe0000
+  device: MX25R64
+  region: external_flash
+mcuboot_secondary_1:
+  address: 0xe0000
+  size: 0x40000
+  device: MX25R64
+  region: external_flash
+external_flash:
+  address: 0x120000
+  size: 0x6e0000
+  device: MX25R64
+  region: external_flash
+pcd_sram:
+  address: 0x20000000
+  size: 0x2000
+  region: sram_primary

--- a/boards/arm/thingy53_nrf5340/pm_static_thingy53_nrf5340_cpuapp_ns.yml
+++ b/boards/arm/thingy53_nrf5340/pm_static_thingy53_nrf5340_cpuapp_ns.yml
@@ -1,0 +1,73 @@
+mcuboot:
+  address: 0x0
+  region: flash_primary
+  size: 0x10000
+mcuboot_pad:
+  address: 0x10000
+  region: flash_primary
+  size: 0x200
+tfm_secure:
+  address: 0x10000
+  size: 0xc200
+  span: [mcuboot_pad, tfm]
+tfm_nonsecure:
+  address: 0x1c200
+  size: 0xd3e00
+  span: [app]
+tfm:
+  address: 0x10200
+  region: flash_primary
+  size: 0xc000
+app:
+  address: 0x1c200
+  region: flash_primary
+  size: 0xd3e00
+mcuboot_primary:
+  address: 0x10000
+  orig_span: &id001
+  - mcuboot_pad
+  - tfm
+  - app
+  region: flash_primary
+  size: 0xe0000
+  span: *id001
+mcuboot_primary_app:
+  address: 0x10200
+  orig_span: &id002
+  - tfm
+  - app
+  region: flash_primary
+  size: 0xdfe00
+  span: *id002
+nonsecure_storage:
+  address: 0xf0000
+  size: 0x10000
+  span: [settings_storage]
+settings_storage:
+  address: 0xf0000
+  region: flash_primary
+  size: 0x10000
+mcuboot_primary_1:
+  address: 0x0
+  size: 0x40000
+  device: flash_ctrl
+  region: ram_flash
+mcuboot_secondary:
+  address: 0x00000
+  size: 0xe0000
+  device: MX25R64
+  region: external_flash
+mcuboot_secondary_1:
+  address: 0xe0000
+  size: 0x40000
+  device: MX25R64
+  region: external_flash
+external_flash:
+  address: 0x120000
+  size: 0x6e0000
+  device: MX25R64
+  region: external_flash
+pcd_sram:
+  address: 0x20000000
+  size: 0x2000
+  region: sram_primary


### PR DESCRIPTION
Change introduces common static Partition Manager configuration.

Jira: NCSDK-18033