### PR TITLE
[backport-v1.9][nrf fromtree] soc: nrf53: Change logging level of anomaly 160 message to DEBUG

### DIFF
--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -76,19 +76,17 @@ static void nrf53_anomaly_160_workaround(void)
 #endif
 }
 
-bool z_arm_on_enter_cpu_idle(void)
+/* This code prevents the CPU from entering sleep again if it already
+ * entered sleep 5 times within last 200 us.
+ */
+static bool nrf53_anomaly_160_check(void)
 {
-	/* This code prevents the CPU from entering sleep again if it already
-	 * entered sleep 5 times within last 200 us.
-	 */
-
 	/* System clock cycles needed to cover 200 us window. */
 	const uint32_t window_cycles =
 		ceiling_fraction(200 * CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC,
 				 1000000);
 	static uint32_t timestamps[5];
 	static bool timestamps_filled;
-	static bool suppress_warning;
 	static uint8_t current;
 	uint8_t oldest = (current + 1) % ARRAY_SIZE(timestamps);
 	uint32_t now = k_cycle_get_32();
@@ -96,13 +94,8 @@ bool z_arm_on_enter_cpu_idle(void)
 	if (timestamps_filled &&
 	    /* + 1 because only fully elapsed cycles need to be counted. */
 	    (now - timestamps[oldest]) < (window_cycles + 1)) {
-		if (!suppress_warning) {
-			LOG_WRN("Anomaly 160 trigger conditions detected.");
-			suppress_warning = true;
-		}
 		return false;
 	}
-	suppress_warning = false;
 
 	/* Check if the CPU actually entered sleep since the last visit here
 	 * (WFE/WFI could return immediately if the wake-up event was already
@@ -124,6 +117,24 @@ bool z_arm_on_enter_cpu_idle(void)
 	timestamps[current] = k_cycle_get_32();
 
 	return true;
+}
+
+bool z_arm_on_enter_cpu_idle(void)
+{
+	bool ok_to_sleep = nrf53_anomaly_160_check();
+
+#if (LOG_LEVEL >= LOG_LEVEL_DBG)
+	static bool suppress_message;
+
+	if (ok_to_sleep) {
+		suppress_message = false;
+	} else {
+		LOG_DBG("Anomaly 160 trigger conditions detected.");
+		suppress_message = true;
+	}
+#endif
+
+	return ok_to_sleep;
 }
 #endif /* CONFIG_SOC_NRF53_ANOMALY_160_WORKAROUND */
 

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -128,7 +128,7 @@ bool z_arm_on_enter_cpu_idle(void)
 
 	if (ok_to_sleep) {
 		suppress_message = false;
-	} else {
+	} else if (!suppress_message) {
 		LOG_DBG("Anomaly 160 trigger conditions detected.");
 		suppress_message = true;
 	}


### PR DESCRIPTION
This is a follow-up to commit fe3b97a87f480eb473cd58cc1990a5845c2ca9c6.
    
This message should not be a warning, as it does not actually indicate that something potentially bad happened. On the contrary, it informs that conditions in which the anomaly 160 could occur were detected and the anomaly was prevented from occurring. There is no need for this message to appear in the default configuration (INFO level). In fact, the message would undesirably flood the console in some cases (like the kernel/mem_protect/stack_random test) and sometimes it would also require enlarging the stack of the idle thread (the function is called underneath k_cpu_idle()). Therefore, the logging level of this message is changed to DEBUG.
    
Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>
(cherry picked from commit 7195db01f45d8045c3dc8e982155694ee6d06928)