### PR TITLE
[backport 3.1.99-ncs1] Bluetooth: host: Fix RPA timeout expiration

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1629,7 +1629,7 @@ int bt_le_ext_adv_stop(struct bt_le_ext_adv *adv)
 	}
 
 	if (atomic_test_and_clear_bit(adv->flags, BT_ADV_LIMITED)) {
-		atomic_clear_bit(adv->flags, BT_ADV_RPA_VALID);
+		bt_id_adv_limited_stopped(adv);
 
 #if defined(CONFIG_BT_SMP)
 		bt_id_pending_keys_update();
@@ -2005,7 +2005,7 @@ void bt_hci_le_adv_set_terminated(struct net_buf *buf)
 	}
 
 	if (atomic_test_and_clear_bit(adv->flags, BT_ADV_LIMITED)) {
-		atomic_clear_bit(adv->flags, BT_ADV_RPA_VALID);
+		bt_id_adv_limited_stopped(adv);
 
 #if defined(CONFIG_BT_SMP)
 		bt_id_pending_keys_update();

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -87,6 +87,8 @@ enum {
 	 * of the RPA timeout.
 	 */
 	BT_ADV_RPA_VALID,
+	/* The private random address of the advertiser is being updated. */
+	BT_ADV_RPA_UPDATE,
 	/* The advertiser set is limited by a timeout, or number of advertising
 	 * events, or both.
 	 */

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -184,9 +184,10 @@ int bt_id_set_adv_random_addr(struct bt_le_ext_adv *adv,
 	return 0;
 }
 
-static void adv_rpa_invalidate(struct bt_le_ext_adv *adv, void *data)
+static void adv_disabled_rpa_invalidate(struct bt_le_ext_adv *adv, void *data)
 {
-	if (!atomic_test_bit(adv->flags, BT_ADV_LIMITED)) {
+	/* Don't invalidate RPA of enabled advertising set. */
+	if (!atomic_test_bit(adv->flags, BT_ADV_ENABLED)) {
 		atomic_clear_bit(adv->flags, BT_ADV_RPA_VALID);
 	}
 }
@@ -199,8 +200,13 @@ static void le_rpa_invalidate(void)
 		atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_VALID);
 	}
 
+	/* Invalidate RPA of advertising sets that are disabled.
+	 *
+	 * Enabled advertising set have to call rpa_expired callback first to
+	 * determine if the RPA of the advertising set should be rotated.
+	 */
 	if (IS_ENABLED(CONFIG_BT_BROADCASTER)) {
-		bt_le_ext_adv_foreach(adv_rpa_invalidate, NULL);
+		bt_le_ext_adv_foreach(adv_disabled_rpa_invalidate, NULL);
 	}
 }
 
@@ -387,41 +393,35 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 #if defined(CONFIG_BT_EXT_ADV) && defined(CONFIG_BT_PRIVACY)
 static void adv_disable_rpa(struct bt_le_ext_adv *adv, void *data)
 {
-	uint8_t adv_index = bt_le_ext_adv_get_index(adv);
-	bool *adv_disabled = data;
 	bool rpa_invalid = true;
-
-	adv_disabled[adv_index] = false;
-
-	/* Invalidate RPA only for non-limited advertising sets. */
-	if (atomic_test_bit(adv->flags, BT_ADV_LIMITED)) {
-		return;
-	}
 
 	/* Disable advertising sets to prepare them for RPA update. */
 	if (atomic_test_bit(adv->flags, BT_ADV_ENABLED) &&
+	    !atomic_test_bit(adv->flags, BT_ADV_LIMITED) &&
 	    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
 		bt_le_adv_set_enable_ext(adv, false, NULL);
 
-		adv_disabled[adv_index] = true;
-	}
+		atomic_set_bit(adv->flags, BT_ADV_RPA_UPDATE);
 
-	/* Notify the user about the RPA timeout and set the RPA validity. */
-	if (adv->cb && adv->cb->rpa_expired) {
-		rpa_invalid = adv->cb->rpa_expired(adv);
-	}
+		/* Notify the user about the RPA timeout and set the RPA validity. */
+		if (adv->cb && adv->cb->rpa_expired) {
+			rpa_invalid = adv->cb->rpa_expired(adv);
+		}
 
-	if (rpa_invalid) {
-		atomic_clear_bit(adv->flags, BT_ADV_RPA_VALID);
+		if (rpa_invalid) {
+			atomic_clear_bit(adv->flags, BT_ADV_RPA_VALID);
+		} else {
+			/* Submit the timeout in case no advertising set updates their RPA
+			 * in the current period. This makes sure that the RPA timer is running.
+			 */
+			le_rpa_timeout_submit();
+		}
 	}
 }
 
 static void adv_enable_rpa(struct bt_le_ext_adv *adv, void *data)
 {
-	uint8_t adv_index = bt_le_ext_adv_get_index(adv);
-	bool *adv_disabled = data;
-
-	if (adv_disabled[adv_index]) {
+	if (atomic_test_and_clear_bit(adv->flags, BT_ADV_RPA_UPDATE)) {
 		int err;
 
 		err = bt_id_set_adv_private_addr(adv);
@@ -438,16 +438,9 @@ static void adv_enable_rpa(struct bt_le_ext_adv *adv, void *data)
 static void adv_update_rpa_foreach(void)
 {
 #if defined(CONFIG_BT_EXT_ADV) && defined(CONFIG_BT_PRIVACY)
-	bool adv_disabled[CONFIG_BT_EXT_ADV_MAX_ADV_SET];
+	bt_le_ext_adv_foreach(adv_disable_rpa, NULL);
 
-	bt_le_ext_adv_foreach(adv_disable_rpa, adv_disabled);
-
-	/* Submit the timeout in case all sets use the same
-	 * RPA for the next rotation period.
-	 */
-	le_rpa_timeout_submit();
-
-	bt_le_ext_adv_foreach(adv_enable_rpa, adv_disabled);
+	bt_le_ext_adv_foreach(adv_enable_rpa, NULL);
 #endif
 }
 
@@ -462,8 +455,6 @@ static void le_update_private_addr(void)
 	    IS_ENABLED(CONFIG_BT_EXT_ADV) &&
 	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
 		adv_update_rpa_foreach();
-	} else {
-		le_rpa_invalidate();
 	}
 
 #if defined(CONFIG_BT_OBSERVER)
@@ -528,6 +519,7 @@ static void le_force_rpa_timeout(void)
 
 	k_work_cancel_delayable_sync(&bt_dev.rpa_update, &sync);
 #endif
+	le_rpa_invalidate();
 	le_update_private_addr();
 }
 
@@ -549,6 +541,8 @@ static void rpa_timeout(struct k_work *work)
 		}
 	}
 
+	le_rpa_invalidate();
+
 	if (IS_ENABLED(CONFIG_BT_BROADCASTER)) {
 		bt_le_ext_adv_foreach(adv_is_private_enabled, &adv_enabled);
 	}
@@ -558,7 +552,6 @@ static void rpa_timeout(struct k_work *work)
 	      atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING) ||
 	      (atomic_test_bit(bt_dev.flags, BT_DEV_SCANNING) &&
 	       atomic_test_bit(bt_dev.flags, BT_DEV_ACTIVE_SCAN)))) {
-		le_rpa_invalidate();
 		return;
 	}
 

--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -71,7 +71,6 @@ static void adv_id_check_func(struct bt_le_ext_adv *adv, void *data)
 	}
 }
 
-#if defined(CONFIG_BT_PRIVACY)
 static void adv_is_private_enabled(struct bt_le_ext_adv *adv, void *data)
 {
 	bool *adv_enabled = data;
@@ -81,7 +80,6 @@ static void adv_is_private_enabled(struct bt_le_ext_adv *adv, void *data)
 		*adv_enabled = true;
 	}
 }
-#endif /* defined(CONFIG_BT_PRIVACY) */
 
 #if defined(CONFIG_BT_SMP)
 static void adv_is_limited_enabled(struct bt_le_ext_adv *adv, void *data)
@@ -184,11 +182,30 @@ int bt_id_set_adv_random_addr(struct bt_le_ext_adv *adv,
 	return 0;
 }
 
-static void adv_disabled_rpa_invalidate(struct bt_le_ext_adv *adv, void *data)
+static void adv_rpa_expired(struct bt_le_ext_adv *adv)
 {
-	/* Don't invalidate RPA of enabled advertising set. */
-	if (!atomic_test_bit(adv->flags, BT_ADV_ENABLED)) {
+	bool rpa_invalid = true;
+
+#if defined(CONFIG_BT_EXT_ADV) && defined(CONFIG_BT_PRIVACY)
+	/* Notify the user about the RPA timeout and set the RPA validity. */
+	if (atomic_test_bit(adv->flags, BT_ADV_RPA_VALID) &&
+	    adv->cb && adv->cb->rpa_expired) {
+		rpa_invalid = adv->cb->rpa_expired(adv);
+	}
+#endif
+	if (rpa_invalid) {
 		atomic_clear_bit(adv->flags, BT_ADV_RPA_VALID);
+	}
+}
+
+static void adv_rpa_invalidate(struct bt_le_ext_adv *adv, void *data)
+{
+	/* RPA of Advertisers limited by timeot or number of packets only expire
+	 * when they are stopped.
+	 */
+	if (!atomic_test_bit(adv->flags, BT_ADV_LIMITED) &&
+	    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
+		adv_rpa_expired(adv);
 	}
 }
 
@@ -200,13 +217,8 @@ static void le_rpa_invalidate(void)
 		atomic_clear_bit(bt_dev.flags, BT_DEV_RPA_VALID);
 	}
 
-	/* Invalidate RPA of advertising sets that are disabled.
-	 *
-	 * Enabled advertising set have to call rpa_expired callback first to
-	 * determine if the RPA of the advertising set should be rotated.
-	 */
 	if (IS_ENABLED(CONFIG_BT_BROADCASTER)) {
-		bt_le_ext_adv_foreach(adv_disabled_rpa_invalidate, NULL);
+		bt_le_ext_adv_foreach(adv_rpa_invalidate, NULL);
 	}
 }
 
@@ -298,6 +310,13 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 
 	/* check if RPA is valid */
 	if (atomic_test_bit(adv->flags, BT_ADV_RPA_VALID)) {
+		/* Schedule the RPA timer if it is not running.
+		 * The RPA may be valid without the timer running.
+		 */
+		if (!atomic_test_bit(adv->flags, BT_ADV_LIMITED)) {
+			le_rpa_timeout_submit();
+		}
+
 		return 0;
 	}
 
@@ -390,10 +409,9 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv)
 }
 #endif /* defined(CONFIG_BT_PRIVACY) */
 
-#if defined(CONFIG_BT_EXT_ADV) && defined(CONFIG_BT_PRIVACY)
-static void adv_disable_rpa(struct bt_le_ext_adv *adv, void *data)
+static void adv_pause_rpa(struct bt_le_ext_adv *adv, void *data)
 {
-	bool rpa_invalid = true;
+	bool *adv_enabled = data;
 
 	/* Disable advertising sets to prepare them for RPA update. */
 	if (atomic_test_bit(adv->flags, BT_ADV_ENABLED) &&
@@ -402,21 +420,26 @@ static void adv_disable_rpa(struct bt_le_ext_adv *adv, void *data)
 		bt_le_adv_set_enable_ext(adv, false, NULL);
 
 		atomic_set_bit(adv->flags, BT_ADV_RPA_UPDATE);
+		*adv_enabled = true;
+	}
+}
 
-		/* Notify the user about the RPA timeout and set the RPA validity. */
-		if (adv->cb && adv->cb->rpa_expired) {
-			rpa_invalid = adv->cb->rpa_expired(adv);
-		}
+static bool le_adv_rpa_timeout(void)
+{
+	bool adv_enabled = false;
 
-		if (rpa_invalid) {
-			atomic_clear_bit(adv->flags, BT_ADV_RPA_VALID);
+	if (IS_ENABLED(CONFIG_BT_BROADCASTER)) {
+		if (IS_ENABLED(CONFIG_BT_EXT_ADV) &&
+		    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+			/* Pause all advertising sets using RPAs */
+			bt_le_ext_adv_foreach(adv_pause_rpa, &adv_enabled);
 		} else {
-			/* Submit the timeout in case no advertising set updates their RPA
-			 * in the current period. This makes sure that the RPA timer is running.
-			 */
-			le_rpa_timeout_submit();
+			/* Check if advertising set is enabled */
+			bt_le_ext_adv_foreach(adv_is_private_enabled, &adv_enabled);
 		}
 	}
+
+	return adv_enabled;
 }
 
 static void adv_enable_rpa(struct bt_le_ext_adv *adv, void *data)
@@ -433,16 +456,6 @@ static void adv_enable_rpa(struct bt_le_ext_adv *adv, void *data)
 		bt_le_adv_set_enable_ext(adv, true, NULL);
 	}
 }
-#endif /* defined(CONFIG_BT_EXT_ADV) && defined(CONFIG_BT_PRIVACY) */
-
-static void adv_update_rpa_foreach(void)
-{
-#if defined(CONFIG_BT_EXT_ADV) && defined(CONFIG_BT_PRIVACY)
-	bt_le_ext_adv_foreach(adv_disable_rpa, NULL);
-
-	bt_le_ext_adv_foreach(adv_enable_rpa, NULL);
-#endif
-}
 
 static void le_update_private_addr(void)
 {
@@ -450,12 +463,6 @@ static void le_update_private_addr(void)
 	bool adv_enabled = false;
 	uint8_t id = BT_ID_DEFAULT;
 	int err;
-
-	if (IS_ENABLED(CONFIG_BT_BROADCASTER) &&
-	    IS_ENABLED(CONFIG_BT_EXT_ADV) &&
-	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
-		adv_update_rpa_foreach();
-	}
 
 #if defined(CONFIG_BT_OBSERVER)
 	bool scan_enabled = false;
@@ -501,6 +508,12 @@ static void le_update_private_addr(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_BROADCASTER) &&
+	    IS_ENABLED(CONFIG_BT_EXT_ADV) &&
+	    BT_DEV_FEAT_LE_EXT_ADV(bt_dev.le.features)) {
+		bt_le_ext_adv_foreach(adv_enable_rpa, NULL);
+	}
+
+	if (IS_ENABLED(CONFIG_BT_BROADCASTER) &&
 	    adv && adv_enabled) {
 		bt_le_adv_set_enable_legacy(adv, true);
 	}
@@ -519,6 +532,7 @@ static void le_force_rpa_timeout(void)
 
 	k_work_cancel_delayable_sync(&bt_dev.rpa_update, &sync);
 #endif
+	(void)le_adv_rpa_timeout();
 	le_rpa_invalidate();
 	le_update_private_addr();
 }
@@ -526,7 +540,7 @@ static void le_force_rpa_timeout(void)
 #if defined(CONFIG_BT_PRIVACY)
 static void rpa_timeout(struct k_work *work)
 {
-	bool adv_enabled = false;
+	bool adv_enabled;
 
 	BT_DBG("");
 
@@ -541,11 +555,8 @@ static void rpa_timeout(struct k_work *work)
 		}
 	}
 
+	adv_enabled = le_adv_rpa_timeout();
 	le_rpa_invalidate();
-
-	if (IS_ENABLED(CONFIG_BT_BROADCASTER)) {
-		bt_le_ext_adv_foreach(adv_is_private_enabled, &adv_enabled);
-	}
 
 	/* IF no roles using the RPA is running we can stop the RPA timer */
 	if (!(adv_enabled ||
@@ -667,6 +678,11 @@ bool bt_id_adv_random_addr_check(const struct bt_le_adv_param *param)
 	 * the error code to the application.
 	 */
 	return true;
+}
+
+void bt_id_adv_limited_stopped(struct bt_le_ext_adv *adv)
+{
+	adv_rpa_expired(adv);
 }
 
 #if defined(CONFIG_BT_SMP)

--- a/subsys/bluetooth/host/id.h
+++ b/subsys/bluetooth/host/id.h
@@ -43,3 +43,5 @@ int bt_id_set_adv_private_addr(struct bt_le_ext_adv *adv);
 int bt_id_set_private_addr(uint8_t id);
 
 void bt_id_pending_keys_update(void);
+
+void bt_id_adv_limited_stopped(struct bt_le_ext_adv *adv);


### PR DESCRIPTION
Fix RPA timeout expiration when BT_EXT_ADV has been enabled.

Always invalidate the device RPA on RPA timeout.
This RPA is used by the scan roles, and the advertiser that was started
using the bt_le_adv_start API.

Call the RPA expire callback only on advertising sets that are enabled
and not being limited by a timeout and not using the identity address.
On RPA timeout always invalidate the RPA of advertising sets that are
disabled.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/51208
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/51228
Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/51247

Manifest PR: https://github.com/nrfconnect/sdk-nrf/pull/9405