### PR TITLE
[nrf noup] boards: thingy53_nrf5340: Set MCUBoot to use all of RAM

### DIFF
--- a/boards/arm/thingy53_nrf5340/Kconfig.defconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig.defconfig
@@ -14,6 +14,9 @@ config BOOTLOADER_MCUBOOT
 config BOARD_ENABLE_CPUNET
 	default y if !MCUBOOT
 
+config MCUBOOT_USE_ALL_AVAILABLE_RAM
+	default y if BOOTLOADER_MCUBOOT
+
 # By default, if we build for a Non-Secure version of the board,
 # enable building with TF-M as the Secure Execution Environment.
 config BUILD_WITH_TFM


### PR DESCRIPTION
Change enables MCUBoot to use all available RAM on thingy53 as it require more RAM than what is reserved as secure. This will make thingy53 a little bit less secure than our other boards. Since this is a prototype board I think it should be okay as we require the enabled MCUBoot features for it to be programmable without a debugger.

Jira: NCSDK-17250

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>