### PR TITLE
[nrf fromtree] Bluetooth: Controller: Fix missing DF related radio register reset

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -20,6 +20,7 @@
 #include "hal/cpu.h"
 #include "hal/ccm.h"
 #include "hal/radio.h"
+#include "hal/radio_df.h"
 #include "hal/ticker.h"
 
 #include "ll_sw/pdu.h"
@@ -214,6 +215,10 @@ void radio_reset(void)
 	 *       explicitly assigned by functions in this file.
 	 */
 	NRF_RADIO->PCNF1 = HAL_RADIO_RESET_VALUE_PCNF1;
+
+#if defined(CONFIG_BT_CTLR_DF) && !defined(CONFIG_ZTEST)
+	radio_df_reset();
+#endif /* CONFIG_BT_CTLR_DF && !CONFIG_ZTEST */
 
 	/* nRF SoC specific reset/initializations, if any */
 	hal_radio_reset();


### PR DESCRIPTION
Fix missing DF related Radio register reset on radio_reset().

Regression in commit https://github.com/cvinayak/sdk-zephyr/commit/465a96181d7d1aaef6df7fcc3bd197177b4e0b57 ("Bluetooth: Controller:
Explicitly set all bits of used radio registers") due to the
removal of NRF_RADIO->POWER register use that was used to
reset all Radio registers on every new Radio Event.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>
(cherry picked from commit de2029ac586aa3ec155a598242089f16b5421572)