### PR TITLE
Revert "[nrf noup] kconfig: Disallow FPU for SPM"

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -785,7 +785,6 @@ menu "Floating Point Options"
 config FPU
 	bool "Floating point unit (FPU)"
 	depends on CPU_HAS_FPU
-	depends on !IS_SPM
 	help
 	  This option enables the hardware Floating Point Unit (FPU), in order to
 	  support using the floating point registers and instructions.


### PR DESCRIPTION
This reverts commit ee89a68db75bf0d52dbfc9ee0ad9b4e4dfc18500.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>