### PR TITLE
[nrf fromtree]dts: Nordic: Enable NFCT for capable SoC

### DIFF
--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -154,7 +154,7 @@
 			compatible = "nordic,nrf-nfct";
 			reg = <0x40005000 0x1000>;
 			interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
-			status = "disabled";
+			status = "okay";
 		};
 
 		gpiote: gpiote@40006000 {

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -161,7 +161,7 @@
 			compatible = "nordic,nrf-nfct";
 			reg = <0x40005000 0x1000>;
 			interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
-			status = "disabled";
+			status = "okay";
 		};
 
 		gpiote: gpiote@40006000 {

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -156,7 +156,7 @@
 			compatible = "nordic,nrf-nfct";
 			reg = <0x40005000 0x1000>;
 			interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
-			status = "disabled";
+			status = "okay";
 		};
 
 		gpiote: gpiote@40006000 {

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -418,7 +418,7 @@ nfct: nfct@2d000 {
 	compatible = "nordic,nrf-nfct";
 	reg = <0x2d000 0x1000>;
 	interrupts = <45 NRF_DEFAULT_IRQ_PRIORITY>;
-	status = "disabled";
+	status = "okay";
 };
 
 mutex: mutex@30000 {


### PR DESCRIPTION
Enable NFCT peripheral for NFC capable Nordic SoC.

This fixes peripheral_hids_keyboard sample NFC connection.

Signed-off-by: Dominik Chat <dominik.chat@nordicsemi.no>
(cherry picked from commit 6bbaa29a136119bd326f969d7d6dbd842ccd14f4)