### PR TITLE
[nrf fromtree] net: config: Unify the init behaviour when timeout is enabled and not

### DIFF
--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -573,6 +573,13 @@ static uint32_t dhcpv4_manage_timers(struct net_if *iface, int64_t now)
 		return timeleft;
 	}
 
+	if (!net_if_is_up(iface)) {
+		/* An interface is down, the registered event handler will
+		 * restart DHCP procedure when the interface is back up.
+		 */
+		return UINT32_MAX;
+	}
+
 	switch (iface->config.dhcpv4.state) {
 	case NET_DHCPV4_DISABLED:
 		break;

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -194,6 +194,10 @@ int net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr)
 		}
 	}
 
+	if (!net_if_is_up(iface)) {
+		return -ENETDOWN;
+	}
+
 	ret = mld_send_generic(iface, addr, NET_IPV6_MLDv2_MODE_IS_EXCLUDE);
 	if (ret < 0) {
 		return ret;

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -376,20 +376,17 @@ int net_config_init_by_iface(struct net_if *iface, const char *app_info,
 #if defined(CONFIG_NET_NATIVE)
 		net_mgmt_del_event_callback(&mgmt_iface_cb);
 #endif
-
-		/* Network interface did not come up. We will not try
-		 * to setup things in that case.
-		 */
-		if (timeout > 0 && count < 0) {
-			NET_ERR("Timeout while waiting network %s",
-				"interface");
-			return -ENETDOWN;
-		}
 	}
 
 	setup_ipv4(iface);
 	setup_dhcpv4(iface);
 	setup_ipv6(iface, flags);
+
+	/* Network interface did not come up. */
+	if (timeout > 0 && count < 0) {
+		NET_ERR("Timeout while waiting network %s", "interface");
+		return -ENETDOWN;
+	}
 
 	/* Loop here until we are ready to continue. As we might need
 	 * to wait multiple events, sleep smaller amounts of data.


### PR DESCRIPTION
Requested for NCS 2.3.0 by @krish2718 