### PR TITLE
[nrf fromtree] west.yaml: MCUboot synchronization from upstream

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -181,7 +181,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 6902abba270c0fbcbe8ee3bb56fe39bc9acc2774
+      revision: 1558e7ab0aadb4eac11f03befb5ccd3fa3f0aafe
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Update Zephyr fork of MCUboot to revision:
  1558e7ab0aadb4eac11f03befb5ccd3fa3f0aafe

Brings following Zephyr relevant fixes:
 - 1558e7ab boot: zephyr: remove stm32 watchdog defines
 - 4420bb66 boot: zephyr: setup watchdog
 - 393af79e boot_serial: Update zcbor files from zcbor 0.7.0
 - a95a41b3 boot: bootutil: loader: Let image version comparison use build number
 - f7d8660e boot_serial: Fix include paths for zephyr builds
 - c7835371 bootutil: Add FIH for ED25519 sig verification
 - 186ac885 bootutil: Fix FIH return type for EC256
 - 5397c13d zephyr: serial_recovery: Fix broken CDC device selection
 - 918da26a bootutil: Provide boot_set_next function

(cherry picked from commit af2576a127c27e3a715605be53339c3cadca5243)
Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>