### PR TITLE
[nrf fromtree] bluetooth: host: Added extra options to PAST subscribe

### DIFF
--- a/doc/releases/release-notes-3.3.rst
+++ b/doc/releases/release-notes-3.3.rst
@@ -20,6 +20,10 @@ API Changes
 Changes in this release
 =======================
 
+* Bluetooth: Add extra options to bt_le_per_adv_sync_transfer_subscribe to
+  allow disabling sync reports, and enable sync report filtering. these two
+  options are mutually exclusive.
+
 * Bluetooth: :kconfig:option:`CONFIG_BT_PER_ADV_SYNC_TRANSFER_RECEIVER`
   and :kconfig:option:`CONFIG_BT_PER_ADV_SYNC_TRANSFER_SENDER` have been
   added to enable the PAST implementation rather than

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -1569,6 +1569,22 @@ enum {
 
 	/** Only sync to packets with constant tone extension */
 	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_SYNC_ONLY_CTE = BIT(3),
+
+	/**
+	 * @brief Sync to received PAST packets but don't generate sync reports
+	 *
+	 * This option must not be set at the same time as
+	 * @ref BT_LE_PER_ADV_SYNC_TRANSFER_OPT_FILTER_DUPLICATES.
+	 */
+	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_REPORTING_INITIALLY_DISABLED = BIT(4),
+
+	/**
+	 * @brief Sync to received PAST packets and generate sync reports with duplicate filtering
+	 *
+	 * This option must not be set at the same time as
+	 * @ref BT_LE_PER_ADV_SYNC_TRANSFER_OPT_REPORTING_INITIALLY_DISABLED.
+	 */
+	BT_LE_PER_ADV_SYNC_TRANSFER_OPT_FILTER_DUPLICATES = BIT(5),
 };
 
 struct bt_le_per_adv_sync_transfer_param {

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -1766,9 +1766,10 @@ struct bt_hci_rp_le_per_adv_set_info_transfer {
 	uint16_t conn_handle;
 } __packed;
 
-#define BT_HCI_LE_PAST_MODE_NO_SYNC              0x00
-#define BT_HCI_LE_PAST_MODE_NO_REPORTS           0x01
-#define BT_HCI_LE_PAST_MODE_SYNC                 0x02
+#define BT_HCI_LE_PAST_MODE_NO_SYNC                0x00
+#define BT_HCI_LE_PAST_MODE_NO_REPORTS             0x01
+#define BT_HCI_LE_PAST_MODE_SYNC                   0x02
+#define BT_HCI_LE_PAST_MODE_SYNC_FILTER_DUPLICATES 0x03
 
 #define BT_HCI_LE_PAST_CTE_TYPE_NO_AOA           BIT(0)
 #define BT_HCI_LE_PAST_CTE_TYPE_NO_AOD_1US       BIT(1)

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -1693,6 +1693,10 @@ static bool valid_past_param(
 	    param->timeout > 0x4000) {
 		return false;
 	}
+	if ((param->options & BT_LE_PER_ADV_SYNC_TRANSFER_OPT_REPORTING_INITIALLY_DISABLED) &&
+	    (param->options & BT_LE_PER_ADV_SYNC_TRANSFER_OPT_FILTER_DUPLICATES)) {
+		return false;
+	}
 
 	return true;
 }
@@ -1747,6 +1751,7 @@ int bt_le_per_adv_sync_transfer_subscribe(
 	const struct bt_le_per_adv_sync_transfer_param *param)
 {
 	uint8_t cte_type = 0;
+	uint8_t mode = BT_HCI_LE_PAST_MODE_SYNC;
 
 	if (!BT_FEAT_LE_EXT_PER_ADV(bt_dev.le.features)) {
 		return -ENOTSUP;
@@ -1774,13 +1779,16 @@ int bt_le_per_adv_sync_transfer_subscribe(
 		cte_type |= BT_HCI_LE_PAST_CTE_TYPE_ONLY_CTE;
 	}
 
+	if (param->options & BT_LE_PER_ADV_SYNC_TRANSFER_OPT_REPORTING_INITIALLY_DISABLED) {
+		mode = BT_HCI_LE_PAST_MODE_NO_REPORTS;
+	} else if (param->options & BT_LE_PER_ADV_SYNC_TRANSFER_OPT_FILTER_DUPLICATES) {
+		mode = BT_HCI_LE_PAST_MODE_SYNC_FILTER_DUPLICATES;
+	}
+
 	if (conn) {
-		return past_param_set(conn, BT_HCI_LE_PAST_MODE_SYNC,
-				      param->skip, param->timeout, cte_type);
+		return past_param_set(conn, mode, param->skip, param->timeout, cte_type);
 	} else {
-		return default_past_param_set(BT_HCI_LE_PAST_MODE_SYNC,
-					      param->skip, param->timeout,
-					      cte_type);
+		return default_past_param_set(mode, param->skip, param->timeout, cte_type);
 	}
 }
 


### PR DESCRIPTION
allow disabling reports (synchronise but don't generate sync reports) and allows enabling sync reporting with filtering of duplicates. the default option remains to establish sync, with sync reports, but without duplicate filtering.

Signed-off-by: Raphael Treccani-Chinelli <raphael.treccani@nordicsemi.no>
(cherry picked from commit 3e937da264c30350928e440ec9664a1890fdd0aa)
Signed-off-by: Timothy Keys <timothy.keys@nordicsemi.no>