### PR TITLE
[nrf noup] boards: thingy53_nrf5340: Enable MCUboot by default

### DIFF
--- a/boards/arm/thingy53_nrf5340/Kconfig.defconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig.defconfig
@@ -8,6 +8,12 @@ if BOARD_THINGY53_NRF5340_CPUAPP || BOARD_THINGY53_NRF5340_CPUAPP_NS
 config BOARD
 	default "thingy53_nrf5340_cpuapp"
 
+config BOOTLOADER_MCUBOOT
+	default y if !MCUBOOT
+
+config BOARD_ENABLE_CPUNET
+	default y if !MCUBOOT
+
 # By default, if we build for a Non-Secure version of the board,
 # enable building with TF-M as the Secure Execution Environment.
 config BUILD_WITH_TFM

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -14,6 +14,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 		zephyr,ieee802154 = &ieee802154;
+		nordic,pm-ext-flash = &mx25r64;
 	};
 
 	buttons {


### PR DESCRIPTION
Change enables MCUboot bootloader by default to allow programming samples and applications without external programmer (using MCUboot serial recovery).

Jira: NCSDK-18263