### PR TITLE
[nrf fromtree] modules: hal_nordic: 802.15.4 carrier functions made o…

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -205,6 +205,13 @@ endif
 
 endmenu # NRF_802154_SER_HOST || NRF_802154_SER_RADIO
 
+config NRF_802154_CARRIER_FUNCTIONS
+	bool "nRF 802.15.4 carrier functions"
+	depends on NRF_802154_RADIO_DRIVER || NRF_802154_SERIALIZATION
+	help
+	  This option enables functions such as modulated carrier and continuous carrier.
+	  If this option is modified on a multicore SoC, its remote counterpart must be set to the exact same value.
+
 endmenu # HAS_NORDIC_DRIVERS
 
 rsource "nrfx/Kconfig"

--- a/modules/hal_nordic/nrf_802154/CMakeLists.txt
+++ b/modules/hal_nordic/nrf_802154/CMakeLists.txt
@@ -89,6 +89,12 @@ else()
   target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_INTERNAL_RADIO_IRQ_HANDLING=0)
 endif()
 
+if (CONFIG_NRF_802154_CARRIER_FUNCTIONS)
+  target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_CARRIER_FUNCTIONS_ENABLED=1)
+else()
+  target_compile_definitions(zephyr-802154-interface INTERFACE NRF_802154_CARRIER_FUNCTIONS_ENABLED=0)
+endif()
+
 set(NRF52_SERIES  ${CONFIG_SOC_SERIES_NRF52X})
 set(NRF53_SERIES  ${CONFIG_SOC_SERIES_NRF53X})
 set(SER_HOST      ${CONFIG_NRF_802154_SER_HOST})

--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: fe0be3c3546e136a67264084c0e3edfd7354645a
+      revision: 6c9f23498ee6a225fee049c8c5b2e1ac760bd4a8
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
…ptional

Added an option to disable and enable the continuous and optional carrier functions in the nordic 802.15.4 driver.

Signed-off-by: Artur Hadasz <artur.hadasz@nordicsemi.no>
(cherry picked from commit 5ec29589c44d8fa350ce014d0b6219195ba1f015)