### PR TITLE
mcumgr: img_mgmt: Fix using direct-xip mode in the NCS and friends

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -94,6 +94,13 @@ config MCUMGR_GRP_IMG_FRUGAL_LIST
 	  a device but requires support in client software, which has to default omitted values.
 	  Works correctly with mcumgr-cli.
 
+config MCUMGR_GRP_IMG_VERSION_CMP_USE_BUILD_NUMBER
+	bool "Use build number while comparing image version"
+	help
+	  By default, the image version comparison relies only on version major,
+	  minor and revision. Enable this option to take into account the build
+	  number as well.
+
 config MCUMGR_GRP_IMG_UPLOAD_CHECK_HOOK
 	bool "Upload check hook"
 	depends on MCUMGR_MGMT_NOTIFICATION_HOOKS

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -34,14 +34,34 @@
 #include <zephyr/mgmt/mcumgr/mgmt/callbacks.h>
 #endif
 
+#if USE_PARTITION_MANAGER
+#include <flash_map_pm.h>
+
+#ifdef PM_MCUBOOT_SECONDARY_PAD_SIZE
+BUILD_ASSERT(PM_MCUBOOT_PAD_SIZE == PM_MCUBOOT_SECONDARY_PAD_SIZE);
+#endif
+
+#if CONFIG_BUILD_WITH_TFM
+  #define PM_ADDRESS_OFFSET (PM_MCUBOOT_PAD_SIZE + PM_TFM_SIZE)
+#else
+  #define PM_ADDRESS_OFFSET (PM_MCUBOOT_PAD_SIZE)
+#endif
+
+#define FIXED_PARTITION_IS_CHOSEN_CODE_PARTITION(label)	\
+	(FIXED_PARTITION_OFFSET(label) == (PM_ADDRESS - PM_ADDRESS_OFFSET))
+
+#else /* ! USE_PARTITION_MANAGER */
+
 #define FIXED_PARTITION_IS_CHOSEN_CODE_PARTITION(label)	\
 	DT_SAME_NODE(DT_NODELABEL(label), DT_CHOSEN(zephyr_code_partition))
+
+#endif /* USE_PARTITION_MANAGER */
 
 #if !(FIXED_PARTITION_IS_CHOSEN_CODE_PARTITION(slot0_partition) ||	\
         FIXED_PARTITION_IS_CHOSEN_CODE_PARTITION(slot0_ns_partition) || \
 	FIXED_PARTITION_IS_CHOSEN_CODE_PARTITION(slot1_partition) ||	\
 	FIXED_PARTITION_IS_CHOSEN_CODE_PARTITION(slot2_partition))
-#error "Unsupported chosen zephyr,code-partition for boot application."
+#error "Unsupported chosen code partition for boot application."
 #endif
 
 LOG_MODULE_REGISTER(mcumgr_img_grp, CONFIG_MCUMGR_GRP_IMG_LOG_LEVEL);

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -278,7 +278,13 @@ img_mgmt_vercmp(const struct image_version *a, const struct image_version *b)
 		return 1;
 	}
 
-	/* Note: For semver compatibility, don't compare the 32-bit build num. */
+#if defined(CONFIG_MCUMGR_GRP_IMG_VERSION_CMP_USE_BUILD_NUMBER)
+	if (a->iv_build_num < b->iv_build_num) {
+		return -1;
+	} else if (a->iv_build_num > b->iv_build_num) {
+		return 1;
+	}
+#endif
 
 	return 0;
 }

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -646,7 +646,7 @@ img_mgmt_upload_inspect(const struct img_mgmt_upload_req *req,
 
 
 		if (req->upgrade) {
-			/* User specified upgrade-only.  Make sure new image version is
+			/* User specified upgrade-only. Make sure new image version is
 			 * greater than that of the currently running image.
 			 */
 			rc = img_mgmt_my_version(&cur_ver);
@@ -654,7 +654,7 @@ img_mgmt_upload_inspect(const struct img_mgmt_upload_req *req,
 				return MGMT_ERR_EUNKNOWN;
 			}
 
-			if (img_mgmt_vercmp(&cur_ver, &hdr->ih_ver) > 0) {
+			if (img_mgmt_vercmp(&cur_ver, &hdr->ih_ver) >= 0) {
 				IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action,
 					img_mgmt_err_str_downgrade);
 				return MGMT_ERR_EBADSTATE;


### PR DESCRIPTION
Fix check for chosen code partition in direct-xip mode and improve image version comparison.