### PR TITLE
[nrf fromtree] drivers: uart_nrfx_uarte: Prevent re-enabling RX until UART_RX_DISABLED

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1955,10 +1955,11 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 		nrf_uarte_enable(uarte);
 
 #ifdef UARTE_ANY_ASYNC
-		if (HW_RX_COUNTING_ENABLED(data)) {
-			nrfx_timer_enable(&cfg->timer);
-		}
 		if (data->async) {
+			if (HW_RX_COUNTING_ENABLED(data)) {
+				nrfx_timer_enable(&cfg->timer);
+			}
+
 			return 0;
 		}
 #endif

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -112,7 +112,8 @@ struct uarte_async_cb {
 	atomic_t low_power_mask;
 	uint8_t rx_flush_buffer[UARTE_HW_RX_FIFO_SIZE];
 	uint8_t rx_flush_cnt;
-	bool rx_enabled;
+	volatile bool rx_enabled;
+	volatile bool discard_rx_fifo;
 	bool hw_rx_counting;
 	bool pending_tx;
 	/* Flag to ensure that RX timeout won't be executed during ENDRX ISR */
@@ -897,7 +898,11 @@ static int uarte_nrfx_rx_enable(const struct device *dev, uint8_t *buf,
 		return -ENOTSUP;
 	}
 
-	if (data->async->rx_enabled) {
+	/* Signal error if RX is already enabled or if the driver is waiting
+	 * for the RXTO event after a call to uart_rx_disable() to discard
+	 * data from the UARTE internal RX FIFO.
+	 */
+	if (data->async->rx_enabled || data->async->discard_rx_fifo) {
 		return -EBUSY;
 	}
 
@@ -1013,6 +1018,7 @@ static int uarte_nrfx_rx_disable(const struct device *dev)
 
 	k_timer_stop(&data->async->rx_timeout_timer);
 	data->async->rx_enabled = false;
+	data->async->discard_rx_fifo = true;
 
 	nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STOPRX);
 
@@ -1334,16 +1340,17 @@ static void rxto_isr(const struct device *dev)
 	rx_buf_release(dev, &data->async->rx_buf);
 	rx_buf_release(dev, &data->async->rx_next_buf);
 
-	/* If the rx_enabled flag is still set at this point, it means that
-	 * RX is being disabled because all provided RX buffers have been
-	 * filled up. Clear the flag then, so that RX can be enabled again.
-	 *
-	 * If the flag is already cleared, it means that RX was aborted by
-	 * a call to uart_rx_disable() and data from FIFO should be discarded.
+	/* This point can be reached in two cases:
+	 * 1. RX is disabled because all provided RX buffers have been filled.
+	 * 2. RX was explicitly disabled by a call to uart_rx_disable().
+	 * In both cases, the rx_enabled flag is cleared, so that RX can be
+	 * enabled again.
+	 * In the second case, additionally, data from the UARTE internal RX
+	 * FIFO need to be discarded.
 	 */
-	if (data->async->rx_enabled) {
-		data->async->rx_enabled = false;
-	} else {
+	data->async->rx_enabled = false;
+	if (data->async->discard_rx_fifo) {
+		data->async->discard_rx_fifo = false;
 		(void)rx_flush(dev, NULL, 0);
 	}
 


### PR DESCRIPTION
Fix the driver so that after a call to uart_rx_disable() it does not allow re-enabling RX until the UART_RX_DISABLED is generated (what means that the disabling procedure is complete). Otherwise, it is possible that the RXTO event from the previous RX is handled right after a new RX is started, and the RX buffer pointer gets corrupted in the `rx_flush()` function.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>
(cherry picked from commit c984a343afdb06abb7cf8cca03c00eacdf88675e)
Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>