### PR TITLE
nrf53: Halt app CPU before flashing netcore

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -343,6 +343,8 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
             net_hex.write_hex_file(net_hex_file)
             app_hex.write_hex_file(app_hex_file)
 
+            # halt app CPU before flashing network core
+            program_commands.append(['nrfjprog', '--halt', '--coprocessor', 'CP_APPLICATION'])
             add_program_cmd(net_hex_file, 'CP_NETWORK', [])
             add_program_cmd(app_hex_file, 'CP_APPLICATION', qspi_erase_opt)
         # Otherwise, only the network core is programmed.


### PR DESCRIPTION
Ongoing IPC communication between the app and net cores can cause flashing to fail on the nrf53 . This is because the network core is flashed first and the app core is not halted during this time. Attempted IPC communication can then lead to assertions/resets during the flashing process.  

This PR proposes to halt the app core before halting and flashing the network core for the nrf53. 