### PR TITLE
[nrf fromlist] settings: Make settings_subsys_init() thread safe

### DIFF
--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -15,6 +15,7 @@
 #include "settings/settings_file.h"
 #include <zephyr/kernel.h>
 
+extern struct k_mutex settings_lock;
 
 bool settings_subsys_initialized;
 
@@ -27,17 +28,19 @@ int settings_subsys_init(void)
 
 	int err = 0;
 
-	if (settings_subsys_initialized) {
-		return 0;
+	k_mutex_lock(&settings_lock, K_FOREVER);
+
+	if (!settings_subsys_initialized) {
+		settings_init();
+
+		err = settings_backend_init(); /* func rises kernel panic once error */
+
+		if (!err) {
+			settings_subsys_initialized = true;
+		}
 	}
 
-	settings_init();
-
-	err = settings_backend_init(); /* func rises kernel panic once error */
-
-	if (!err) {
-		settings_subsys_initialized = true;
-	}
+	k_mutex_unlock(&settings_lock);
 
 	return err;
 }


### PR DESCRIPTION
Multiple components may use the settings subsystem, so ensure settings_subsys_init() is thread safe.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/54943