### PR TITLE
net: wifi_mgmt: Support to provide raw scan data

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -113,6 +113,7 @@ enum net_event_wifi_cmd {
 	NET_EVENT_WIFI_CMD_IFACE_STATUS,
 	NET_EVENT_WIFI_CMD_TWT,
 	NET_EVENT_WIFI_CMD_TWT_SLEEP_STATE,
+	NET_EVENT_WIFI_CMD_RAW_SCAN_RESULT,
 };
 
 #define NET_EVENT_WIFI_SCAN_RESULT				\
@@ -135,6 +136,9 @@ enum net_event_wifi_cmd {
 
 #define NET_EVENT_WIFI_TWT_SLEEP_STATE				\
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_TWT_SLEEP_STATE)
+
+#define NET_EVENT_WIFI_RAW_SCAN_RESULT                          \
+	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_RAW_SCAN_RESULT)
 /* Each result is provided to the net_mgmt_event_callback
  * via its info attribute (see net_mgmt.h)
  */
@@ -274,11 +278,23 @@ enum wifi_twt_sleep_state {
 	WIFI_TWT_STATE_AWAKE = 1,
 };
 
+#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+struct wifi_raw_scan_result {
+	int8_t rssi;
+	int frame_length;
+	unsigned short frequency;
+	uint8_t data[CONFIG_WIFI_MGMT_RAW_SCAN_RESULT_LENGTH];
+};
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 #include <zephyr/net/net_if.h>
 
 typedef void (*scan_result_cb_t)(struct net_if *iface, int status,
 				 struct wifi_scan_result *entry);
 
+#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+typedef void (*raw_scan_result_cb_t)(struct net_if *iface, int status,
+				     struct wifi_raw_scan_result *entry);
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 struct net_wifi_mgmt_offload {
 	/**
 	 * Mandatory to get in first position.
@@ -328,6 +344,10 @@ void wifi_mgmt_raise_iface_status_event(struct net_if *iface,
 void wifi_mgmt_raise_twt_event(struct net_if *iface,
 		struct wifi_twt_params *twt_params);
 void wifi_mgmt_raise_twt_sleep_state(struct net_if *iface, int twt_sleep_state);
+#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+void wifi_mgmt_raise_raw_scan_result_event(struct net_if *iface,
+		struct wifi_raw_scan_result *raw_scan_info);
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -30,6 +30,9 @@ union net_mgmt_events {
 #endif /* CONFIG_NET_DHCPV4 */
 #if defined(CONFIG_NET_L2_WIFI_MGMT)
 	struct wifi_scan_result wifi_scan_result;
+#if defined(CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS)
+	struct wifi_raw_scan_result raw_scan_result;
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 #endif /* CONFIG_NET_L2_WIFI_MGMT */
 #if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV6_MLD)
 	struct net_event_ipv6_route ipv6_route;

--- a/subsys/net/l2/Kconfig
+++ b/subsys/net/l2/Kconfig
@@ -110,6 +110,7 @@ module-dep = NET_LOG
 module-str = Log level for Wi-Fi management layer
 module-help = Enables Wi-Fi management interface to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
+source "subsys/net/l2/wifi/Kconfig"
 endif # NET_L2_WIFI_MGMT
 
 config NET_L2_WIFI_SHELL

--- a/subsys/net/l2/wifi/Kconfig
+++ b/subsys/net/l2/wifi/Kconfig
@@ -1,0 +1,29 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config WIFI_MGMT_RAW_SCAN_RESULTS
+	bool "Raw scan results"
+	help
+	  This option enables raw scan results. When enabled, the raw scan
+	  results (beacons or probe responses) are provided to the application.
+	  Enabling this config will increase the net_mgmt event size
+	  considerably.
+
+if WIFI_MGMT_RAW_SCAN_RESULTS
+
+config WIFI_MGMT_RAW_SCAN_RESULT_LENGTH
+	int "Maximum length of raw scan results"
+	default 512
+	help
+	  This option defines the maximum length of raw scan results.
+
+config WIFI_MGMT_RAW_SCAN_RESULTS_ONLY
+	bool "Only raw scan results"
+	help
+	  This option enables only raw scan results. When enabled, the raw scan
+	  results (beacons or probe responses) are provided to the application.
+	  The scan results are not parsed and the application is responsible
+	  for parsing the scan results. Normal scan results are not provided
+	  to the application.
+
+endif # WIFI_MGMT_RAW_SCAN_RESULTS

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -81,8 +81,10 @@ static void scan_result_cb(struct net_if *iface, int status,
 		return;
 	}
 
+#ifndef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS_ONLY
 	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_SCAN_RESULT, iface,
 					entry, sizeof(struct wifi_scan_result));
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS_ONLY */
 }
 
 static int wifi_scan(uint32_t mgmt_request, struct net_if *iface,
@@ -362,3 +364,20 @@ void wifi_mgmt_raise_twt_sleep_state(struct net_if *iface,
 					iface, INT_TO_POINTER(twt_sleep_state),
 					sizeof(twt_sleep_state));
 }
+
+#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+void wifi_mgmt_raise_raw_scan_result_event(struct net_if *iface,
+					   struct wifi_raw_scan_result *raw_scan_result)
+{
+	if (raw_scan_result->frame_length > CONFIG_WIFI_MGMT_RAW_SCAN_RESULT_LENGTH) {
+		LOG_INF("raw scan result frame length = %d too big,"
+			 "saving upto max raw scan length = %d",
+			 raw_scan_result->frame_length,
+			 CONFIG_WIFI_MGMT_RAW_SCAN_RESULT_LENGTH);
+	}
+
+	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_RAW_SCAN_RESULT,
+					iface, raw_scan_result,
+					sizeof(*raw_scan_result));
+}
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -26,11 +26,20 @@ LOG_MODULE_REGISTER(net_wifi_shell, LOG_LEVEL_INF);
 
 #define WIFI_SHELL_MODULE "wifi"
 
+#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS_ONLY
+#define WIFI_SHELL_MGMT_EVENTS (NET_EVENT_WIFI_RAW_SCAN_RESULT |        \
+				NET_EVENT_WIFI_SCAN_DONE |              \
+				NET_EVENT_WIFI_CONNECT_RESULT |         \
+				NET_EVENT_WIFI_DISCONNECT_RESULT |  \
+				NET_EVENT_WIFI_TWT)
+#else
 #define WIFI_SHELL_MGMT_EVENTS (NET_EVENT_WIFI_SCAN_RESULT |		\
 				NET_EVENT_WIFI_SCAN_DONE |		\
 				NET_EVENT_WIFI_CONNECT_RESULT |		\
 				NET_EVENT_WIFI_DISCONNECT_RESULT |  \
-				NET_EVENT_WIFI_TWT)
+				NET_EVENT_WIFI_TWT |		\
+				NET_EVENT_WIFI_RAW_SCAN_RESULT)
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS_ONLY */
 
 static struct {
 	const struct shell *sh;
@@ -100,6 +109,81 @@ static void handle_wifi_scan_result(struct net_mgmt_event_callback *cb)
 		      net_sprint_ll_addr_buf(entry->mac, WIFI_MAC_ADDR_LEN, mac_string_buf,
 					     sizeof(mac_string_buf)) : ""));
 }
+
+#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+static int wifi_freq_to_channel(int frequency)
+{
+	int channel = 0;
+
+	if (frequency == 2484) { /* channel 14 */
+		channel = 14;
+	} else if ((frequency <= 2472) && (frequency >= 2412)) {
+		channel = ((frequency - 2412) / 5) + 1;
+	} else if ((frequency <= 5320) && (frequency >= 5180)) {
+		channel = ((frequency - 5180) / 5) + 36;
+	} else if ((frequency <= 5720) && (frequency >= 5500)) {
+		channel = ((frequency - 5500) / 5) + 100;
+	} else if ((frequency <= 5895) && (frequency >= 5745)) {
+		channel = ((frequency - 5745) / 5) + 149;
+	} else {
+		channel = frequency;
+	}
+
+	return channel;
+}
+
+static enum wifi_frequency_bands wifi_freq_to_band(int frequency)
+{
+	enum wifi_frequency_bands band = WIFI_FREQ_BAND_2_4_GHZ;
+
+	if ((frequency  >= 2401) && (frequency <= 2495)) {
+		band = WIFI_FREQ_BAND_2_4_GHZ;
+	} else if ((frequency  >= 5170) && (frequency <= 5895)) {
+		band = WIFI_FREQ_BAND_5_GHZ;
+	} else {
+		band = WIFI_FREQ_BAND_6_GHZ;
+	}
+
+	return band;
+}
+
+static void handle_wifi_raw_scan_result(struct net_mgmt_event_callback *cb)
+{
+	struct wifi_raw_scan_result *raw =
+		(struct wifi_raw_scan_result *)cb->info;
+	int channel;
+	int band;
+	int rssi;
+	int i = 0;
+	uint8_t mac_string_buf[sizeof("xx:xx:xx:xx:xx:xx")];
+
+	scan_result++;
+
+	if (scan_result == 1U) {
+		print(context.sh, SHELL_NORMAL,
+		      "\n%-4s | %-13s | %-4s |  %-15s | %-15s | %-32s\n",
+		      "Num", "Channel (Band)", "RSSI", "BSSID", "Frame length", "Frame Body");
+	}
+
+	rssi = raw->rssi;
+	channel = wifi_freq_to_channel(raw->frequency);
+	band = wifi_freq_to_band(raw->frequency);
+
+	print(context.sh, SHELL_NORMAL, "%-4d | %-4u (%-6s) | %-4d | %s |      %-4d        ",
+	      scan_result,
+	      channel,
+	      wifi_band_txt(band),
+	      rssi,
+	      net_sprint_ll_addr_buf(raw->data + 10, WIFI_MAC_ADDR_LEN, mac_string_buf,
+				     sizeof(mac_string_buf)), raw->frame_length);
+
+	for (i = 0; i < 32; i++) {
+		print(context.sh, SHELL_NORMAL, "%02X ", *(raw->data + i));
+	}
+
+	print(context.sh, SHELL_NORMAL, "\n");
+}
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 
 static void handle_wifi_scan_done(struct net_mgmt_event_callback *cb)
 {
@@ -216,6 +300,11 @@ static void wifi_mgmt_event_handler(struct net_mgmt_event_callback *cb,
 	case NET_EVENT_WIFI_TWT:
 		handle_wifi_twt_event(cb);
 		break;
+#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+	case NET_EVENT_WIFI_RAW_SCAN_RESULT:
+		handle_wifi_raw_scan_result(cb);
+		break;
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
 	default:
 		break;
 	}


### PR DESCRIPTION
Support to provide raw beacon and probe response data to registered application.