### PR TITLE
[nrf fromlist] net: context: Set priority based on DSCP

### DIFF
--- a/subsys/net/ip/ipv4.h
+++ b/subsys/net/ip/ipv4.h
@@ -232,6 +232,16 @@ static inline void net_ipv4_set_dscp(uint8_t *tos, uint8_t dscp)
 }
 
 /**
+ * @brief Convert DSCP value to priority.
+ *
+ * @param dscp DSCP value.
+ */
+static inline uint8_t net_ipv4_dscp_to_priority(uint8_t dscp)
+{
+	return dscp >> 3;
+}
+
+/**
  * @brief Decode ECN value from ToS field.
  *
  * @param tos ToS field value from the IPv4 header.

--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -524,6 +524,16 @@ static inline void net_ipv6_set_dscp(uint8_t *tc, uint8_t dscp)
 }
 
 /**
+ * @brief Convert DSCP value to priority.
+ *
+ * @param dscp DSCP value.
+ */
+static inline uint8_t net_ipv6_dscp_to_priority(uint8_t dscp)
+{
+	return dscp >> 3;
+}
+
+/**
  * @brief Decode ECN value from TC field.
  *
  * @param tc TC field value from the IPv6 header.

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -895,6 +895,11 @@ int net_context_create_ipv4_new(struct net_context *context,
 #if defined(CONFIG_NET_CONTEXT_DSCP_ECN)
 	net_pkt_set_ip_dscp(pkt, net_ipv4_get_dscp(context->options.dscp_ecn));
 	net_pkt_set_ip_ecn(pkt, net_ipv4_get_ecn(context->options.dscp_ecn));
+	/* Direct priority takes precedence over DSCP */
+	if (!IS_ENABLED(CONFIG_NET_CONTEXT_PRIORITY)) {
+		net_pkt_set_priority(pkt, net_ipv4_dscp_to_priority(
+			net_ipv4_get_dscp(context->options.dscp_ecn)));
+	}
 #endif
 
 	return net_ipv4_create(pkt, src, dst);
@@ -925,6 +930,11 @@ int net_context_create_ipv6_new(struct net_context *context,
 #if defined(CONFIG_NET_CONTEXT_DSCP_ECN)
 	net_pkt_set_ip_dscp(pkt, net_ipv6_get_dscp(context->options.dscp_ecn));
 	net_pkt_set_ip_ecn(pkt, net_ipv6_get_ecn(context->options.dscp_ecn));
+	/* Direct priority takes precedence over DSCP */
+	if (!IS_ENABLED(CONFIG_NET_CONTEXT_PRIORITY)) {
+		net_pkt_set_priority(pkt, net_ipv6_dscp_to_priority(
+			net_ipv6_get_dscp(context->options.dscp_ecn)));
+	}
 #endif
 
 	return net_ipv6_create(pkt, src, dst);


### PR DESCRIPTION
If a socket has DSCP set then the packets from the socket should also be marked with appropriate priority in case traffic classes are used in networking stack.

Signed-off-by: Krishna T <krishna.t@nordicsemi.no>
(cherry picked from commit 0df54dd47faf7ce0eec2d8e508d6dc31f643ff18)