### PR TITLE
[nrf noup] cmake: west: Use unix-style path for west on windows

### DIFF
--- a/cmake/modules/west.cmake
+++ b/cmake/modules/west.cmake
@@ -106,3 +106,9 @@ else()
     set(WEST WEST-NOTFOUND CACHE INTERNAL "West")
   endif()
 endif()
+
+if(DEFINED WEST_PYTHON AND WIN32)
+  # Replace windows back-slashes in path with forward-slashes to prevent issues
+  # with the back-slashes being wrongly interpreted as escape sequence codes.
+  file(TO_CMAKE_PATH "${WEST_PYTHON}" WEST_PYTHON)
+endif()


### PR DESCRIPTION
Fixes an issue whereby the back-slashes in the WEST_PYTHON variable were wrongly treated as escape sequence codes.