### PR TITLE
[nrf fromtree] twister: Bring back scope selection rule using platfor…

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -685,10 +685,8 @@ class TestPlan:
                 b = set(filter(lambda item: item.name in ts.platform_allow, self.platforms))
                 c = a.intersection(b)
                 if not c:
-                    _platform_scope = list(filter(lambda item: item.name in ts.platform_allow, \
+                    platform_scope = list(filter(lambda item: item.name in ts.platform_allow, \
                                              self.platforms))
-                    if len(_platform_scope) > 0:
-                        platform_scope = _platform_scope[:1]
 
 
             # list of instances per testsuite, aka configurations.


### PR DESCRIPTION
…m_allow

A change to the scope selection rules was introduced by #52715 but it doesn't comply with the description in the code. What's more, the change introduces major issues i.e. non deterministic scope selection, especially in a CI environment. More context at #57595

(cherry picked from commit 3bf7f83f213f96daa9a17cd3ddd4cff0a200bb9d)
Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>