### PR TITLE
Backport: lock the github action runner version to 20.04

### DIFF
--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   compliance_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Run coding guidelines checks on patch series (PR)
     steps:
     - name: Checkout the code

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -4,7 +4,7 @@ on: pull_request
 
 jobs:
   maintainer_check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Check MAINTAINERS file
     steps:
     - name: Checkout the code
@@ -22,7 +22,7 @@ jobs:
         python3 ./scripts/get_maintainer.py path CMakeLists.txt
 
   check_compliance:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Run compliance checks on patch series (PR)
     steps:
     - name: Update PATH for west

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -35,8 +35,9 @@ env:
 jobs:
   doc-build-html:
     name: "Documentation Build (HTML)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 45
+
     concurrency:
       group: doc-build-html-${{ github.ref }}
       cancel-in-progress: true
@@ -121,7 +122,7 @@ jobs:
 
   doc-build-pdf:
     name: "Documentation Build (PDF)"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: texlive/texlive:latest
     timeout-minutes: 45
     concurrency:

--- a/.github/workflows/doc-publish-pr.yml
+++ b/.github/workflows/doc-publish-pr.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   doc-publish:
     name: Publish Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: |
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   doc-publish:
     name: Publish Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: |
       github.event.workflow_run.event != 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&


### PR DESCRIPTION
commit aea5f90d7dcad14695218aae49d37827b416a9cd
    [nrf fromtree] ci: compliance: Use Ubuntu 20.04 runner image
    
    This commit updates the compliance check workflow to use a specific
    runner image version, ubuntu-20.04, instead of the latest version in
    order to prevent any potential breakages due to the 'latest' version
    change by GitHub.
    
commit 7d8541f05e92c4de8e497ccc220794e2d2493e60
    [nrf fromtree] ci: doc: Use Ubuntu 20.04 runner image
    
    This commit updates the documentation build and publish workflows to
    use a specific runner image version, ubuntu-20.04, instead of the
    latest version in order to prevent any potential breakages due to the
    'latest' version change by GitHub.
    
commit 65b0b52715d67967681023651001ace6ac46272c
    [nrf fromtree] ci: coding_guidelines: Use Ubuntu 20.04 runner image
    
    This commit updates the coding guidelines workflow to use a specific
    runner image version, ubuntu-20.04, instead of the latest version in
    order to prevent any potential breakages due to the 'latest' version
    change by GitHub.
    
