### PR TITLE
[nrf fromlist] lib: newlib: Define _ANSI_SOURCE

### DIFF
--- a/lib/libc/newlib/CMakeLists.txt
+++ b/lib/libc/newlib/CMakeLists.txt
@@ -26,6 +26,13 @@ if(LIBC_LIBRARY_DIR)
   set(LIBC_LIBRARY_DIR_FLAG -L${LIBC_LIBRARY_DIR})
 endif()
 
+# Define _ANSI_SOURCE in order to prevent Newlib from defining POSIX primitives
+# in its headers when GNU dialect is used (-std=gnu*). Newlib features.h
+# defines _DEFAULT_SOURCE when __STRICT_ANSI__ is not defined by GCC (i.e. when
+# -std=gnu*), which leads to various POSIX definitions being provided by the
+# Newlib headers and conflicts with the POSIX definitions provided by Zephyr.
+zephyr_compile_definitions(_ANSI_SOURCE)
+
 # define __LINUX_ERRNO_EXTENSIONS__ so we get errno defines like -ESHUTDOWN
 # used by the network stack
 zephyr_compile_definitions(__LINUX_ERRNO_EXTENSIONS__)


### PR DESCRIPTION
This commit updates the Newlib integration to define `_ANSI_SOURCE` in order to prevent Newlib from defining POSIX primitives in its headers when GNU dialect is used (`-std=gnu*`).

Newlib `features.h` defines `_DEFAULT_SOURCE` when `__STRICT_ANSI__` is not defined by GCC (i.e. when `-std=gnu*`), which results in the Newlib headers defining POSIX primitives that are in conflict with the POSIX primitives defined by Zephyr.

Newlib must not define POSIX primitives unless the feature test macros such as `_POSIX_SOURCE`, `_GNU_SOURCE` and `_DEFAULT_SOURCE` are explicitly defined.

Note that `-std=gnu` does not imply `_GNU_SOURCE` or `_DEFAULT_SOURCE` because it is only supposed to instruct the compiler to use the GNU C language dialect (i.e. GNU C language extensions).

Refer to the GitHub issue #52739 for more details.

Upstream PR: zephyrproject-rtos/zephyr#52740

Signed-off-by: Stephanos Ioannidis <stephanos.ioannidis@nordicsemi.no>

Fixes NCSIDB-890