### PR TITLE
[nrf fromtree] boards: nrf52_bsim: add parts of cmsis_compiler.h

### DIFF
--- a/boards/posix/nrf52_bsim/cmsis_compiler.h
+++ b/boards/posix/nrf52_bsim/cmsis_compiler.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * This header defines replacements for CMSIS compiler attributes.
+ */
+
+#ifndef BOARDS_POSIX_NRF52_BSIM_CMSIS_COMPILER_H
+#define BOARDS_POSIX_NRF52_BSIM_CMSIS_COMPILER_H
+
+#include <zephyr/toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef __PACKED
+#define __PACKED __packed
+#endif
+
+#ifndef __PACKED_STRUCT
+#define __PACKED_STRUCT struct __packed
+#endif
+
+#ifndef __PACKED_UNION
+#define __PACKED_UNION union __packed
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARDS_POSIX_NRF52_BSIM_CMSIS_COMPILER_H */


### PR DESCRIPTION
Add a replacement cmsis_compiler.h header for the nrf52_bsim target. Partial version for now, we can more of its contents when needed.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>
Signed-off-by: Ilhan Ates <ilhan.ates@nordicsemi.no>
(cherry picked from commit 7b48d85dfe525c7bccd514f295378acdd4069b3b)