### PR TITLE
[nrf fromtree] bluetooth: host: drop incomplete data in periodic scanner

### DIFF
--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -808,6 +808,14 @@ void bt_hci_le_per_adv_report(struct net_buf *buf)
 			 */
 			bt_hci_le_per_adv_report_recv(per_adv_sync, &buf->b, &info);
 		} else {
+			if (evt->data_status == BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_INCOMPLETE) {
+				LOG_DBG("Received incomplete advertising data. "
+					"Advertising report dropped.");
+
+				per_adv_sync->report_truncated = true;
+				net_buf_simple_reset(&per_adv_sync->reassembly);
+				return;
+			}
 			if (net_buf_simple_tailroom(&per_adv_sync->reassembly) < evt->length) {
 				/* The buffer is too small for the entire report. Drop it */
 				LOG_WRN("Buffer is too small to reassemble the report. "


### PR DESCRIPTION
[nrf fromtree] Cherry-pick requested by buildsquad. Hopefully it fixes an unstable test result. This PR contains only one of the commits in the downstream PR.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/54074

This changes the periodic scanner to drop periodic adv reports with incomplete data. This avoids incorrect data being sent to application in the case where the periodic adv data is not successfully received by the scanner.

Fixes zephyrproject-rtos#54072

Signed-off-by: Pierce Lowe <pierce.lowe@nordicsemi.no>
(cherry picked from commit a7c1c27e38dd8bb964730cf440d8c6f9091cf899)