### PR TITLE
fixup: [nrf noup] ci: NCS-specific CI tweaks

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -41,9 +41,11 @@ jobs:
         #[[ "$(git rev-list --merges --count origin/${BASE_REF}..)" == "0" ]] || \
         #(echo "::error ::Merge commits not allowed, rebase instead";false)
         # Sauce tag checks before rebasing
+        # Handle single commit separately
+        if [[ "$(git rev-list --first-parent --count origin/${BASE_REF}..HEAD)" == "1" ]]; then COMMITS="--commit"; else COMMITS="--commits"; fi
         git rev-list --first-parent origin/${BASE_REF}..HEAD | paste -sd, | \
         xargs gitlint -c ncs-sauce-tags.enable=true \
-        -c title-starts-with-subsystem.regex=".*" --commits
+        -c title-starts-with-subsystem.regex=".*" $COMMITS
         git rebase origin/${BASE_REF}
         # debug
         git log  --pretty=oneline | head -n 10


### PR DESCRIPTION
When merging a single commit we should be using "--commit" option of gitlint as per [1] from 0.9.0 "--commits" doesn't work for single commit causing gitlint to lint all commits in the repo.

FYI, [2] fixes this issue, but it is not merged yet.

[1] - https://github.com/jorisroovers/gitlint/blob/main/CHANGELOG.md#v090-2017-12-03 [2] - https://github.com/jorisroovers/gitlint/pull/412

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>