### PR TITLE
[nrf fromtree] drivers: uart_nrfx_uarte: Fix call to HW_RX_COUNTING_E…

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1956,10 +1956,11 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 		nrf_uarte_enable(uarte);
 
 #ifdef UARTE_ANY_ASYNC
-		if (HW_RX_COUNTING_ENABLED(data)) {
-			nrfx_timer_enable(&cfg->timer);
-		}
 		if (data->async) {
+			if (HW_RX_COUNTING_ENABLED(data)) {
+				nrfx_timer_enable(&cfg->timer);
+			}
+
 			return 0;
 		}
 #endif


### PR DESCRIPTION
…NABLED()

Since the macro references `data->async->hw_rx_counting`, it cannot be called when `data->async` is NULL, and this could happen when the PM_DEVICE_ACTION_RESUME action was requested for an instance that uses the interrupt-driven API while for another instance that uses the asynchronous API the hardware counting of bytes was configured. Prevent this by calling the macro from a proper `if` block.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>
(cherry picked from commit 9628ecdc39f0dac696160910bce97c06f6a90af0)