### PR TITLE
[nrf fromlist] boards: thingy52_nrf52832: Remove regulator sync from vdd-pwr-ctrl

### DIFF
--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -72,7 +72,7 @@
 	};
 
 	vdd_pwr: vdd-pwr-ctrl {
-		compatible = "regulator-fixed-sync", "regulator-fixed";
+		compatible = "regulator-fixed";
 		regulator-name = "vdd-pwr-ctrl";
 		enable-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;


### PR DESCRIPTION
Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/52504

The regulator defines non-zero `startup-delay-us`, so `regulator-fixed-sync` cannot be used.