### PR TITLE
[nrf fromtree] bluetooth: host: smp: unauth bond overwrite on differe…

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -503,6 +503,17 @@ config BT_ID_UNPAIR_MATCHING_BONDS
 	  link-layer. The Host does not have control over this acknowledgment,
 	  and the order of distribution is fixed by the specification.
 
+config BT_ID_ALLOW_UNAUTH_OVERWRITE
+	bool "Allow unauthenticated pairing with same peer with other local identity"
+	depends on !BT_SMP_ALLOW_UNAUTH_OVERWRITE
+	help
+	  This option allows unauthenticated pairing attempts made by the
+	  peer where an unauthenticated bond already exists on other local
+	  identity. This configuration still blocks unauthenticated pairing
+	  attempts on the same local identity. To allow the pairing procedure
+	  unconditionally, please see the BT_SMP_ALLOW_UNAUTH_OVERWRITE
+	  configuration.
+
 config BT_SMP_USB_HCI_CTLR_WORKAROUND
 	bool "Workaround for USB HCI controller out-of-order events"
 	depends on BT_TESTING

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -789,7 +789,10 @@ static bool update_keys_check(struct bt_smp *smp, struct bt_keys *keys)
 	if (!IS_ENABLED(CONFIG_BT_SMP_ALLOW_UNAUTH_OVERWRITE) &&
 	    (!(keys->flags & BT_KEYS_AUTHENTICATED)
 	     && smp->method == JUST_WORKS)) {
-		return false;
+		if (!IS_ENABLED(CONFIG_BT_ID_ALLOW_UNAUTH_OVERWRITE) ||
+		    (keys->id == smp->chan.chan.conn->id)) {
+			return false;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
…nt identity

Added a new Kconfig option for the Bluetooth Host to allow unauthenticated pairing attempts made by the peer where an unauthenticated bond already exists on other local identity.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>
(cherry picked from commit 916e02563cf5742a0948c0ee9987083c32ce4d34)