### PR TITLE
[nrf fromtree] wifi: shell: Print beacon interval and DTIM period

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -180,6 +180,8 @@ struct wifi_iface_status {
 	enum wifi_security_type security;
 	enum wifi_mfp_options mfp;
 	int rssi;
+	unsigned short dtim_period;
+	unsigned char beacon_interval;
 };
 
 struct wifi_ps_params {

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -370,6 +370,8 @@ static int cmd_wifi_status(const struct shell *sh, size_t argc, char *argv[])
 		shell_fprintf(sh, SHELL_NORMAL, "MFP: %s\n",
 				wifi_mfp_txt(status.mfp));
 		shell_fprintf(sh, SHELL_NORMAL, "RSSI: %d\n", status.rssi);
+		shell_fprintf(sh, SHELL_NORMAL, "Beacon Interval: %d\n", status.beacon_interval);
+		shell_fprintf(sh, SHELL_NORMAL, "DTIM: %d\n", status.dtim_period);
 	}
 
 	return 0;


### PR DESCRIPTION
Print beacon interval and DTIM period as part of Wi-Fi status output.

Signed-off-by: Ravi Dondaputi <ravi.dondaputi@nordicsemi.no>
(cherry picked from commit c75421f37724a2bf0cbda8473ac8fe96008bb8fc)