### PR TITLE
net: wifi_mgmt: Add support for power save timeout configuration

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -41,6 +41,7 @@ enum net_request_wifi_cmd {
 	NET_REQUEST_WIFI_CMD_TWT,
 	NET_REQUEST_WIFI_CMD_PS_CONFIG,
 	NET_REQUEST_WIFI_CMD_REG_DOMAIN,
+	NET_REQUEST_WIFI_CMD_PS_TIMEOUT,
 };
 
 #define NET_REQUEST_WIFI_SCAN					\
@@ -96,6 +97,11 @@ NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_CONFIG);
 	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_REG_DOMAIN)
 
 NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_REG_DOMAIN);
+
+#define NET_REQUEST_WIFI_PS_TIMEOUT			\
+	(_NET_WIFI_BASE | NET_REQUEST_WIFI_CMD_PS_TIMEOUT)
+
+NET_MGMT_DEFINE_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_TIMEOUT);
 
 enum net_event_wifi_cmd {
 	NET_EVENT_WIFI_CMD_SCAN_RESULT = 1,
@@ -182,6 +188,10 @@ struct wifi_ps_params {
 
 struct wifi_ps_mode_params {
 	enum wifi_ps_mode mode;
+};
+
+struct wifi_ps_timeout_params {
+	int timeout_ms;
 };
 
 struct wifi_twt_params {
@@ -287,6 +297,8 @@ struct net_wifi_mgmt_offload {
 	int (*set_twt)(const struct device *dev, struct wifi_twt_params *params);
 	int (*get_power_save_config)(const struct device *dev, struct wifi_ps_config *config);
 	int (*reg_domain)(const struct device *dev, struct wifi_reg_domain *reg_domain);
+	int (*set_power_save_timeout)(const struct device *dev,
+				      struct wifi_ps_timeout_params *ps_timeout);
 };
 
 /* Make sure that the network interface API is properly setup inside

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -333,3 +333,24 @@ static int wifi_reg_domain(uint32_t mgmt_request, struct net_if *iface,
 }
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_REG_DOMAIN, wifi_reg_domain);
+
+static int wifi_set_power_save_timeout(uint32_t mgmt_request, struct net_if *iface,
+				       void *data, size_t len)
+{
+	const struct device *dev = net_if_get_device(iface);
+	struct net_wifi_mgmt_offload *off_api =
+		(struct net_wifi_mgmt_offload *) dev->api;
+	struct wifi_ps_timeout_params *ps_timeout = data;
+
+	if (off_api == NULL || off_api->set_power_save_timeout == NULL) {
+		return -ENOTSUP;
+	}
+
+	if (!data || len != sizeof(*ps_timeout)) {
+		return -EINVAL;
+	}
+
+	return off_api->set_power_save_timeout(dev, ps_timeout);
+}
+
+NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_TIMEOUT, wifi_set_power_save_timeout);

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -577,6 +577,41 @@ static int cmd_wifi_twt_setup_quick(const struct shell *sh, size_t argc,
 }
 
 
+static int cmd_wifi_ps_timeout(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct net_if *iface = net_if_get_default();
+	struct wifi_ps_timeout_params params = { 0 };
+	long timeout_ms = 0;
+	int err = 0;
+
+	context.sh = sh;
+
+	if (argc != 2) {
+		shell_fprintf(sh, SHELL_WARNING, "Invalid number of arguments\n");
+		return -ENOEXEC;
+	}
+
+	timeout_ms = shell_strtol(argv[1], 10, &err);
+
+	if (err) {
+		shell_error(sh, "Unable to parse input (err %d)", err);
+		return err;
+	}
+
+	params.timeout_ms = timeout_ms;
+
+	if (net_mgmt(NET_REQUEST_WIFI_PS_TIMEOUT, iface, &params, sizeof(params))) {
+		shell_fprintf(sh, SHELL_WARNING, "Setting power save timeout failed\n");
+		return -ENOEXEC;
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL,
+		"Power save timeout %d ms\n", params.timeout_ms);
+
+	return 0;
+}
+
+
 static int cmd_wifi_twt_setup(const struct shell *sh, size_t argc,
 			      char *argv[])
 {
@@ -853,6 +888,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 		"-f: Force to use this regulatory hint over any other regulatory hints\n"
 		"Note: This may cause regulatory compliance issues, use it at your own risk.",
 		cmd_wifi_reg_domain),
+	SHELL_CMD(ps_timeout, NULL,
+		  "Configure Wi-Fi power save inactivity timer(in ms)",
+		  cmd_wifi_ps_timeout),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
Add support for configuring power save timeout in Wi-Fi chipsets. Changes to configure power save inactivity timer.

Signed-off-by: Ajay Parida <ajay.parida@nordicsemi.no>