### PR TITLE
[nrf fromtree] nrfx: align implementation to nrfx 2.10 API

### DIFF
--- a/drivers/ipm/ipm_nrfx_ipc.c
+++ b/drivers/ipm/ipm_nrfx_ipc.c
@@ -28,20 +28,15 @@ static void gipm_send(uint32_t id);
 
 #if IS_ENABLED(CONFIG_IPM_NRF_SINGLE_INSTANCE)
 
-static void nrfx_ipc_handler(uint32_t event_mask, void *p_context)
+static void nrfx_ipc_handler(uint8_t event_idx, void *p_context)
 {
 	if (nrfx_ipm_data.callback) {
-		while (event_mask) {
-			uint8_t event_idx = __CLZ(__RBIT(event_mask));
-
-			__ASSERT(event_idx < NRFX_IPC_ID_MAX_VALUE,
-				 "Illegal event_idx: %d", event_idx);
-			event_mask &= ~BIT(event_idx);
-			nrfx_ipm_data.callback(DEVICE_DT_INST_GET(0),
-					       nrfx_ipm_data.user_data,
-					       event_idx,
-					       NULL);
-		}
+		__ASSERT(event_idx < NRFX_IPC_ID_MAX_VALUE,
+			 "Illegal event_idx: %d", event_idx);
+		nrfx_ipm_data.callback(DEVICE_DT_INST_GET(0),
+				       nrfx_ipm_data.user_data,
+				       event_idx,
+				       NULL);
 	}
 }
 
@@ -124,21 +119,16 @@ struct vipm_nrf_data {
 
 static struct vipm_nrf_data nrfx_vipm_data;
 
-static void vipm_dispatcher(uint32_t event_mask, void *p_context)
+static void vipm_dispatcher(uint8_t event_idx, void *p_context)
 {
-	while (event_mask) {
-		uint8_t event_idx = __CLZ(__RBIT(event_mask));
-
-		__ASSERT(event_idx < NRFX_IPC_ID_MAX_VALUE,
-			 "Illegal event_idx: %d", event_idx);
-		event_mask &= ~BIT(event_idx);
-		if (nrfx_vipm_data.callback[event_idx] != NULL) {
-			nrfx_vipm_data.callback[event_idx]
-				(nrfx_vipm_data.ipm_device[event_idx],
-				 nrfx_vipm_data.user_data[event_idx],
-				 0,
-				 NULL);
-		}
+	__ASSERT(event_idx < NRFX_IPC_ID_MAX_VALUE,
+		 "Illegal event_idx: %d", event_idx);
+	if (nrfx_vipm_data.callback[event_idx] != NULL) {
+		nrfx_vipm_data.callback[event_idx]
+			(nrfx_vipm_data.ipm_device[event_idx],
+			 nrfx_vipm_data.user_data[event_idx],
+			 0,
+			 NULL);
 	}
 }
 

--- a/drivers/mbox/mbox_nrfx_ipc.c
+++ b/drivers/mbox/mbox_nrfx_ipc.c
@@ -45,27 +45,23 @@ static inline bool is_tx_channel_valid(const struct device *dev, uint32_t ch)
 	return ((ch < IPC_CONF_NUM) && (conf->tx_mask & BIT(ch)));
 }
 
-static void mbox_dispatcher(uint32_t event_mask, void *p_context)
+static void mbox_dispatcher(uint8_t event_idx, void *p_context)
 {
 	struct mbox_nrf_data *data = (struct mbox_nrf_data *) p_context;
 	const struct device *dev = data->dev;
 
-	while (event_mask) {
-		uint32_t channel = __CLZ(__RBIT(event_mask));
+	uint32_t channel = event_idx;
 
-		if (!is_rx_channel_valid(dev, channel)) {
-			LOG_WRN("RX event on illegal channel");
-		}
+	if (!is_rx_channel_valid(dev, channel)) {
+		LOG_WRN("RX event on illegal channel");
+	}
 
-		if (!(data->enabled_mask & BIT(channel))) {
-			LOG_WRN("RX event on disabled channel");
-		}
+	if (!(data->enabled_mask & BIT(channel))) {
+		LOG_WRN("RX event on disabled channel");
+	}
 
-		event_mask &= ~BIT(channel);
-
-		if (data->cb[channel] != NULL) {
-			data->cb[channel](dev, channel, data->user_data[channel], NULL);
-		}
+	if (data->cb[channel] != NULL) {
+		data->cb[channel](dev, channel, data->user_data[channel], NULL);
 	}
 }
 

--- a/modules/hal_nordic/nrfx/nrfx_config.h
+++ b/modules/hal_nordic/nrfx/nrfx_config.h
@@ -10,10 +10,10 @@
 #include <zephyr/devicetree.h>
 
 /*
- * NRFX API version 2.9 flag.
- * When the flag is set NRFX API is compatible with the previous NRFX release.
+ * NRFX API version 2.10 flag.
+ * When the flag is set NRFX API is compatible with the newest NRFX release.
  */
-#define NRFX_CONFIG_API_VER_2_9 1
+#define NRFX_CONFIG_API_VER_2_10 1
 
 /*
  * These are mappings of Kconfig options enabling nrfx drivers and particular


### PR DESCRIPTION
Pulls alignment to nrfx 2.10 API in IPM and MBOX drivers shims