### PR TITLE
[backport-v1.9][nrf fromtree] soc: nrf53: Add workaround for anomaly 160

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library("CI_LIB") _
+@Library("CI_LIB@v1.9-branch") _
 
 def pipeline = new ncs.sdk_zephyr.Main()
 

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -54,6 +54,14 @@ config CODE_DATA_RELOCATION_SRAM
 	  config is used to create an MPU entry for the SRAM space used for code
 	  relocation.
 
+config ARM_ON_ENTER_CPU_IDLE_HOOK
+	bool
+	help
+	  Enables a hook (z_arm_on_enter_cpu_idle()) that is called when
+	  the CPU is made idle (by k_cpu_idle() or k_cpu_atomic_idle()).
+	  If needed, this hook can be used to prevent the CPU from actually
+	  entering sleep by skipping the WFE/WFI instruction.
+
 rsource "core/aarch32/Kconfig"
 
 endmenu

--- a/arch/arm/core/aarch32/cpu_idle.S
+++ b/arch/arm/core/aarch32/cpu_idle.S
@@ -50,6 +50,33 @@ SECTION_FUNC(TEXT, z_arm_cpu_idle_init)
 #endif
 	bx	lr
 
+.macro _sleep_if_allowed wait_instruction
+#if defined(CONFIG_ARM_ON_ENTER_CPU_IDLE_HOOK)
+	push	{r0, lr}
+	bl	z_arm_on_enter_cpu_idle
+	/* Skip the wait instruction if on_enter_cpu_idle() returns false. */
+	cmp	r0, #0
+	beq	_skip_\@
+#endif /* CONFIG_ARM_ON_ENTER_CPU_IDLE_HOOK */
+
+	/*
+	 * Wait for all memory transactions to complete before entering low
+	 * power state.
+	 */
+	dsb
+	\wait_instruction
+
+#if defined(CONFIG_ARM_ON_ENTER_CPU_IDLE_HOOK)
+_skip_\@:
+#if defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE)
+	pop	{r0, r1}
+	mov	lr, r1
+#else
+	pop	{r0, lr}
+#endif /* CONFIG_ARMV6_M_ARMV8_M_BASELINE */
+#endif /* CONFIG_ARM_ON_ENTER_CPU_IDLE_HOOK */
+.endm
+
 SECTION_FUNC(TEXT, arch_cpu_idle)
 #ifdef CONFIG_TRACING
 	push	{r0, lr}
@@ -91,14 +118,8 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
 	 */
 #endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 
-	/*
-	 * Wait for all memory transactions to complete before entering low
-	 * power state.
-	 */
-	dsb
-
 	/* Enter low power state */
-	wfi
+	_sleep_if_allowed wfi
 
 	/*
 	 * Clear PRIMASK and flush instruction buffer to immediately service
@@ -140,7 +161,7 @@ SECTION_FUNC(TEXT, arch_cpu_atomic_idle)
 	/* No BASEPRI, call wfe directly
 	 * (SEVONPEND is set in z_arm_cpu_idle_init())
 	 */
-	wfe
+	_sleep_if_allowed wfe
 
 	cmp	r0, #0
 	bne	_irq_disabled
@@ -154,7 +175,7 @@ _irq_disabled:
 	/* unlock BASEPRI so wfe gets interrupted by incoming interrupts */
 	msr	BASEPRI, r1
 
-	wfe
+	_sleep_if_allowed wfe
 
 	msr	BASEPRI, r0
 	cpsie	i

--- a/drivers/entropy/entropy_nrf5.c
+++ b/drivers/entropy/entropy_nrf5.c
@@ -292,18 +292,7 @@ static int entropy_nrf5_get_entropy_isr(const struct device *dev,
 
 			while (!nrf_rng_event_check(NRF_RNG,
 						    NRF_RNG_EVENT_VALRDY)) {
-				/*
-				 * To guarantee waking up from the event, the
-				 * SEV-On-Pend feature must be enabled (enabled
-				 * during ARCH initialization).
-				 *
-				 * DSB is recommended by spec before WFE (to
-				 * guarantee completion of memory transactions)
-				 */
-				__DSB();
-				__WFE();
-				__SEV();
-				__WFE();
+				k_cpu_atomic_idle(irq_lock());
 			}
 
 			byte = random_byte_get();

--- a/include/arch/arm/aarch32/misc.h
+++ b/include/arch/arm/aarch32/misc.h
@@ -42,6 +42,15 @@ static ALWAYS_INLINE void arch_nop(void)
 extern bool z_arm_thread_is_in_user_mode(void);
 #endif
 
+#if defined(CONFIG_ARM_ON_ENTER_CPU_IDLE_HOOK)
+/* Prototype of a hook that can be enabled to be called every time the CPU is
+ * made idle (the calls will be done from k_cpu_idle() and k_cpu_atomic_idle()).
+ * If this hook returns false, the CPU is prevented from entering the actual
+ * sleep (the WFE/WFI instruction is skipped).
+ */
+bool z_arm_on_enter_cpu_idle(void);
+#endif
+
 #endif
 
 #ifdef __cplusplus

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -113,6 +113,7 @@ config SOC_NRF5340_CPUNET
 	select HAS_HW_NRF_UARTE0
 	select HAS_HW_NRF_WDT
 	select HAS_NO_PM
+	imply SOC_NRF53_ANOMALY_160_WORKAROUND
 
 choice
 	prompt "nRF53x MCU Selection"
@@ -128,16 +129,22 @@ config SOC_NRF5340_CPUNET_QKAA
 
 endchoice
 
+config SOC_NRF53_ANOMALY_160_WORKAROUND
+	bool
+	depends on SYS_CLOCK_EXISTS
+	select ARM_ON_ENTER_CPU_IDLE_HOOK
 
 if SOC_NRF5340_CPUAPP
 
 config SOC_DCDC_NRF53X_APP
 	bool
+	imply SOC_NRF53_ANOMALY_160_WORKAROUND
 	help
 	  Enable nRF53 series System on Chip Application MCU DC/DC converter.
 
 config SOC_DCDC_NRF53X_NET
 	bool
+	imply SOC_NRF53_ANOMALY_160_WORKAROUND
 	help
 	  Enable nRF53 series System on Chip Network MCU DC/DC converter.
 

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -18,6 +18,7 @@
 #include <soc/nrfx_coredep.h>
 #include <logging/log.h>
 #include <nrf_erratas.h>
+#include <hal/nrf_power.h>
 #if defined(CONFIG_SOC_NRF5340_CPUAPP)
 #include <hal/nrf_cache.h>
 #include <hal/nrf_gpio.h>
@@ -48,6 +49,83 @@ extern void z_arm_nmi_init(void);
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);
+
+#if defined(CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND)
+static void nrf53_anomaly_160_workaround(void)
+{
+	/* This part is supposed to be removed once the writes are available
+	 * in hal_nordic/nrfx/MDK.
+	 */
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) && !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	*((volatile uint32_t *)0x5000470C) = 0x7Eul;
+	*((volatile uint32_t *)0x5000493C) = 0x7Eul;
+	*((volatile uint32_t *)0x50002118) = 0x7Ful;
+	*((volatile uint32_t *)0x50039E04) = 0x0ul;
+	*((volatile uint32_t *)0x50039E08) = 0x0ul;
+	*((volatile uint32_t *)0x50101110) = 0x0ul;
+	*((volatile uint32_t *)0x50002124) = 0x0ul;
+	*((volatile uint32_t *)0x5000212C) = 0x0ul;
+	*((volatile uint32_t *)0x502012A0) = 0x0ul;
+#elif defined(CONFIG_SOC_NRF5340_CPUNET)
+	*((volatile uint32_t *)0x41002118) = 0x7Ful;
+	*((volatile uint32_t *)0x41080E04) = 0x0ul;
+	*((volatile uint32_t *)0x41080E08) = 0x0ul;
+	*((volatile uint32_t *)0x41002124) = 0x0ul;
+	*((volatile uint32_t *)0x4100212C) = 0x0ul;
+	*((volatile uint32_t *)0x41101110) = 0x0ul;
+#endif
+}
+
+bool z_arm_on_enter_cpu_idle(void)
+{
+	/* This code prevents the CPU from entering sleep again if it already
+	 * entered sleep 5 times within last 200 us.
+	 */
+
+	/* System clock cycles needed to cover 200 us window. */
+	const uint32_t window_cycles =
+		ceiling_fraction(200 * CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
+				 1000000);
+	static uint32_t timestamps[5];
+	static bool timestamps_filled;
+	static bool suppress_warning;
+	static uint8_t current;
+	uint8_t oldest = (current + 1) % ARRAY_SIZE(timestamps);
+	uint32_t now = k_cycle_get_32();
+
+	if (timestamps_filled &&
+	    /* + 1 because only fully elapsed cycles need to be counted. */
+	    (now - timestamps[oldest]) < (window_cycles + 1)) {
+		if (!suppress_warning) {
+			LOG_WRN("Anomaly 160 trigger conditions detected.");
+			suppress_warning = true;
+		}
+		return false;
+	}
+	suppress_warning = false;
+
+	/* Check if the CPU actually entered sleep since the last visit here
+	 * (WFE/WFI could return immediately if the wake-up event was already
+	 * registered).
+	 */
+	if (nrf_power_event_check(NRF_POWER, NRF_POWER_EVENT_SLEEPENTER)) {
+		nrf_power_event_clear(NRF_POWER, NRF_POWER_EVENT_SLEEPENTER);
+		/* If so, update the index at which the current timestamp is
+		 * to be stored so that it replaces the oldest one, otherwise
+		 * (when the CPU did not sleep), the recently stored timestamp
+		 * is updated.
+		 */
+		current = oldest;
+		if (current == 0) {
+			timestamps_filled = true;
+		}
+	}
+
+	timestamps[current] = k_cycle_get_32();
+
+	return true;
+}
+#endif /* CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND */
 
 static int nordicsemi_nrf53_init(const struct device *arg)
 {
@@ -108,6 +186,11 @@ static int nordicsemi_nrf53_init(const struct device *arg)
 	nrf_oscillators_hfxo_cap_set(NRF_OSCILLATORS, true, capvalue);
 #elif defined(CONFIG_SOC_HFXO_CAP_EXTERNAL)
 	nrf_oscillators_hfxo_cap_set(NRF_OSCILLATORS, false, 0);
+#endif
+
+#if defined(CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND)
+	/* This needs to be done before DC/DC operation is enabled. */
+	nrf53_anomaly_160_workaround();
 #endif
 
 #if defined(CONFIG_SOC_DCDC_NRF53X_APP)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
@@ -11,6 +11,15 @@ static inline void cpu_sleep(void)
 	defined(CONFIG_CPU_CORTEX_M4) || \
 	defined(CONFIG_CPU_CORTEX_M33) || \
 	defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
+	/*
+	 * To guarantee waking up from the event, the
+	 * SEV-On-Pend feature must be enabled (enabled
+	 * during ARCH initialization).
+	 *
+	 * DSB is recommended by spec before WFE (to
+	 * guarantee completion of memory transactions)
+	 */
+	__DSB();
 	__WFE();
 	__SEV();
 	__WFE();

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
@@ -5,25 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <kernel.h>
+
 static inline void cpu_sleep(void)
 {
-#if defined(CONFIG_CPU_CORTEX_M0) || \
-	defined(CONFIG_CPU_CORTEX_M4) || \
-	defined(CONFIG_CPU_CORTEX_M33) || \
-	defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
-	/*
-	 * To guarantee waking up from the event, the
-	 * SEV-On-Pend feature must be enabled (enabled
-	 * during ARCH initialization).
-	 *
-	 * DSB is recommended by spec before WFE (to
-	 * guarantee completion of memory transactions)
-	 */
-	__DSB();
-	__WFE();
-	__SEV();
-	__WFE();
-#endif
+	k_cpu_atomic_idle(irq_lock());
 }
 
 static inline void cpu_dmb(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ecb.c
@@ -12,6 +12,8 @@
 #include <hal/nrf_ecb.h>
 
 #include "util/mem.h"
+
+#include "hal/cpu.h"
 #include "hal/ecb.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
@@ -39,7 +41,10 @@ static void do_ecb(struct ecb_param *ecb)
 #if defined(CONFIG_SOC_SERIES_BSIM_NRFXX)
 			k_busy_wait(10);
 #else
-			/*__WFE();*/
+			/* FIXME: use cpu_sleep(), but that will need interrupt
+			 *        wake up source and hence necessary appropriate
+			 *        code.
+			 */
 #endif
 		}
 		nrf_ecb_task_trigger(NRF_ECB, NRF_ECB_TASK_STOPECB);
@@ -188,9 +193,7 @@ uint32_t ecb_ut(void)
 	ecb.context = &context;
 	status = ecb_encrypt_nonblocking(&ecb);
 	do {
-		__WFE();
-		__SEV();
-		__WFE();
+		cpu_sleep();
 	} while (!context.done);
 
 	if (context.status != 0U) {

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -17,6 +17,7 @@
 
 #include "util/mem.h"
 
+#include "hal/cpu.h"
 #include "hal/ccm.h"
 #include "hal/radio.h"
 #include "hal/ticker.h"
@@ -1521,9 +1522,7 @@ uint32_t radio_ccm_is_done(void)
 {
 	nrf_ccm_int_enable(NRF_CCM, CCM_INTENSET_ENDCRYPT_Msk);
 	while (NRF_CCM->EVENTS_ENDCRYPT == 0) {
-		__WFE();
-		__SEV();
-		__WFE();
+		cpu_sleep();
 	}
 	nrf_ccm_int_disable(NRF_CCM, CCM_INTENCLR_ENDCRYPT_Msk);
 	NVIC_ClearPendingIRQ(nrfx_get_irq_number(NRF_CCM));
@@ -1613,9 +1612,7 @@ uint32_t radio_ar_has_match(void)
 	nrf_aar_int_enable(NRF_AAR, AAR_INTENSET_END_Msk);
 
 	while (NRF_AAR->EVENTS_END == 0U) {
-		__WFE();
-		__SEV();
-		__WFE();
+		cpu_sleep();
 	}
 
 	nrf_aar_int_disable(NRF_AAR, AAR_INTENCLR_END_Msk);
@@ -1647,9 +1644,7 @@ void radio_ar_resolve(const uint8_t *addr)
 	nrf_aar_task_trigger(NRF_AAR, NRF_AAR_TASK_START);
 
 	while (NRF_AAR->EVENTS_END == 0) {
-		__WFE();
-		__SEV();
-		__WFE();
+		cpu_sleep();
 	}
 
 	nrf_aar_int_disable(NRF_AAR, AAR_INTENCLR_END_Msk);


### PR DESCRIPTION
Cherry-pick a set of upstream commits to get the workaround for nRF53 anomaly 160 in NCS 1.9.