### PR TITLE
[nrf fromlist] net: l2: ethernet: Fix double free

### DIFF
--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -744,6 +744,19 @@ void net_arp_clear_cache(struct net_if *iface)
 	k_mutex_unlock(&arp_mutex);
 }
 
+int net_arp_clear_pending(struct net_if *iface, struct in_addr *dst)
+{
+	struct arp_entry *entry = arp_entry_find_pending(iface, dst);
+
+	if (!entry) {
+		return -ENOENT;
+	}
+
+	arp_entry_cleanup(entry, true);
+
+	return 0;
+}
+
 int net_arp_foreach(net_arp_cb_t cb, void *user_data)
 {
 	int ret = 0;

--- a/subsys/net/l2/ethernet/arp.h
+++ b/subsys/net/l2/ethernet/arp.h
@@ -49,6 +49,9 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 enum net_verdict net_arp_input(struct net_pkt *pkt,
 			       struct net_eth_hdr *eth_hdr);
 
+int net_arp_clear_pending(struct net_if *iface,
+				struct in_addr *dst);
+
 struct arp_entry {
 	sys_snode_t node;
 	uint32_t req_start;
@@ -79,6 +82,7 @@ void net_arp_init(void);
 #define net_arp_clear_cache(...)
 #define net_arp_foreach(...) 0
 #define net_arp_init(...)
+#define net_arp_clear_pending(...) 0
 
 #endif /* CONFIG_NET_ARP */
 

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -601,8 +601,9 @@ static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 {
 	const struct ethernet_api *api = net_if_get_device(iface)->api;
 	struct ethernet_context *ctx = net_if_l2_data(iface);
-	uint16_t ptype;
+	uint16_t ptype = 0;
 	int ret;
+	struct net_pkt *orig_pkt = pkt;
 
 	if (!api) {
 		ret = -ENOENT;
@@ -717,6 +718,19 @@ send:
 	if (ret != 0) {
 		eth_stats_update_errors_tx(iface);
 		ethernet_remove_l2_header(pkt);
+		if (IS_ENABLED(CONFIG_NET_ARP) && ptype == htons(NET_ETH_PTYPE_ARP)) {
+			/* Original packet was added to ARP's pending Q, so, to avoid it
+			 * being freed, take a reference, the reference is dropped when we
+			 * clear the pending Q in ARP and then it will be freed by net_if.
+			 */
+			net_pkt_ref(orig_pkt);
+			if (net_arp_clear_pending(iface,
+				(struct in_addr *)NET_IPV4_HDR(pkt)->dst)) {
+				NET_DBG("Could not find pending ARP entry");
+			}
+			/* Free the ARP request */
+			net_pkt_unref(pkt);
+		}
 		goto error;
 	}
 


### PR DESCRIPTION
In the case of no ARP entry, the incoming packet is added to the ARP's pending queue, while ARP is being resolved. Here a reference is taken by the ARP layer to the packet to avoid it being freed, but the Ethernet immediately puts down the reference and send the ARP packet to the driver.

If the ARP request fails for some reason, L2 returns failure to net_if which then puts down the reference and the packet will be freed as the reference count is now zero.

But the packet is still in the ARP's pending queue and after timeout ARP will put down the reference causing double free bus fault (double free message is only seen if the CONFIG_NET_PKT_LOG_LEVEL_DBG is enabled, so, a bit hard to debug.

Fix this but not putting down the reference in Ethernet that was taken by ARP and let ARP timeout handling free the pending packet.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>
(cherry picked from commit 6934eaaae8777b2caebcde49bc1f83ae53073274)