### PR TITLE
[nrf noup] cmake: modules: Add NRF_DIR dir to snippets root

### DIFF
--- a/cmake/modules/snippets.cmake
+++ b/cmake/modules/snippets.cmake
@@ -59,6 +59,7 @@ function(zephyr_process_snippets)
   # Set SNIPPET_ROOT.
   list(APPEND SNIPPET_ROOT ${APPLICATION_SOURCE_DIR})
   list(APPEND SNIPPET_ROOT ${ZEPHYR_BASE})
+  list(APPEND SNIPPET_ROOT ${ZEPHYR_NRF_MODULE_DIR})
   unset(real_snippet_root)
   foreach(snippet_dir ${SNIPPET_ROOT})
     # The user might have put a symbolic link in here, for example.


### PR DESCRIPTION
Add nRF directory to snippets root to allow placing snippets in the sdk-nrf/snippets directory. CmakeLists.txt in nRF directory is handled after the snippets so that adding the directory in sdk-nrf will not work.

Relates to https://github.com/nrfconnect/sdk-nrf/pull/10891