### PR TITLE
[nrf fromtree] nrf_rtc_timer fixes related to missed timeout expirations

### DIFF
--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -405,7 +405,7 @@ static void sys_clock_timeout_handler(int32_t chan,
 				      void *user_data)
 {
 	uint32_t cc_value = absolute_time_to_cc(expire_time);
-	uint64_t dticks = (expire_time - last_count) / CYC_PER_TICK;
+	uint32_t dticks = (uint32_t)(expire_time - last_count) / CYC_PER_TICK;
 
 	last_count += dticks * CYC_PER_TICK;
 
@@ -419,8 +419,7 @@ static void sys_clock_timeout_handler(int32_t chan,
 					  sys_clock_timeout_handler, NULL);
 	}
 
-	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ?
-			   (int32_t)dticks : (dticks > 0));
+	sys_clock_announce(dticks);
 }
 
 static bool channel_processing_check_and_clear(int32_t chan)

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -424,25 +424,18 @@ static void sys_clock_timeout_handler(int32_t chan,
 
 static bool channel_processing_check_and_clear(int32_t chan)
 {
-	bool result = false;
-
-	uint32_t mcu_critical_state = full_int_lock();
-
 	if (nrf_rtc_int_enable_check(RTC, RTC_CHANNEL_INT_MASK(chan))) {
 		/* The processing of channel can be caused by CC match
 		 * or be forced.
 		 */
-		result = (atomic_and(&force_isr_mask, ~BIT(chan)) & BIT(chan)) ||
-			 event_check(chan);
-
-		if (result) {
+		if ((atomic_and(&force_isr_mask, ~BIT(chan)) & BIT(chan)) ||
+		    event_check(chan)) {
 			event_clear(chan);
+			return true;
 		}
 	}
 
-	full_int_unlock(mcu_critical_state);
-
-	return result;
+	return false;
 }
 
 static void process_channel(int32_t chan)

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -428,7 +428,7 @@ static bool channel_processing_check_and_clear(int32_t chan)
 		/* The processing of channel can be caused by CC match
 		 * or be forced.
 		 */
-		result = atomic_and(&force_isr_mask, ~BIT(chan)) ||
+		result = (atomic_and(&force_isr_mask, ~BIT(chan)) & BIT(chan)) ||
 			 event_check(chan);
 
 		if (result) {

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -66,11 +66,6 @@ static void set_comparator(int32_t chan, uint32_t cyc)
 	nrf_rtc_cc_set(RTC, chan, cyc & COUNTER_MAX);
 }
 
-static uint32_t get_comparator(int32_t chan)
-{
-	return nrf_rtc_cc_get(RTC, chan);
-}
-
 static bool event_check(int32_t chan)
 {
 	return nrf_rtc_event_check(RTC, RTC_CHANNEL_EVENT_ADDR(chan));
@@ -387,7 +382,7 @@ static inline bool in_anchor_range(uint32_t cc_value)
 	return (cc_value >= ANCHOR_RANGE_START) && (cc_value < ANCHOR_RANGE_END);
 }
 
-static inline bool anchor_update(uint32_t cc_value)
+static inline void anchor_update(uint32_t cc_value)
 {
 	/* Update anchor when far from overflow */
 	if (in_anchor_range(cc_value)) {
@@ -397,10 +392,7 @@ static inline bool anchor_update(uint32_t cc_value)
 		 * `z_nrf_rtc_timer_read`.
 		 */
 		anchor = (((uint64_t)overflow_cnt) << COUNTER_BIT_WIDTH) + cc_value;
-		return true;
 	}
-
-	return false;
 }
 
 static void sys_clock_timeout_handler(int32_t chan,
@@ -412,7 +404,7 @@ static void sys_clock_timeout_handler(int32_t chan,
 
 	last_count += dticks * CYC_PER_TICK;
 
-	bool anchor_updated = anchor_update(cc_value);
+	anchor_update(cc_value);
 
 	if (!IS_ENABLED(CONFIG_TICKLESS_KERNEL)) {
 		/* protection is not needed because we are in the RTC interrupt
@@ -424,19 +416,6 @@ static void sys_clock_timeout_handler(int32_t chan,
 
 	sys_clock_announce(IS_ENABLED(CONFIG_TICKLESS_KERNEL) ?
 			   (int32_t)dticks : (dticks > 0));
-
-	if (cc_value == get_comparator(chan)) {
-		/* New value was not set. Set something that can update anchor.
-		 * If anchor was updated we can enable same CC value to trigger
-		 * interrupt after full cycle. Else set event in anchor update
-		 * range. Since anchor was not updated we know that it's very
-		 * far from mid point so setting is done without any protection.
-		 */
-		if (!anchor_updated) {
-			set_comparator(chan, COUNTER_HALF_SPAN);
-		}
-		event_enable(chan);
-	}
 }
 
 static bool channel_processing_check_and_clear(int32_t chan)
@@ -627,6 +606,8 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 
 	/* Due to elapsed time the calculation above might produce a
 	 * duration that laps the counter.  Don't let it.
+	 * This limitation also guarantees that the anchor will be properly
+	 * updated before every overflow (see anchor_update()).
 	 */
 	if (cyc > MAX_CYCLES) {
 		cyc = MAX_CYCLES;

--- a/drivers/timer/nrf_rtc_timer.c
+++ b/drivers/timer/nrf_rtc_timer.c
@@ -670,7 +670,7 @@ static int sys_clock_driver_init(const struct device *dev)
 	}
 
 	uint32_t initial_timeout = IS_ENABLED(CONFIG_TICKLESS_KERNEL) ?
-		MAX_TICKS : (counter() + CYC_PER_TICK);
+		MAX_CYCLES : CYC_PER_TICK;
 
 	compare_set(0, initial_timeout, sys_clock_timeout_handler, NULL);
 

--- a/tests/drivers/timer/nrf_rtc_timer/src/main.c
+++ b/tests/drivers/timer/nrf_rtc_timer/src/main.c
@@ -477,6 +477,69 @@ ZTEST(nrf_rtc_timer, test_next_cycle_timeouts)
 	z_nrf_rtc_timer_chan_free(chan);
 }
 
+static void tight_rescheduling_handler(int32_t chan,
+				       uint64_t expire_time,
+				       void *user_data)
+{
+	if (user_data) {
+		*(bool *)user_data = true;
+	}
+}
+
+ZTEST(nrf_rtc_timer, test_tight_rescheduling)
+{
+	int32_t chan;
+	volatile bool expired;
+	/* This test tries to schedule an alarm to CYCLE_DIFF cycles from
+	 * the current moment and then, after a delay that is changed in
+	 * each iteration, tries to reschedule this alarm to one cycle later.
+	 * It does not matter if the first alarm actually occurs, the key
+	 * thing is to always get the second one.
+	 */
+	enum {
+		CYCLE_DIFF = 5,
+		/* One RTC cycle is ~30.5 us. Check a range of delays from
+		 * more than one cycle before the moment on which the first
+		 * alarm is scheduled to a few microseconds after that alarm
+		 * (when it is actually too late for rescheduling).
+		 */
+		DELAY_MIN = 30 * CYCLE_DIFF - 40,
+		DELAY_MAX = 30 * CYCLE_DIFF + 10,
+	};
+
+	chan = z_nrf_rtc_timer_chan_alloc();
+	zassert_true(chan > 0, "Failed to allocate RTC channel.");
+
+	/* Repeat the whole test a couple of times to get also (presumably)
+	 * various micro delays resulting from execution of the test routine
+	 * itself asynchronously to the RTC.
+	 */
+	for (uint32_t i = 0; i < 20; ++i) {
+		for (uint32_t delay = DELAY_MIN; delay <= DELAY_MAX; ++delay) {
+			uint64_t start = z_nrf_rtc_timer_read();
+
+			z_nrf_rtc_timer_set(chan, start + CYCLE_DIFF,
+				tight_rescheduling_handler, NULL);
+
+			k_busy_wait(delay);
+
+			expired = false;
+			z_nrf_rtc_timer_set(chan, start + CYCLE_DIFF + 1,
+				tight_rescheduling_handler, (void *)&expired);
+
+			while (!expired &&
+				(z_nrf_rtc_timer_read() - start) <
+					CYCLE_DIFF + 10) {
+			}
+			zassert_true(expired,
+				"Timeout expiration missed (d: %u us, i: %u)",
+				delay, i);
+		}
+	}
+
+	z_nrf_rtc_timer_chan_free(chan);
+}
+
 static void *rtc_timer_setup(void)
 {
 	init_zli_timer0();


### PR DESCRIPTION
Cherry-pick a set of upstream commits that fix a problem in the system timer driver (nrf_rtc_timer) that in specific conditions the COMPARE event for a scheduled timeout was not handled properly and in consequence the timeout expired with an additional delay of 512 seconds, i.e. after the RTC overflowed.