### PR TITLE
[nrf noup] boards: thingy53_nrf5340: Change tfm partition size

### DIFF
--- a/boards/arm/thingy53_nrf5340/pm_static_thingy53_nrf5340_cpuapp_ns.yml
+++ b/boards/arm/thingy53_nrf5340/pm_static_thingy53_nrf5340_cpuapp_ns.yml
@@ -8,20 +8,20 @@ mcuboot_pad:
   size: 0x200
 tfm_secure:
   address: 0x10000
-  size: 0xc200
+  size: 0xc000
   span: [mcuboot_pad, tfm]
 tfm_nonsecure:
-  address: 0x1c200
-  size: 0xd3e00
+  address: 0x1c000
+  size: 0xd4000
   span: [app]
 tfm:
   address: 0x10200
   region: flash_primary
-  size: 0xc000
+  size: 0xbe00
 app:
-  address: 0x1c200
+  address: 0x1c000
   region: flash_primary
-  size: 0xd3e00
+  size: 0xd4000
 mcuboot_primary:
   address: 0x10000
   orig_span: &id001


### PR DESCRIPTION
The tfm_nonsecure partition must be SPU region aligned, therefore the size of the tfm partition must be reduced by the size of the mcuboot_pad partition when TF-M is used in combination with MCUBoot.

Ref: NCSDK-19515
Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>