### PR TITLE
[nrf fromtree] net: dns: Check existing DNS servers before reconfigure

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1386,6 +1386,59 @@ int dns_resolve_close(struct dns_resolve_context *ctx)
 	return ret;
 }
 
+static bool dns_server_exists(struct dns_resolve_context *ctx,
+			      const struct sockaddr *addr)
+{
+	for (int i = 0; i < SERVER_COUNT; i++) {
+		if (IS_ENABLED(CONFIG_NET_IPV4) && (addr->sa_family == AF_INET) &&
+		    (ctx->servers[i].dns_server.sa_family == AF_INET)) {
+			if (net_ipv4_addr_cmp(&net_sin(addr)->sin_addr,
+					      &net_sin(&ctx->servers[i].dns_server)->sin_addr)) {
+				return true;
+			}
+		}
+
+		if (IS_ENABLED(CONFIG_NET_IPV6) && (addr->sa_family == AF_INET6) &&
+		    (ctx->servers[i].dns_server.sa_family == AF_INET6)) {
+			if (net_ipv6_addr_cmp(&net_sin6(addr)->sin6_addr,
+					      &net_sin6(&ctx->servers[i].dns_server)->sin6_addr)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+static bool dns_servers_exists(struct dns_resolve_context *ctx,
+			       const char *servers[],
+			       const struct sockaddr *servers_sa[])
+{
+	if (servers) {
+		for (int i = 0; i < SERVER_COUNT && servers[i]; i++) {
+			struct sockaddr addr;
+
+			if (!net_ipaddr_parse(servers[i], strlen(servers[i]), &addr)) {
+				continue;
+			}
+
+			if (!dns_server_exists(ctx, &addr)) {
+				return false;
+			}
+		}
+	}
+
+	if (servers_sa) {
+		for (int i = 0; i < SERVER_COUNT && servers_sa[i]; i++) {
+			if (!dns_server_exists(ctx, servers_sa[i])) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
 int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
 			    const char *servers[],
 			    const struct sockaddr *servers_sa[])
@@ -1397,6 +1450,12 @@ int dns_resolve_reconfigure(struct dns_resolve_context *ctx,
 	}
 
 	k_mutex_lock(&ctx->lock, K_FOREVER);
+
+	if (dns_servers_exists(ctx, servers, servers_sa)) {
+		/* DNS servers did not change. */
+		err = 0;
+		goto unlock;
+	}
 
 	if (ctx->state == DNS_RESOLVE_CONTEXT_DEACTIVATING) {
 		err = -EBUSY;


### PR DESCRIPTION
In dns_resolve_reconfigure() check if the DNS servers already exist before cancel all ongoing queries. This will solve an issue with getaddrinfo() returning DNS_EAI_CANCELED when receiving a retransmitted DHCP offer and when receiving a IPv6 Router Advertisement.