### PR TITLE
[nrf noup] Bluetooth: Mesh: Update default adv sets for mesh

### DIFF
--- a/subsys/bluetooth/Kconfig.adv
+++ b/subsys/bluetooth/Kconfig.adv
@@ -30,6 +30,7 @@ config BT_EXT_ADV_LEGACY_SUPPORT
 config BT_EXT_ADV_MAX_ADV_SET
 	int "Maximum number of simultaneous advertising sets"
 	range 1 64
+	default 7 if BT_MESH
 	default 1
 	help
 	  Maximum number of simultaneous Bluetooth advertising sets

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -397,7 +397,7 @@ if BT_MESH_ADV_EXT
 
 config BT_MESH_RELAY_ADV_SETS
 	int "Maximum of simultaneous relay message support"
-	default 0
+	default 4
 	range 0 BT_EXT_ADV_MAX_ADV_SET
 	depends on BT_MESH_RELAY
 	help
@@ -426,6 +426,7 @@ config BT_MESH_ADV_EXT_RELAY_USING_MAIN_ADV_SET
 config BT_MESH_ADV_EXT_GATT_SEPARATE
 	bool "Use a separate extended advertising set for GATT Server Advertising"
 	depends on BT_MESH_GATT_SERVER
+	default y
 	help
 	  Use a separate extended advertising set for GATT Server Advertising,
 	  otherwise a shared advertising set will be used.
@@ -433,6 +434,7 @@ config BT_MESH_ADV_EXT_GATT_SEPARATE
 config BT_MESH_ADV_EXT_FRIEND_SEPARATE
 	bool "Use a separate extended advertising set for Friend advertising"
 	depends on BT_MESH_FRIEND
+	default y
 	help
 	  Use a separate extended advertising set for Friend advertising,
 	  otherwise a shared advertising set will be used. Using the separate
@@ -673,7 +675,7 @@ config BT_MESH_RELAY_RETRANSMIT_INTERVAL
 
 config BT_MESH_RELAY_BUF_COUNT
 	int "Number of advertising buffers for relayed messages"
-	default 32
+	default 7
 	range 1 256
 	help
 	  Number of advertising buffers available for messages to be relayed.


### PR DESCRIPTION
Change default mesh configuration when running with SoftDevice Controller to get better performance.

Why it is changed this way:
- This configuration is only tested on SDC and may not give the same performance on ZLL, thus can't be set in upstream;
- `default <N> if BT_LL_SOFTDEVICE` can't be used as it won't work for nRF53 board where the controller is not present in the app core.