### PR TITLE
lib: tftp_client: Add data handler in TFTP client

### DIFF
--- a/include/zephyr/net/tftp.h
+++ b/include/zephyr/net/tftp.h
@@ -19,9 +19,22 @@
 extern "C" {
 #endif
 
+/**
+ * @typedef tftp_data_handler_t
+ *
+ * Handler to handle data received from TFTP server
+ *
+ * @param data    Data received.
+ * @param datalen Length of the data received.
+ *
+ * @note The handler must not call @ref tftp_get.
+ */
+typedef void (*tftp_data_handler_t)(const uint8_t *data, size_t datalen);
+
 struct tftpc {
 	uint8_t   *user_buf;
 	uint32_t  user_buf_size;
+	tftp_data_handler_t data_handler;
 };
 
 /* TFTP Client Error codes. */


### PR DESCRIPTION
Currently the client relies on buffer from application to save received data, which limits the size of remote file to the size of allocated buffer.

Add an alternative data handler to send the received data (max 512 bytes each) to application directly, with the merit of 
.No limitation on the size of remote file
.No memory copy in tftp_client library
.No buffer allocation in application required

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>