### PR TITLE
[nrf noup] thingy53_nrf5340 DTS was missing nordic,pm-ext-flash

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -14,6 +14,7 @@
 		zephyr,bt-c2h-uart = &uart0;
 		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 		zephyr,ieee802154 = &ieee802154;
+		nordic,pm-ext-flash = &mx25r64;
 	};
 
 	buttons {


### PR DESCRIPTION
Add missing chosen nordic,pm-ext-flash to thingy53_nrf5340, which prevented the board based applications to build.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>