### PR TITLE
subsys: bluetooth: host: Fix dangling reference in service changed

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3192,11 +3192,11 @@ static void sc_restore_rsp(struct bt_conn *conn,
 }
 
 static struct bt_gatt_indicate_params sc_restore_params[CONFIG_BT_MAX_CONN];
+static uint16_t sc_range[2];
 
 static void sc_restore(struct bt_conn *conn)
 {
 	struct gatt_sc_cfg *cfg;
-	uint16_t sc_range[2];
 	uint8_t index;
 
 	cfg = find_sc_cfg(conn->id, &conn->le.dst);


### PR DESCRIPTION
The bt_gatt_indicate() expects its parameters to remain valid while the indicate procedure is active. But the `sc_range` variable was local to the function. It is assigned to the `data` field and passed on to bt_gatt_indicate(). The memory associated with `sc_range` goes out of scope as soon as the function returns thereby breaking the contract of the API. This dangling reference will lead to undefined behavior. This is now fixed by making the `sc_range` array a file global variable.

Found as violation of MISRA C:2012 and CERT DCL30-C by sonarcloud.