### PR TITLE
[nrf noup] scripts: west_commands: runners: nrfjprog: bring --snr back

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -5,6 +5,7 @@
 
 '''Runner for flashing with nrfjprog.'''
 
+from functools import partial
 import os
 from pathlib import Path
 import shlex
@@ -12,7 +13,7 @@ import subprocess
 import sys
 from re import fullmatch, escape
 
-from runners.core import ZephyrBinaryRunner, RunnerCaps
+from runners.core import ZephyrBinaryRunner, RunnerCaps, depr_action
 
 try:
     from intelhex import IntelHex
@@ -69,6 +70,10 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--softreset', required=False,
                             action='store_true',
                             help='use reset instead of pinreset')
+        parser.add_argument('--snr', required=False, dest='dev_id',
+                            action=partial(depr_action,
+                                           replacement='-i/--dev-id'),
+                            help='Deprecated: use -i/--dev-id instead')
         parser.add_argument('--force', required=False,
                             action='store_true',
                             help='Flash even if the result cannot be guaranteed.')


### PR DESCRIPTION
This patch partially reverts 2cee5ff.

nRF VScode extension implemented support for the new option, `--dev-id`, however, it relied on deprecated code paths to detect wether Zephyr supported `--dev-id` or not. The extension has been updated to fix this issue, so this patch can be safely removed once a new release of the extension gets deployed. In the mean time, it will allow people working on `main` to not experience any issues.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>