### PR TITLE
[nrf noup] Bluetooth: Mesh: zero randomization for friend's adv

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -812,7 +812,7 @@ config BT_MESH_LPN_INIT_POLL_TIMEOUT
 config BT_MESH_LPN_SCAN_LATENCY
 	int "Latency for enabling scanning"
 	range 0 50
-	default 15
+	default 2
 	help
 	  Latency in milliseconds that it takes to enable scanning. This
 	  is in practice how much time in advance before the Receive Window

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -13,6 +13,9 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/mesh.h>
+#if defined(CONFIG_BT_LL_SOFTDEVICE)
+#include <sdc_hci_vs.h>
+#endif
 
 #include "common/bt_str.h"
 
@@ -132,6 +135,28 @@ static inline struct bt_mesh_ext_adv *gatt_adv_get(void)
 #else /* !CONFIG_BT_MESH_ADV_EXT_GATT_SEPARATE */
 	return &adv_main;
 #endif /* CONFIG_BT_MESH_ADV_EXT_GATT_SEPARATE */
+}
+
+static int set_adv_randomness(uint8_t handle, int rand_us)
+{
+#if defined(CONFIG_BT_LL_SOFTDEVICE)
+	struct net_buf *buf;
+	sdc_hci_cmd_vs_set_adv_randomness_t *cmd_params;
+
+	buf = bt_hci_cmd_create(SDC_HCI_OPCODE_CMD_VS_SET_ADV_RANDOMNESS, sizeof(*cmd_params));
+	if (!buf) {
+		LOG_ERR("Could not allocate command buffer");
+		return -ENOMEM;
+	}
+
+	cmd_params = net_buf_add(buf, sizeof(*cmd_params));
+	cmd_params->adv_handle = handle;
+	cmd_params->rand_us = rand_us;
+
+	return bt_hci_cmd_send_sync(SDC_HCI_OPCODE_CMD_VS_SET_ADV_RANDOMNESS, buf, NULL);
+#else
+	return 0;
+#endif /* defined(CONFIG_BT_LL_SOFTDEVICE) */
 }
 
 static int adv_start(struct bt_mesh_ext_adv *adv,
@@ -455,6 +480,13 @@ int bt_mesh_adv_enable(void)
 					   &adv->instance);
 		if (err) {
 			return err;
+		}
+
+		if (IS_ENABLED(CONFIG_BT_LL_SOFTDEVICE) && adv->tag & BT_MESH_FRIEND_ADV) {
+			err = set_adv_randomness(adv->instance->handle, 0);
+			if (err) {
+				LOG_ERR("Failed to set zero randomness: %d", err);
+			}
 		}
 	}
 


### PR DESCRIPTION
Friend's replies on LPN's polls do not assume randomization in advertiser. Zero randomization will help to optimize time when LPN keeps receiving window open and save power.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>