### PR TITLE
Upstream fixes for mesh and mesh friendship

### DIFF
--- a/include/zephyr/bluetooth/mesh/msg.h
+++ b/include/zephyr/bluetooth/mesh/msg.h
@@ -99,6 +99,50 @@ struct bt_mesh_msg_ctx {
 	uint8_t  send_ttl;
 };
 
+/**
+ * @brief Helper for bt_mesh_msg_ctx structure initialization.
+ *
+ * @param net_key_idx NetKey Index of the subnet to send the message on. Only used if
+ * @c app_key_idx points to devkey.
+ * @param app_key_idx AppKey Index to encrypt the message with.
+ * @param dst Remote addr.
+ * @param ttl Time To Live.
+ */
+#define BT_MESH_MSG_CTX_INIT(net_key_idx, app_key_idx, dst, ttl) \
+	{ \
+		.net_idx = (net_key_idx), \
+		.app_idx = (app_key_idx), \
+		.addr = (dst), \
+		.send_ttl = (ttl), \
+	}
+
+/**
+ * @brief Helper for bt_mesh_msg_ctx structure initialization secured with Application Key.
+ *
+ * @param app_key_idx AppKey Index to encrypt the message with.
+ * @param dst Remote addr.
+ */
+#define BT_MESH_MSG_CTX_INIT_APP(app_key_idx, dst) \
+	BT_MESH_MSG_CTX_INIT(0, app_key_idx, dst, BT_MESH_TTL_DEFAULT)
+
+/**
+ * @brief Helper for bt_mesh_msg_ctx structure initialization secured with Device Key of a remote
+ * device.
+ *
+ * @param net_key_idx NetKey Index of the subnet to send the message on.
+ * @param dst Remote addr.
+ */
+#define BT_MESH_MSG_CTX_INIT_DEV(net_key_idx, dst) \
+	BT_MESH_MSG_CTX_INIT(net_key_idx, BT_MESH_KEY_DEV_REMOTE, dst, BT_MESH_TTL_DEFAULT)
+
+/**
+ * @brief Helper for bt_mesh_msg_ctx structure initialization using Model Publication context.
+ *
+ * @param pub Pointer to a model publication context.
+ */
+#define BT_MESH_MSG_CTX_INIT_PUB(pub) \
+	BT_MESH_MSG_CTX_INIT(0, (pub)->key, (pub)->addr, (pub)->ttl)
+
 /** @brief Initialize a model message.
  *
  *  Clears the message buffer contents, and encodes the given opcode.

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -421,7 +421,17 @@ config BT_MESH_ADV_EXT_GATT_SEPARATE
 	depends on BT_MESH_GATT_SERVER
 	help
 	  Use a separate extended advertising set for GATT Server Advertising,
-	  otherwise will be used a shared advertising set.
+	  otherwise a shared advertising set will be used.
+
+config BT_MESH_ADV_EXT_FRIEND_SEPARATE
+	bool "Use a separate extended advertising set for Friend advertising"
+	depends on BT_MESH_FRIEND
+	help
+	  Use a separate extended advertising set for Friend advertising,
+	  otherwise a shared advertising set will be used. Using the separate
+	  extended advertising set makes the Friend node send friendship
+	  messages as close to the start of the ReceiveWindow as possible,
+	  thus reducing the scanning time on the Low Power node.
 
 endif # BT_MESH_ADV_EXT
 
@@ -880,12 +890,14 @@ config BT_MESH_FRIEND_SEG_RX
 
 config BT_MESH_FRIEND_ADV_LATENCY
 	int "Latency for enabling advertising"
+	range 0 4
 	default 0
 	help
-	  Latency in milliseconds that it takes to start friend advertising
-	  after requesting it. Used to tune the receive delay window to make
-	  Friend poll events more efficient by compensating for the time the
-	  non-ideal latency otherwise would add to the delay.
+	  Latency in milliseconds between request for and start of Friend
+	  advertising. Used to tune the ReceiveDelay, making Friend
+	  start sending a message earlier thus compensating for the time between
+	  pushing the message to the Bluetooth host and the actual advertising
+	  start.
 
 endif # BT_MESH_FRIEND
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -878,6 +878,15 @@ config BT_MESH_FRIEND_SEG_RX
 	  many elements we can simultaneously be receiving segmented
 	  messages from when the messages are going into the Friend queue.
 
+config BT_MESH_FRIEND_ADV_LATENCY
+	int "Latency for enabling advertising"
+	default 0
+	help
+	  Latency in milliseconds that it takes to start friend advertising
+	  after requesting it. Used to tune the receive delay window to make
+	  Friend poll events more efficient by compensating for the time the
+	  non-ideal latency otherwise would add to the delay.
+
 endif # BT_MESH_FRIEND
 
 config BT_MESH_CFG_CLI

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -188,11 +188,7 @@ static int publish_transmit(struct bt_mesh_model *mod)
 {
 	NET_BUF_SIMPLE_DEFINE(sdu, BT_MESH_TX_SDU_MAX);
 	struct bt_mesh_model_pub *pub = mod->pub;
-	struct bt_mesh_msg_ctx ctx = {
-		.addr = pub->addr,
-		.send_ttl = pub->ttl,
-		.app_idx = pub->key,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_PUB(pub);
 	struct bt_mesh_net_tx tx = {
 		.ctx = &ctx,
 		.src = bt_mesh_model_elem(mod)->addr,

--- a/subsys/bluetooth/mesh/adv.c
+++ b/subsys/bluetooth/mesh/adv.c
@@ -43,6 +43,7 @@ const uint8_t bt_mesh_adv_type[BT_MESH_ADV_TYPES] = {
 
 static K_FIFO_DEFINE(bt_mesh_adv_queue);
 static K_FIFO_DEFINE(bt_mesh_relay_queue);
+static K_FIFO_DEFINE(bt_mesh_friend_queue);
 
 static void adv_buf_destroy(struct net_buf *buf)
 {
@@ -65,6 +66,14 @@ NET_BUF_POOL_DEFINE(relay_buf_pool, CONFIG_BT_MESH_RELAY_BUF_COUNT,
 		    adv_buf_destroy);
 
 static struct bt_mesh_adv adv_relay_pool[CONFIG_BT_MESH_RELAY_BUF_COUNT];
+#endif
+
+#if defined(CONFIG_BT_MESH_ADV_EXT_FRIEND_SEPARATE)
+NET_BUF_POOL_DEFINE(friend_buf_pool, CONFIG_BT_MESH_FRIEND_LPN_COUNT,
+		    BT_MESH_ADV_DATA_SIZE, BT_MESH_ADV_USER_DATA_SIZE,
+		    adv_buf_destroy);
+
+static struct bt_mesh_adv adv_friend_pool[CONFIG_BT_MESH_FRIEND_LPN_COUNT];
 #endif
 
 static struct net_buf *bt_mesh_adv_create_from_pool(struct net_buf_pool *buf_pool,
@@ -110,11 +119,19 @@ struct net_buf *bt_mesh_adv_create(enum bt_mesh_adv_type type,
 	}
 #endif
 
+#if defined(CONFIG_BT_MESH_ADV_EXT_FRIEND_SEPARATE)
+	if (tag & BT_MESH_FRIEND_ADV) {
+		return bt_mesh_adv_create_from_pool(&friend_buf_pool,
+						    adv_friend_pool, type,
+						    tag, xmit, timeout);
+	}
+#endif
+
 	return bt_mesh_adv_create_from_pool(&adv_buf_pool, adv_local_pool, type,
 					    tag, xmit, timeout);
 }
 
-#if CONFIG_BT_MESH_RELAY_ADV_SETS
+#if CONFIG_BT_MESH_RELAY_ADV_SETS || CONFIG_BT_MESH_ADV_EXT_FRIEND_SEPARATE
 static struct net_buf *process_events(struct k_poll_event *ev, int count)
 {
 	for (; count; ev++, count--) {
@@ -159,22 +176,21 @@ struct net_buf *bt_mesh_adv_buf_get(k_timeout_t timeout)
 	return process_events(events, ARRAY_SIZE(events));
 }
 
-static struct net_buf *bt_mesh_adv_buf_relay_get(k_timeout_t timeout)
-{
-	return net_buf_get(&bt_mesh_relay_queue, timeout);
-}
-
 struct net_buf *bt_mesh_adv_buf_get_by_tag(uint8_t tag, k_timeout_t timeout)
 {
-	if (tag & BT_MESH_LOCAL_ADV) {
-		return bt_mesh_adv_buf_get(timeout);
-	} else if (tag & BT_MESH_RELAY_ADV) {
-		return bt_mesh_adv_buf_relay_get(timeout);
-	} else {
-		return NULL;
+	if (IS_ENABLED(CONFIG_BT_MESH_ADV_EXT_FRIEND_SEPARATE) && tag & BT_MESH_FRIEND_ADV) {
+		return net_buf_get(&bt_mesh_friend_queue, timeout);
 	}
+
+#if CONFIG_BT_MESH_RELAY_ADV_SETS
+	if (tag & BT_MESH_RELAY_ADV) {
+		return net_buf_get(&bt_mesh_relay_queue, timeout);
+	}
+#endif
+
+	return bt_mesh_adv_buf_get(timeout);
 }
-#else /* !CONFIG_BT_MESH_RELAY_ADV_SETS */
+#else /* !(CONFIG_BT_MESH_RELAY_ADV_SETS || CONFIG_BT_MESH_ADV_EXT_FRIEND_SEPARATE) */
 struct net_buf *bt_mesh_adv_buf_get(k_timeout_t timeout)
 {
 	return net_buf_get(&bt_mesh_adv_queue, timeout);
@@ -186,7 +202,7 @@ struct net_buf *bt_mesh_adv_buf_get_by_tag(uint8_t tag, k_timeout_t timeout)
 
 	return bt_mesh_adv_buf_get(timeout);
 }
-#endif /* CONFIG_BT_MESH_RELAY_ADV_SETS */
+#endif /* CONFIG_BT_MESH_RELAY_ADV_SETS || CONFIG_BT_MESH_ADV_EXT_FRIEND_SEPARATE */
 
 void bt_mesh_adv_buf_get_cancel(void)
 {
@@ -198,6 +214,9 @@ void bt_mesh_adv_buf_get_cancel(void)
 	k_fifo_cancel_wait(&bt_mesh_relay_queue);
 #endif /* CONFIG_BT_MESH_RELAY_ADV_SETS */
 
+	if (IS_ENABLED(CONFIG_BT_MESH_ADV_EXT_FRIEND_SEPARATE)) {
+		k_fifo_cancel_wait(&bt_mesh_friend_queue);
+	}
 }
 
 void bt_mesh_adv_send(struct net_buf *buf, const struct bt_mesh_send_cb *cb,
@@ -210,18 +229,23 @@ void bt_mesh_adv_send(struct net_buf *buf, const struct bt_mesh_send_cb *cb,
 	BT_MESH_ADV(buf)->cb_data = cb_data;
 	BT_MESH_ADV(buf)->busy = 1U;
 
+	if (IS_ENABLED(CONFIG_BT_MESH_ADV_EXT_FRIEND_SEPARATE) &&
+	    BT_MESH_ADV(buf)->tag == BT_MESH_FRIEND_ADV) {
+		net_buf_put(&bt_mesh_friend_queue, net_buf_ref(buf));
+		bt_mesh_adv_buf_friend_ready();
+		return;
+	}
+
 #if CONFIG_BT_MESH_RELAY_ADV_SETS
-	if (BT_MESH_ADV(buf)->tag == BT_MESH_LOCAL_ADV) {
-		net_buf_put(&bt_mesh_adv_queue, net_buf_ref(buf));
-		bt_mesh_adv_buf_local_ready();
-	} else {
+	if (BT_MESH_ADV(buf)->tag == BT_MESH_RELAY_ADV) {
 		net_buf_put(&bt_mesh_relay_queue, net_buf_ref(buf));
 		bt_mesh_adv_buf_relay_ready();
+		return;
 	}
-#else /* !CONFIG_BT_MESH_RELAY_ADV_SETS */
+#endif
+
 	net_buf_put(&bt_mesh_adv_queue, net_buf_ref(buf));
 	bt_mesh_adv_buf_local_ready();
-#endif /* CONFIG_BT_MESH_RELAY_ADV_SETS */
 }
 
 int bt_mesh_adv_gatt_send(void)

--- a/subsys/bluetooth/mesh/adv.h
+++ b/subsys/bluetooth/mesh/adv.h
@@ -29,6 +29,7 @@ enum bt_mesh_adv_tag {
 	BT_MESH_LOCAL_ADV = BIT(0),
 	BT_MESH_RELAY_ADV = BIT(1),
 	BT_MESH_PROXY_ADV = BIT(2),
+	BT_MESH_FRIEND_ADV = BIT(3),
 };
 
 struct bt_mesh_adv {
@@ -38,7 +39,7 @@ struct bt_mesh_adv {
 	uint8_t      type:2,
 		  started:1,
 		  busy:1,
-		  tag:3;
+		  tag:4;
 
 	uint8_t      xmit;
 };
@@ -73,6 +74,8 @@ int bt_mesh_adv_enable(void);
 void bt_mesh_adv_buf_local_ready(void);
 
 void bt_mesh_adv_buf_relay_ready(void);
+
+void bt_mesh_adv_buf_friend_ready(void);
 
 int bt_mesh_adv_gatt_send(void);
 

--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -665,12 +665,12 @@ void bt_mesh_app_key_pending_store(void)
 			continue;
 		}
 
+		update->valid = 0U;
+
 		if (update->clear) {
 			clear_app_key(update->key_idx);
 		} else {
 			store_app_key(update->key_idx);
 		}
-
-		update->valid = 0U;
 	}
 }

--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -1023,27 +1023,29 @@ static void store_cdb_pending_nodes(void)
 
 	for (i = 0; i < ARRAY_SIZE(cdb_node_updates); ++i) {
 		struct node_update *update = &cdb_node_updates[i];
+		uint16_t addr;
 
 		if (update->addr == BT_MESH_ADDR_UNASSIGNED) {
 			continue;
 		}
 
-		LOG_DBG("addr: 0x%04x, clear: %d", update->addr, update->clear);
+		addr = update->addr;
+		update->addr = BT_MESH_ADDR_UNASSIGNED;
+
+		LOG_DBG("addr: 0x%04x, clear: %d", addr, update->clear);
 
 		if (update->clear) {
-			clear_cdb_node(update->addr);
+			clear_cdb_node(addr);
 		} else {
 			struct bt_mesh_cdb_node *node;
 
-			node = bt_mesh_cdb_node_get(update->addr);
+			node = bt_mesh_cdb_node_get(addr);
 			if (node) {
 				store_cdb_node(node);
 			} else {
-				LOG_WRN("Node 0x%04x not found", update->addr);
+				LOG_WRN("Node 0x%04x not found", addr);
 			}
 		}
-
-		update->addr = BT_MESH_ADDR_UNASSIGNED;
 	}
 }
 
@@ -1057,6 +1059,8 @@ static void store_cdb_pending_keys(void)
 		if (!update->valid) {
 			continue;
 		}
+
+		update->valid = 0U;
 
 		if (update->clear) {
 			if (update->app_key) {
@@ -1085,8 +1089,6 @@ static void store_cdb_pending_keys(void)
 				}
 			}
 		}
-
-		update->valid = 0U;
 	}
 }
 

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -1372,12 +1372,7 @@ int bt_mesh_cfg_cli_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page,
 				  struct net_buf_simple *comp)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_DEV_COMP_DATA_GET, 1);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct comp_data param = {
 		.page = rsp,
 		.comp = comp,
@@ -1398,12 +1393,7 @@ int bt_mesh_cfg_cli_comp_data_get(uint16_t net_idx, uint16_t addr, uint8_t page,
 static int get_state_u8(uint16_t net_idx, uint16_t addr, uint32_t op, uint32_t rsp, uint8_t *val)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 0);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	const struct bt_mesh_msg_rsp_ctx rsp_ctx = {
 		.ack = &cli->ack_ctx,
 		.op = rsp,
@@ -1419,12 +1409,7 @@ static int set_state_u8(uint16_t net_idx, uint16_t addr, uint32_t op, uint32_t r
 			uint8_t *val)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 1);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	const struct bt_mesh_msg_rsp_ctx rsp_ctx = {
 		.ack = &cli->ack_ctx,
 		.op = rsp,
@@ -1447,12 +1432,7 @@ int bt_mesh_cfg_cli_krp_get(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
 			    uint8_t *phase)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_KRP_GET, 2);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct krp_param param = {
 		.status = status,
 		.phase = phase,
@@ -1474,12 +1454,7 @@ int bt_mesh_cfg_cli_krp_set(uint16_t net_idx, uint16_t addr, uint16_t key_net_id
 			    uint8_t transition, uint8_t *status, uint8_t *phase)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_KRP_SET, 3);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct krp_param param = {
 		.status = status,
 		.phase = phase,
@@ -1548,12 +1523,7 @@ int bt_mesh_cfg_cli_net_transmit_get(uint16_t net_idx, uint16_t addr, uint8_t *t
 int bt_mesh_cfg_cli_relay_get(uint16_t net_idx, uint16_t addr, uint8_t *status, uint8_t *transmit)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_RELAY_GET, 0);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct relay_param param = {
 		.status = status,
 		.transmit = transmit,
@@ -1574,12 +1544,7 @@ int bt_mesh_cfg_cli_relay_set(uint16_t net_idx, uint16_t addr, uint8_t new_relay
 			      uint8_t new_transmit, uint8_t *status, uint8_t *transmit)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_RELAY_SET, 2);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct relay_param param = {
 		.status = status,
 		.transmit = transmit,
@@ -1602,12 +1567,7 @@ int bt_mesh_cfg_cli_net_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_ne
 				const uint8_t net_key[16], uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_ADD, 18);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct net_key_param param = {
 		.status = status,
 		.net_idx = key_net_idx,
@@ -1630,12 +1590,7 @@ int bt_mesh_cfg_cli_net_key_update(uint16_t net_idx, uint16_t addr, uint16_t key
 				   const uint8_t net_key[16], uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_UPDATE, 18);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct net_key_param param = {
 		.status = status,
 		.net_idx = key_net_idx,
@@ -1657,12 +1612,7 @@ int bt_mesh_cfg_cli_net_key_update(uint16_t net_idx, uint16_t addr, uint16_t key
 int bt_mesh_cfg_cli_net_key_get(uint16_t net_idx, uint16_t addr, uint16_t *keys, size_t *key_cnt)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_GET, 0);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct net_key_list_param param = {
 		.keys = keys,
 		.key_cnt = key_cnt,
@@ -1683,12 +1633,7 @@ int bt_mesh_cfg_cli_net_key_del(uint16_t net_idx, uint16_t addr, uint16_t key_ne
 				uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NET_KEY_DEL, 2);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct net_key_param param = {
 		.status = status,
 		.net_idx = key_net_idx,
@@ -1710,12 +1655,7 @@ int bt_mesh_cfg_cli_app_key_add(uint16_t net_idx, uint16_t addr, uint16_t key_ne
 				uint16_t key_app_idx, const uint8_t app_key[16], uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_ADD, 19);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct app_key_param param = {
 		.status = status,
 		.net_idx = key_net_idx,
@@ -1739,12 +1679,7 @@ int bt_mesh_cfg_cli_app_key_update(uint16_t net_idx, uint16_t addr, uint16_t key
 				   uint16_t key_app_idx, const uint8_t app_key[16], uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_UPDATE, 19);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct app_key_param param = {
 		.status = status,
 		.net_idx = key_net_idx,
@@ -1767,12 +1702,7 @@ int bt_mesh_cfg_cli_app_key_update(uint16_t net_idx, uint16_t addr, uint16_t key
 int bt_mesh_cfg_cli_node_reset(uint16_t net_idx, uint16_t addr, bool *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_RESET, 0);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 
 	if (status) {
 		*status = false;
@@ -1794,12 +1724,7 @@ int bt_mesh_cfg_cli_app_key_get(uint16_t net_idx, uint16_t addr, uint16_t key_ne
 				uint8_t *status, uint16_t *keys, size_t *key_cnt)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_GET, 2);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct app_key_list_param param = {
 		.net_idx = key_net_idx,
 		.status = status,
@@ -1824,12 +1749,7 @@ int bt_mesh_cfg_cli_app_key_del(uint16_t net_idx, uint16_t addr, uint16_t key_ne
 				uint16_t key_app_idx, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_APP_KEY_DEL, 3);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct app_key_param param = {
 		.status = status,
 		.net_idx = key_net_idx,
@@ -1852,12 +1772,7 @@ static int mod_app_bind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uin
 			uint16_t mod_id, uint16_t cid, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_BIND, 8);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct mod_app_param param = {
 		.status = status,
 		.elem_addr = elem_addr,
@@ -1906,12 +1821,7 @@ static int mod_app_unbind(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, u
 			  uint16_t mod_id, uint16_t cid, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_APP_UNBIND, 8);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct mod_app_param param = {
 		.status = status,
 		.elem_addr = elem_addr,
@@ -1961,12 +1871,7 @@ static int mod_member_list_get(uint32_t op, uint32_t expect_op, uint16_t net_idx
 			       uint16_t *apps, size_t *app_cnt)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 6);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct mod_member_list_param param = {
 		.status = status,
 		.elem_addr = elem_addr,
@@ -2021,12 +1926,7 @@ static int mod_sub(uint32_t op, uint16_t net_idx, uint16_t addr, uint16_t elem_a
 		   uint16_t sub_addr, uint16_t mod_id, uint16_t cid, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 8);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct mod_sub_param param = {
 		.status = status,
 		.elem_addr = elem_addr,
@@ -2150,12 +2050,7 @@ static int mod_sub_va(uint32_t op, uint16_t net_idx, uint16_t addr, uint16_t ele
 		      uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, DUMMY_2_BYTE_OP, 22);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct mod_sub_param param = {
 		.status = status,
 		.elem_addr = elem_addr,
@@ -2270,12 +2165,7 @@ static int mod_pub_get(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint
 		       uint16_t cid, struct bt_mesh_cfg_cli_mod_pub *pub, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_GET, 6);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct mod_pub_param param = {
 		.mod_id = mod_id,
 		.cid = cid,
@@ -2325,12 +2215,7 @@ static int mod_pub_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, uint
 		       uint16_t cid, struct bt_mesh_cfg_cli_mod_pub *pub, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_SET, 13);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct mod_pub_param param = {
 		.mod_id = mod_id,
 		.cid = cid,
@@ -2367,12 +2252,7 @@ static int mod_pub_va_set(uint16_t net_idx, uint16_t addr, uint16_t elem_addr, u
 			  uint16_t cid, struct bt_mesh_cfg_cli_mod_pub *pub, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_MOD_PUB_VA_SET, 27);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct mod_pub_param param = {
 		.mod_id = mod_id,
 		.cid = cid,
@@ -2444,12 +2324,7 @@ int bt_mesh_cfg_cli_hb_sub_set(uint16_t net_idx, uint16_t addr, struct bt_mesh_c
 			       uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_SUB_SET, 5);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct hb_sub_param param = {
 		.status = status,
 		.sub = sub,
@@ -2478,12 +2353,7 @@ int bt_mesh_cfg_cli_hb_sub_get(uint16_t net_idx, uint16_t addr, struct bt_mesh_c
 			       uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_SUB_GET, 0);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct hb_sub_param param = {
 		.status = status,
 		.sub = sub,
@@ -2504,12 +2374,7 @@ int bt_mesh_cfg_cli_hb_pub_set(uint16_t net_idx, uint16_t addr,
 			       const struct bt_mesh_cfg_cli_hb_pub *pub, uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_PUB_SET, 9);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct hb_pub_param param = {
 		.status = status,
 	};
@@ -2540,12 +2405,7 @@ int bt_mesh_cfg_cli_hb_pub_get(uint16_t net_idx, uint16_t addr, struct bt_mesh_c
 			       uint8_t *status)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_HEARTBEAT_PUB_GET, 0);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct hb_pub_param param = {
 		.status = status,
 		.pub = pub,
@@ -2566,12 +2426,7 @@ int bt_mesh_cfg_cli_node_identity_set(uint16_t net_idx, uint16_t addr, uint16_t 
 				      uint8_t new_identity, uint8_t *status, uint8_t *identity)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_IDENTITY_SET, 4);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct node_idt_param param = {
 		.status = status,
 		.net_idx = key_net_idx,
@@ -2595,12 +2450,7 @@ int bt_mesh_cfg_cli_node_identity_get(uint16_t net_idx, uint16_t addr, uint16_t 
 				      uint8_t *status, uint8_t *identity)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_NODE_IDENTITY_GET, 2);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct node_idt_param param = {
 		.status = status,
 		.net_idx = key_net_idx,
@@ -2623,12 +2473,7 @@ int bt_mesh_cfg_cli_lpn_timeout_get(uint16_t net_idx, uint16_t addr, uint16_t un
 				    int32_t *polltimeout)
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, OP_LPN_TIMEOUT_GET, 2);
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = net_idx,
-		.app_idx = BT_MESH_KEY_DEV_REMOTE,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_DEV(net_idx, addr);
 	struct lpn_timeout_param param = {
 		.unicast_addr = unicast_addr,
 		.polltimeout = polltimeout,

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -1034,7 +1034,7 @@ init_friend:
 	frnd->lpn = rx->ctx.addr;
 	frnd->num_elem = msg->num_elem;
 	frnd->subnet = rx->sub;
-	frnd->recv_delay = msg->recv_delay;
+	frnd->recv_delay = msg->recv_delay - CONFIG_BT_MESH_FRIEND_ADV_LATENCY;
 	frnd->poll_to = poll_to * 100U;
 	frnd->lpn_counter = sys_be16_to_cpu(msg->lpn_counter);
 	frnd->clear.frnd = sys_be16_to_cpu(msg->prev_addr);

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -1269,7 +1269,7 @@ static void friend_timeout(struct k_work *work)
 	frnd->queue_size--;
 
 send_last:
-	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_LOCAL_ADV,
+	buf = bt_mesh_adv_create(BT_MESH_ADV_DATA, BT_MESH_FRIEND_ADV,
 				 FRIEND_XMIT, K_NO_WAIT);
 	if (!buf) {
 		LOG_ERR("Unable to allocate friend adv buffer");

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -135,20 +135,11 @@ static void purge_buffers(sys_slist_t *list)
 
 		buf = (void *)sys_slist_get_not_empty(list);
 
+		buf->frags = NULL;
+		buf->flags &= ~NET_BUF_FRAGS;
+
 		net_buf_unref(buf);
 	}
-}
-
-static void purge_seg_buffers(struct net_buf *buf)
-{
-	/* Fragments head has always 2 references: one when allocated, one when becomes
-	 * fragments head.
-	 */
-	net_buf_unref(buf);
-
-	do {
-		buf = net_buf_frag_del(NULL, buf);
-	} while (buf != NULL);
 }
 
 /* Intentionally start a little bit late into the ReceiveWindow when
@@ -186,10 +177,8 @@ static void friend_clear(struct bt_mesh_friend *frnd)
 	for (i = 0; i < ARRAY_SIZE(frnd->seg); i++) {
 		struct bt_mesh_friend_seg *seg = &frnd->seg[i];
 
-		if (seg->buf) {
-			purge_seg_buffers(seg->buf);
-			seg->seg_count = 0U;
-		}
+		purge_buffers(&seg->queue);
+		seg->seg_count = 0U;
 	}
 
 	STRUCT_SECTION_FOREACH(bt_mesh_friend_cb, cb) {
@@ -1076,7 +1065,7 @@ init_friend:
 
 static bool is_seg(struct bt_mesh_friend_seg *seg, uint16_t src, uint16_t seq_zero)
 {
-	struct net_buf *buf = seg->buf;
+	struct net_buf *buf = (void *)sys_slist_peek_head(&seg->queue);
 	struct net_buf_simple_state state;
 	uint16_t buf_seq_zero;
 	uint16_t buf_src;
@@ -1109,7 +1098,7 @@ static struct bt_mesh_friend_seg *get_seg(struct bt_mesh_friend *frnd,
 			return seg;
 		}
 
-		if (!unassigned && !seg->buf) {
+		if (!unassigned && !sys_slist_peek_head(&seg->queue)) {
 			unassigned = seg;
 		}
 	}
@@ -1144,13 +1133,16 @@ static void enqueue_friend_pdu(struct bt_mesh_friend *frnd,
 		return;
 	}
 
-	seg->buf = net_buf_frag_add(seg->buf, buf);
+	net_buf_slist_put(&seg->queue, buf);
 
 	if (type == BT_MESH_FRIEND_PDU_COMPLETE) {
-		net_buf_slist_put(&frnd->queue, seg->buf);
+		sys_slist_merge_slist(&frnd->queue, &seg->queue);
 
 		frnd->queue_size += seg->seg_count;
 		seg->seg_count = 0U;
+	} else {
+		/* Mark the buffer as having more to come after it */
+		buf->flags |= NET_BUF_FRAGS;
 	}
 }
 
@@ -1267,15 +1259,6 @@ static void friend_timeout(struct k_work *work)
 		return;
 	}
 
-	/* Put next segment to the friend queue. */
-	if (frnd->last != net_buf_frag_last(frnd->last)) {
-		struct net_buf *next;
-
-		next = net_buf_frag_del(NULL, frnd->last);
-		net_buf_frag_add(NULL, next);
-		sys_slist_prepend(&frnd->queue, &next->node);
-	}
-
 	md = (uint8_t)(sys_slist_peek_head(&frnd->queue) != NULL);
 
 	update_overwrite(frnd->last, md);
@@ -1283,6 +1266,10 @@ static void friend_timeout(struct k_work *work)
 	if (encrypt_friend_pdu(frnd, frnd->last, false)) {
 		return;
 	}
+
+	/* Clear the flag we use for segment tracking */
+	frnd->last->flags &= ~NET_BUF_FRAGS;
+	frnd->last->frags = NULL;
 
 	LOG_DBG("Sending buf %p from Friend Queue of LPN 0x%04x", frnd->last, frnd->lpn);
 	frnd->queue_size--;
@@ -1357,11 +1344,16 @@ int bt_mesh_friend_init(void)
 
 	for (i = 0; i < ARRAY_SIZE(bt_mesh.frnd); i++) {
 		struct bt_mesh_friend *frnd = &bt_mesh.frnd[i];
+		int j;
 
 		sys_slist_init(&frnd->queue);
 
 		k_work_init_delayable(&frnd->timer, friend_timeout);
 		k_work_init_delayable(&frnd->clear.timer, clear_timeout);
+
+		for (j = 0; j < ARRAY_SIZE(frnd->seg); j++) {
+			sys_slist_init(&frnd->seg[j].queue);
+		}
 	}
 
 	return 0;
@@ -1655,16 +1647,11 @@ static bool friend_queue_prepare_space(struct bt_mesh_friend *frnd, uint16_t add
 		frnd->queue_size--;
 		avail_space++;
 
-		if (buf != net_buf_frag_last(buf)) {
-			struct net_buf *next;
+		pending_segments = (buf->flags & NET_BUF_FRAGS);
 
-			next = net_buf_frag_del(NULL, buf);
-
-			net_buf_frag_add(NULL, next);
-			sys_slist_prepend(&frnd->queue, &next->node);
-
-			pending_segments = true;
-		}
+		/* Make sure old slist entry state doesn't remain */
+		buf->frags = NULL;
+		buf->flags &= ~NET_BUF_FRAGS;
 
 		net_buf_unref(buf);
 	}
@@ -1785,7 +1772,7 @@ void bt_mesh_friend_clear_incomplete(struct bt_mesh_subnet *sub, uint16_t src,
 
 			LOG_WRN("Clearing incomplete segments for 0x%04x", src);
 
-			purge_seg_buffers(seg->buf);
+			purge_buffers(&seg->queue);
 			seg->seg_count = 0U;
 			break;
 		}

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -191,11 +191,7 @@ const struct bt_mesh_model_op bt_mesh_health_cli_op[] = {
 
 int bt_mesh_health_attention_get(uint16_t addr, uint16_t app_idx, uint8_t *attention)
 {
-	struct bt_mesh_msg_ctx ctx = {
-		.app_idx = app_idx,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(app_idx, addr);
 
 	return bt_mesh_health_cli_attention_get(health_cli, &ctx, attention);
 }
@@ -203,33 +199,21 @@ int bt_mesh_health_attention_get(uint16_t addr, uint16_t app_idx, uint8_t *atten
 int bt_mesh_health_attention_set(uint16_t addr, uint16_t app_idx,
 				 uint8_t attention, uint8_t *updated_attention)
 {
-	struct bt_mesh_msg_ctx ctx = {
-		.app_idx = app_idx,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(app_idx, addr);
 
 	return bt_mesh_health_cli_attention_set(health_cli, &ctx, attention, updated_attention);
 }
 
 int bt_mesh_health_attention_set_unack(uint16_t addr, uint16_t app_idx, uint8_t attention)
 {
-	struct bt_mesh_msg_ctx ctx = {
-		.app_idx = app_idx,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(app_idx, addr);
 
 	return bt_mesh_health_cli_attention_set_unack(health_cli, &ctx, attention);
 }
 
 int bt_mesh_health_period_get(uint16_t addr, uint16_t app_idx, uint8_t *divisor)
 {
-	struct bt_mesh_msg_ctx ctx = {
-		.app_idx = app_idx,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(app_idx, addr);
 
 	return bt_mesh_health_cli_period_get(health_cli, &ctx, divisor);
 }
@@ -237,22 +221,14 @@ int bt_mesh_health_period_get(uint16_t addr, uint16_t app_idx, uint8_t *divisor)
 int bt_mesh_health_period_set(uint16_t addr, uint16_t app_idx, uint8_t divisor,
 			      uint8_t *updated_divisor)
 {
-	struct bt_mesh_msg_ctx ctx = {
-		.app_idx = app_idx,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(app_idx, addr);
 
 	return bt_mesh_health_cli_period_set(health_cli, &ctx, divisor, updated_divisor);
 }
 
 int bt_mesh_health_period_set_unack(uint16_t addr, uint16_t app_idx, uint8_t divisor)
 {
-	struct bt_mesh_msg_ctx ctx = {
-		.app_idx = app_idx,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(app_idx, addr);
 
 	return bt_mesh_health_cli_period_set_unack(health_cli, &ctx, divisor);
 }
@@ -260,22 +236,14 @@ int bt_mesh_health_period_set_unack(uint16_t addr, uint16_t app_idx, uint8_t div
 int bt_mesh_health_fault_test(uint16_t addr, uint16_t app_idx, uint16_t cid, uint8_t test_id,
 			      uint8_t *faults, size_t *fault_count)
 {
-	struct bt_mesh_msg_ctx ctx = {
-		.app_idx = app_idx,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(app_idx, addr);
 
 	return bt_mesh_health_cli_fault_test(health_cli, &ctx, cid, test_id, faults, fault_count);
 }
 
 int bt_mesh_health_fault_test_unack(uint16_t addr, uint16_t app_idx, uint16_t cid, uint8_t test_id)
 {
-	struct bt_mesh_msg_ctx ctx = {
-		.app_idx = app_idx,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(app_idx, addr);
 
 	return bt_mesh_health_cli_fault_test_unack(health_cli, &ctx, cid, test_id);
 }
@@ -284,11 +252,7 @@ int bt_mesh_health_fault_clear(uint16_t addr, uint16_t app_idx, uint16_t cid,
 				 uint8_t *test_id, uint8_t *faults,
 				 size_t *fault_count)
 {
-	struct bt_mesh_msg_ctx ctx = {
-		.app_idx = app_idx,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(app_idx, addr);
 
 	return bt_mesh_health_cli_fault_clear(health_cli, &ctx, cid, test_id, faults, fault_count);
 }
@@ -296,11 +260,7 @@ int bt_mesh_health_fault_clear(uint16_t addr, uint16_t app_idx, uint16_t cid,
 int bt_mesh_health_fault_clear_unack(uint16_t addr, uint16_t app_idx,
 				     uint16_t cid)
 {
-	struct bt_mesh_msg_ctx ctx = {
-		.app_idx = app_idx,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(app_idx, addr);
 
 	return bt_mesh_health_cli_fault_clear_unack(health_cli, &ctx, cid);
 }
@@ -309,11 +269,7 @@ int bt_mesh_health_fault_get(uint16_t addr, uint16_t app_idx, uint16_t cid,
 				 uint8_t *test_id, uint8_t *faults,
 				 size_t *fault_count)
 {
-	struct bt_mesh_msg_ctx ctx = {
-		.app_idx = app_idx,
-		.addr = addr,
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(app_idx, addr);
 
 	return bt_mesh_health_cli_fault_get(health_cli, &ctx, cid, test_id, faults, fault_count);
 }

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -189,6 +189,8 @@ void bt_mesh_reset(void)
 	memset(bt_mesh.flags, 0, sizeof(bt_mesh.flags));
 	atomic_set_bit(bt_mesh.flags, BT_MESH_INIT);
 
+	bt_mesh_scan_disable();
+
 	/* If this fails, the work handler will return early on the next
 	 * execution, as the device is not provisioned. If the device is
 	 * reprovisioned, the timer is always restarted.
@@ -231,7 +233,6 @@ void bt_mesh_reset(void)
 
 	(void)memset(bt_mesh.dev_key, 0, sizeof(bt_mesh.dev_key));
 
-	bt_mesh_scan_disable();
 	bt_mesh_beacon_disable();
 
 	bt_mesh_comp_unprovision();

--- a/subsys/bluetooth/mesh/net.h
+++ b/subsys/bluetooth/mesh/net.h
@@ -67,10 +67,7 @@ struct bt_mesh_friend {
 	struct k_work_delayable timer;
 
 	struct bt_mesh_friend_seg {
-		/* First received segment of a segmented message. Rest
-		 * segments are added as net_buf fragments.
-		 */
-		struct net_buf *buf;
+		sys_slist_t queue;
 
 		/* The target number of segments, i.e. not necessarily
 		 * the current number of segments, in the queue. This is

--- a/subsys/bluetooth/mesh/shell/health.c
+++ b/subsys/bluetooth/mesh/shell/health.c
@@ -41,12 +41,8 @@ static int cmd_fault_get(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	struct bt_mesh_health_cli *cli = mod->user_data;
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = bt_mesh_shell_target_ctx.net_idx,
-		.addr = bt_mesh_shell_target_ctx.dst,
-		.app_idx = bt_mesh_shell_target_ctx.app_idx,
-	};
-
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(bt_mesh_shell_target_ctx.app_idx,
+							      bt_mesh_shell_target_ctx.dst);
 	uint8_t faults[32];
 	size_t fault_count;
 	uint8_t test_id;
@@ -79,12 +75,8 @@ static int fault_clear(const struct shell *sh, size_t argc, char *argv[], bool a
 	}
 
 	struct bt_mesh_health_cli *cli = mod->user_data;
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = bt_mesh_shell_target_ctx.net_idx,
-		.addr = bt_mesh_shell_target_ctx.dst,
-		.app_idx = bt_mesh_shell_target_ctx.app_idx,
-	};
-
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(bt_mesh_shell_target_ctx.app_idx,
+							      bt_mesh_shell_target_ctx.dst);
 	uint8_t test_id;
 	uint16_t cid;
 	int err = 0;
@@ -135,12 +127,8 @@ static int fault_test(const struct shell *sh, size_t argc, char *argv[], bool ac
 	}
 
 	struct bt_mesh_health_cli *cli = mod->user_data;
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = bt_mesh_shell_target_ctx.net_idx,
-		.addr = bt_mesh_shell_target_ctx.dst,
-		.app_idx = bt_mesh_shell_target_ctx.app_idx,
-	};
-
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(bt_mesh_shell_target_ctx.app_idx,
+							      bt_mesh_shell_target_ctx.dst);
 	uint8_t test_id;
 	uint16_t cid;
 	int err = 0;
@@ -192,12 +180,8 @@ static int cmd_period_get(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	struct bt_mesh_health_cli *cli = mod->user_data;
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = bt_mesh_shell_target_ctx.net_idx,
-		.addr = bt_mesh_shell_target_ctx.dst,
-		.app_idx = bt_mesh_shell_target_ctx.app_idx,
-	};
-
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(bt_mesh_shell_target_ctx.app_idx,
+							      bt_mesh_shell_target_ctx.dst);
 	uint8_t divisor;
 	int err;
 
@@ -218,12 +202,8 @@ static int period_set(const struct shell *sh, size_t argc, char *argv[], bool ac
 	}
 
 	struct bt_mesh_health_cli *cli = mod->user_data;
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = bt_mesh_shell_target_ctx.net_idx,
-		.addr = bt_mesh_shell_target_ctx.dst,
-		.app_idx = bt_mesh_shell_target_ctx.app_idx,
-	};
-
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(bt_mesh_shell_target_ctx.app_idx,
+							      bt_mesh_shell_target_ctx.dst);
 	uint8_t divisor;
 	int err = 0;
 
@@ -272,12 +252,8 @@ static int cmd_attention_get(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	struct bt_mesh_health_cli *cli = mod->user_data;
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = bt_mesh_shell_target_ctx.net_idx,
-		.addr = bt_mesh_shell_target_ctx.dst,
-		.app_idx = bt_mesh_shell_target_ctx.app_idx,
-	};
-
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(bt_mesh_shell_target_ctx.app_idx,
+							      bt_mesh_shell_target_ctx.dst);
 	uint8_t attention;
 	int err;
 
@@ -298,12 +274,8 @@ static int attention_set(const struct shell *sh, size_t argc, char *argv[], bool
 	}
 
 	struct bt_mesh_health_cli *cli = mod->user_data;
-	struct bt_mesh_msg_ctx ctx = {
-		.net_idx = bt_mesh_shell_target_ctx.net_idx,
-		.addr = bt_mesh_shell_target_ctx.dst,
-		.app_idx = bt_mesh_shell_target_ctx.app_idx,
-	};
-
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT_APP(bt_mesh_shell_target_ctx.app_idx,
+							      bt_mesh_shell_target_ctx.dst);
 	uint8_t attention;
 	int err = 0;
 

--- a/subsys/bluetooth/mesh/shell/shell.c
+++ b/subsys/bluetooth/mesh/shell/shell.c
@@ -882,13 +882,10 @@ static int cmd_net_send(const struct shell *sh, size_t argc, char *argv[])
 {
 	NET_BUF_SIMPLE_DEFINE(msg, 32);
 
-	struct bt_mesh_msg_ctx ctx = {
-		.send_ttl = BT_MESH_TTL_DEFAULT,
-		.net_idx = bt_mesh_shell_target_ctx.net_idx,
-		.addr = bt_mesh_shell_target_ctx.dst,
-		.app_idx = bt_mesh_shell_target_ctx.app_idx,
-
-	};
+	struct bt_mesh_msg_ctx ctx = BT_MESH_MSG_CTX_INIT(bt_mesh_shell_target_ctx.net_idx,
+							  bt_mesh_shell_target_ctx.app_idx,
+							  bt_mesh_shell_target_ctx.dst,
+							  BT_MESH_TTL_DEFAULT);
 	struct bt_mesh_net_tx tx = {
 		.ctx = &ctx,
 		.src = bt_mesh_primary_addr(),

--- a/subsys/bluetooth/mesh/subnet.c
+++ b/subsys/bluetooth/mesh/subnet.c
@@ -831,12 +831,12 @@ void bt_mesh_subnet_pending_store(void)
 			continue;
 		}
 
+		update->valid = 0U;
+
 		if (update->clear) {
 			clear_net_key(update->key_idx);
 		} else {
 			store_subnet(update->key_idx);
 		}
-
-		update->valid = 0U;
 	}
 }


### PR DESCRIPTION
Mesh fixes
- Stop scanner before resetting mesh
- Invalidate pending entries before calling settings API

Friendship fixes and improvement
- Separate adv tag/set for friend
- Config opt for friend adv latency
- Add extra flag to control seg msg in frnd queue
- Remove illegal use of NET_BUF_FRAG in friend.c"