### PR TITLE
[nrf fromlist] drivers: usb_dc_nrfx: Do not uninit on detach

### DIFF
--- a/drivers/usb/device/usb_dc_nrfx.c
+++ b/drivers/usb/device/usb_dc_nrfx.c
@@ -1264,7 +1264,6 @@ static void usbd_work_handler(struct k_work *item)
 int usb_dc_attach(void)
 {
 	struct nrf_usbd_ctx *ctx = get_usbd_ctx();
-	nrfx_err_t err;
 	int ret;
 
 	if (ctx->attached) {
@@ -1281,12 +1280,6 @@ int usb_dc_attach(void)
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    nrfx_isr, nrfx_usbd_irq_handler, 0);
 
-	err = nrfx_usbd_init(usbd_event_handler);
-
-	if (err != NRFX_SUCCESS) {
-		LOG_DBG("nRF USBD driver init failed. Code: %d", (uint32_t)err);
-		return -EIO;
-	}
 	nrfx_power_usbevt_enable();
 
 	ret = eps_ctx_init();
@@ -1322,10 +1315,6 @@ int usb_dc_detach(void)
 
 	if (nrfx_usbd_is_enabled()) {
 		nrfx_usbd_disable();
-	}
-
-	if (nrfx_usbd_is_initialized()) {
-		nrfx_usbd_uninit();
 	}
 
 	(void)hfxo_stop(ctx);
@@ -1887,6 +1876,7 @@ int usb_dc_wakeup_request(void)
 static int usb_init(const struct device *arg)
 {
 	struct nrf_usbd_ctx *ctx = get_usbd_ctx();
+	nrfx_err_t err;
 
 #ifdef CONFIG_HAS_HW_NRF_USBREG
 	/* Use CLOCK/POWER priority for compatibility with other series where
@@ -1910,6 +1900,12 @@ static int usb_init(const struct device *arg)
 	static const nrfx_power_usbevt_config_t usbevt_config = {
 		.handler = usb_dc_power_event_handler
 	};
+
+	err = nrfx_usbd_init(usbd_event_handler);
+	if (err != NRFX_SUCCESS) {
+		LOG_DBG("nRF USBD driver init failed. Code: %d", (uint32_t)err);
+		return -EIO;
+	}
 
 	/* Ignore the return value, as NRFX_ERROR_ALREADY_INITIALIZED is not
 	 * a problem here.


### PR DESCRIPTION
It is possible for nrfx usbd driver to send NRFX_USBBD_EP_ABORTED during endpoint disable. The event is passed to event handler registered with nrfx_usbd_init(). The nrfx_usbd_uninit() removes the registered event handler, replacing it with NULL. If any event is sent after uninit, the NULL pointer is executed and device crashes.

Do not uninit nrfx usbd driver on detach so it is possible for the usb_disable() to disable all the endpoints.

Fixes: 460ca86527dd ("drivers: usb_dc_nrfx: Always allow endpoint disable")

Upstream PR: zephyrproject-rtos/zephyr#52752

(cherry picked from commit fa9a0e31223b3138d87056eabb32b0edb4a18310)
Signed-off-by: Tomasz Moń <tomasz.mon@nordicsemi.no>