### PR TITLE
scripts: ci: Fix for compliance with multi-user machine

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 import traceback
 import shlex
+import shutil
 
 from yamllint import config, linter
 
@@ -369,6 +370,8 @@ class KconfigCheck(ComplianceTest):
         if not os.path.exists(kconfig_path):
             self.error(kconfig_path + " not found")
 
+        kconfiglib_dir = tempfile.mkdtemp(prefix="kconfiglib_")
+
         sys.path.insert(0, kconfig_path)
         # Import globally so that e.g. kconfiglib.Symbol can be referenced in
         # tests
@@ -383,7 +386,7 @@ class KconfigCheck(ComplianceTest):
         os.environ["ARCH_DIR"] = "arch/"
         os.environ["BOARD_DIR"] = "boards/*/*"
         os.environ["ARCH"] = "*"
-        os.environ["KCONFIG_BINARY_DIR"] = tempfile.gettempdir()
+        os.environ["KCONFIG_BINARY_DIR"] = kconfiglib_dir
         os.environ['DEVICETREE_CONF'] = "dummy"
         os.environ['TOOLCHAIN_HAS_NEWLIB'] = "y"
 
@@ -392,10 +395,9 @@ class KconfigCheck(ComplianceTest):
         os.environ["GENERATED_DTS_BOARD_CONF"] = "dummy"
 
         # For multi repo support
-        self.get_modules(os.path.join(tempfile.gettempdir(), "Kconfig.modules"))
-
+        self.get_modules(os.path.join(kconfiglib_dir, "Kconfig.modules"))
         # For Kconfig.dts support
-        self.get_kconfig_dts(os.path.join(tempfile.gettempdir(), "Kconfig.dts"))
+        self.get_kconfig_dts(os.path.join(kconfiglib_dir, "Kconfig.dts"))
 
         # Tells Kconfiglib to generate warnings for all references to undefined
         # symbols within Kconfig files
@@ -410,6 +412,9 @@ class KconfigCheck(ComplianceTest):
         except kconfiglib.KconfigError as e:
             self.failure(str(e))
             raise EndTest
+        finally:
+            # Clean up the temporary directory
+            shutil.rmtree(kconfiglib_dir)
 
     def get_defined_syms(self, kconf):
         # Returns a set() with the names of all defined Kconfig symbols (with no


### PR DESCRIPTION
If in a server multiple users are running compliance then it throws errors as the filename "Kconfig.modules" and "Kconfig.dts" is owned by someone else.

Fix this by creating a randomized Kconfig file and delete after use.