### PR TITLE
Share MCUboot mode to app and use it in MCUmgr for basic DirectXIP support

### DIFF
--- a/Kconfig.mcuboot
+++ b/Kconfig.mcuboot
@@ -1,0 +1,130 @@
+# General configuration options
+
+# Copyright (c) 2014-2015 Wind River Systems, Inc.
+# Copyright (c) 2016 Intel Corporation
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config MCUBOOT
+	bool
+	help
+	  Hidden option used to indicate that the current image is MCUBoot
+
+config BOOTLOADER_MCUBOOT
+	bool "MCUboot bootloader support"
+	select USE_DT_CODE_PARTITION
+	imply INIT_ARCH_HW_AT_BOOT if ARCH_SUPPORTS_ARCH_HW_INIT
+	depends on !MCUBOOT
+	help
+	  This option signifies that the target uses MCUboot as a bootloader,
+	  or in other words that the image is to be chain-loaded by MCUboot.
+	  This sets several required build system and Device Tree options in
+	  order for the image generated to be bootable using the MCUboot open
+	  source bootloader. Currently this includes:
+
+	    * Setting ROM_START_OFFSET to a default value that allows space
+	      for the MCUboot image header
+	    * Activating SW_VECTOR_RELAY_CLIENT on Cortex-M0
+	      (or Armv8-M baseline) targets with no built-in vector relocation
+	      mechanisms
+
+	  By default, this option instructs Zephyr to initialize the core
+	  architecture HW registers during boot, when this is supported by
+	  the application. This removes the need by MCUboot to reset
+	  the core registers' state itself.
+
+if BOOTLOADER_MCUBOOT
+
+config MCUBOOT_CMAKE_WEST_SIGN_PARAMS
+	string "Extra parameters to west sign"
+	default "--quiet"
+	help
+	  Parameters that are passed by cmake to west sign, just after
+	  the command, before all other parameters needed for image
+	  signing.
+	  By default this is set to "--quiet" to prevent extra, non-error,
+	  diagnostic messages from west sign. This does not affect signing
+	  tool for which extra parameters are passed with
+	  MCUBOOT_EXTRA_IMGTOOL_ARGS.
+
+config MCUBOOT_SIGNATURE_KEY_FILE
+	string "Path to the mcuboot signing key file"
+	default ""
+	depends on !MCUBOOT_GENERATE_UNSIGNED_IMAGE
+	help
+	  The file contains a key pair whose public half is verified
+	  by your target's MCUboot image. The file is in PEM format.
+
+	  If set to a non-empty value, the build system tries to
+	  sign the final binaries using a 'west sign -t imgtool' command.
+	  The signed binaries are placed in the build directory
+	  at zephyr/zephyr.signed.bin and zephyr/zephyr.signed.hex.
+
+	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
+	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
+	  and CONFIG_BUILD_OUTPUT_HEX.
+
+	  This option should contain a path to the same file as the
+	  BOOT_SIGNATURE_KEY_FILE option in your MCUboot .config. The path
+	  may be absolute or relative to the west workspace topdir. (The MCUboot
+	  config option is used for the MCUboot bootloader image; this option is
+	  for your application which is to be loaded by MCUboot. The MCUboot
+	  config option can be a relative path from the MCUboot repository
+	  root.)
+
+	  If left empty, you must sign the Zephyr binaries manually.
+
+config MCUBOOT_ENCRYPTION_KEY_FILE
+	string "Path to the mcuboot encryption key file"
+	default ""
+	depends on MCUBOOT_SIGNATURE_KEY_FILE != ""
+	help
+	  The file contains the public key that is used to encrypt the
+	  ephemeral key that encrypts the image. The corresponding
+	  private key is hard coded in the MCUboot source code and is
+	  used to decrypt the ephemeral key that is embedded in the
+	  image. The file is in PEM format.
+
+	  If set to a non-empty value, the build system tries to
+	  sign and encrypt the final binaries using a 'west sign -t imgtool'
+	  command. The binaries are placed in the build directory at
+	  zephyr/zephyr.signed.encrypted.bin and
+	  zephyr/zephyr.signed.encrypted.hex.
+
+	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
+	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
+	  and CONFIG_BUILD_OUTPUT_HEX.
+
+	  This option should either be an absolute path or a path relative to
+	  the west workspace topdir.
+	  Example: './bootloader/mcuboot/enc-rsa2048-pub.pem'
+
+	  If left empty, you must encrypt the Zephyr binaries manually.
+
+config MCUBOOT_EXTRA_IMGTOOL_ARGS
+	string "Extra arguments to pass to imgtool when signing"
+	default ""
+	help
+	  When signing (CONFIG_MCUBOOT_SIGNATURE_KEY_FILE is a non-empty
+	  string) you can use this option to pass extra options to
+	  imgtool.  For example, you could set this to "--version 1.2".
+
+config MCUBOOT_GENERATE_UNSIGNED_IMAGE
+	bool "Generate unsigned binary image bootable with MCUboot"
+	help
+	  Enabling this configuration allows automatic unsigned binary image
+	  generation when MCUboot signing key is not provided,
+	  i.e., MCUBOOT_SIGNATURE_KEY_FILE is left empty.
+
+config MCUBOOT_GENERATE_CONFIRMED_IMAGE
+	bool "Also generate a padded, confirmed image"
+	help
+	  The signed, padded, and confirmed binaries are placed in the build
+	  directory at zephyr/zephyr.signed.confirmed.bin and
+	  zephyr/zephyr.signed.confirmed.hex.
+
+	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
+	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
+	  and CONFIG_BUILD_OUTPUT_HEX.
+
+endif # BOOTLOADER_MCUBOOT

--- a/Kconfig.mcuboot
+++ b/Kconfig.mcuboot
@@ -127,4 +127,46 @@ config MCUBOOT_GENERATE_CONFIRMED_IMAGE
 	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
 	  and CONFIG_BUILD_OUTPUT_HEX.
 
+choice MCUBOOT_BOOTLOADER_MODE
+	prompt "Application assumed MCUboot mode of operation"
+	default MCUBOOT_BOOTLOADER_MODE_SWAP_WITHOUT_SCRATCH # MCUBOOT_BOOTLOADER_MODE
+	help
+	  Informs application build on assumed MCUboot mode of operation.
+	  This is important for validataing application against DT configuration,
+	  which is done by west sign.
+
+config MCUBOOT_BOOTLOADER_MODE_SINGLE_APP
+	bool "MCUboot has been configured for single slot execution"
+	help
+	  MCUboot will only boot slot0_partition placed application and does
+	  not care about other slots. In this mode application is not able
+	  to DFU its own update to secondary slot and all updates need to
+	  be performed using MCUboot serial recovery.
+
+config MCUBOOT_BOOTLOADER_MODE_SWAP_WITHOUT_SCRATCH
+	bool "MCUboot has been configured for swap without scratch operation"
+	help
+	  MCUboot expects slot0_partition and slot1_partition to be present
+	  in DT and application will boot from slot0_partition.
+
+config MCUBOOT_BOOTLOADER_MODE_SWAP_SCRATCH
+	bool "MCUboot has been configured for swap using scratch operation"
+	help
+	  MCUboot expects slot0_partition, slot1_partition and scratch_partition
+	  to be present in DT, and application will boot from slot0_partition.
+	  In this mode scratch_partition is used as temporary storage when
+	  MCUboot swaps application from the secondary slot to the primary
+	  slot.
+
+config MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+	bool "MCUboot has been configured for DirectXIP operation"
+	help
+	  MCUboot expects slot0_partition and slot1_partition to exist in DT.
+	  In this mode MCUboot can boot from either partition and will
+	  select one with higher application image version, which usually
+	  means major.minor.patch triple, unless BOOT_VERSION_CMP_USE_BUILD_NUMBER
+	  is also selected that enables comparison of build number.
+
+endchoice # MCUBOOT_BOOTLOADER_MODE
+
 endif # BOOTLOADER_MCUBOOT

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -2,6 +2,7 @@
 
 # Copyright (c) 2014-2015 Wind River Systems, Inc.
 # Copyright (c) 2016 Intel Corporation
+# Copyright (c) 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 
@@ -783,129 +784,7 @@ config BOOTLOADER_SRAM_SIZE
 	  - Zephyr is a !XIP image, which implicitly assumes existence of a
 	  bootloader that loads the Zephyr !XIP image onto SRAM.
 
-config MCUBOOT
-	bool
-	help
-	  Hidden option used to indicate that the current image is MCUBoot
-
-config BOOTLOADER_MCUBOOT
-	bool "MCUboot bootloader support"
-	select USE_DT_CODE_PARTITION
-	imply INIT_ARCH_HW_AT_BOOT if ARCH_SUPPORTS_ARCH_HW_INIT
-	depends on !MCUBOOT
-	help
-	  This option signifies that the target uses MCUboot as a bootloader,
-	  or in other words that the image is to be chain-loaded by MCUboot.
-	  This sets several required build system and Device Tree options in
-	  order for the image generated to be bootable using the MCUboot open
-	  source bootloader. Currently this includes:
-
-	    * Setting ROM_START_OFFSET to a default value that allows space
-	      for the MCUboot image header
-	    * Activating SW_VECTOR_RELAY_CLIENT on Cortex-M0
-	      (or Armv8-M baseline) targets with no built-in vector relocation
-	      mechanisms
-
-	  By default, this option instructs Zephyr to initialize the core
-	  architecture HW registers during boot, when this is supported by
-	  the application. This removes the need by MCUboot to reset
-	  the core registers' state itself.
-
-if BOOTLOADER_MCUBOOT
-
-config MCUBOOT_CMAKE_WEST_SIGN_PARAMS
-	string "Extra parameters to west sign"
-	default "--quiet"
-	help
-	  Parameters that are passed by cmake to west sign, just after
-	  the command, before all other parameters needed for image
-	  signing.
-	  By default this is set to "--quiet" to prevent extra, non-error,
-	  diagnostic messages from west sign. This does not affect signing
-	  tool for which extra parameters are passed with
-	  MCUBOOT_EXTRA_IMGTOOL_ARGS.
-
-config MCUBOOT_SIGNATURE_KEY_FILE
-	string "Path to the mcuboot signing key file"
-	default ""
-	depends on !MCUBOOT_GENERATE_UNSIGNED_IMAGE
-	help
-	  The file contains a key pair whose public half is verified
-	  by your target's MCUboot image. The file is in PEM format.
-
-	  If set to a non-empty value, the build system tries to
-	  sign the final binaries using a 'west sign -t imgtool' command.
-	  The signed binaries are placed in the build directory
-	  at zephyr/zephyr.signed.bin and zephyr/zephyr.signed.hex.
-
-	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
-	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
-	  and CONFIG_BUILD_OUTPUT_HEX.
-
-	  This option should contain a path to the same file as the
-	  BOOT_SIGNATURE_KEY_FILE option in your MCUboot .config. The path
-	  may be absolute or relative to the west workspace topdir. (The MCUboot
-	  config option is used for the MCUboot bootloader image; this option is
-	  for your application which is to be loaded by MCUboot. The MCUboot
-	  config option can be a relative path from the MCUboot repository
-	  root.)
-
-	  If left empty, you must sign the Zephyr binaries manually.
-
-config MCUBOOT_ENCRYPTION_KEY_FILE
-	string "Path to the mcuboot encryption key file"
-	default ""
-	depends on MCUBOOT_SIGNATURE_KEY_FILE != ""
-	help
-	  The file contains the public key that is used to encrypt the
-	  ephemeral key that encrypts the image. The corresponding
-	  private key is hard coded in the MCUboot source code and is
-	  used to decrypt the ephemeral key that is embedded in the
-	  image. The file is in PEM format.
-
-	  If set to a non-empty value, the build system tries to
-	  sign and encrypt the final binaries using a 'west sign -t imgtool'
-	  command. The binaries are placed in the build directory at
-	  zephyr/zephyr.signed.encrypted.bin and
-	  zephyr/zephyr.signed.encrypted.hex.
-
-	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
-	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
-	  and CONFIG_BUILD_OUTPUT_HEX.
-
-	  This option should either be an absolute path or a path relative to
-	  the west workspace topdir.
-	  Example: './bootloader/mcuboot/enc-rsa2048-pub.pem'
-
-	  If left empty, you must encrypt the Zephyr binaries manually.
-
-config MCUBOOT_EXTRA_IMGTOOL_ARGS
-	string "Extra arguments to pass to imgtool when signing"
-	default ""
-	help
-	  When signing (CONFIG_MCUBOOT_SIGNATURE_KEY_FILE is a non-empty
-	  string) you can use this option to pass extra options to
-	  imgtool.  For example, you could set this to "--version 1.2".
-
-config MCUBOOT_GENERATE_UNSIGNED_IMAGE
-	bool "Generate unsigned binary image bootable with MCUboot"
-	help
-	  Enabling this configuration allows automatic unsigned binary image
-	  generation when MCUboot signing key is not provided,
-	  i.e., MCUBOOT_SIGNATURE_KEY_FILE is left empty.
-
-config MCUBOOT_GENERATE_CONFIRMED_IMAGE
-	bool "Also generate a padded, confirmed image"
-	help
-	  The signed, padded, and confirmed binaries are placed in the build
-	  directory at zephyr/zephyr.signed.confirmed.bin and
-	  zephyr/zephyr.signed.confirmed.hex.
-
-	  The file names can be customized with CONFIG_KERNEL_BIN_NAME.
-	  The existence of bin and hex files depends on CONFIG_BUILD_OUTPUT_BIN
-	  and CONFIG_BUILD_OUTPUT_HEX.
-
-endif # BOOTLOADER_MCUBOOT
+source "Kconfig.mcuboot"
 
 config BOOTLOADER_ESP_IDF
 	bool "ESP-IDF bootloader support"

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -16,6 +16,7 @@ menuconfig MCUMGR_GRP_IMG
 	bool "Mcumgr handlers for image management"
 	depends on FLASH
 	depends on IMG_MANAGER
+	depends on !MCUBOOT_BOOTLOADER_MODE_SINGLE_APP
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
 	help

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -701,7 +701,11 @@ img_mgmt_my_version(struct image_version *ver)
 static const struct mgmt_handler img_mgmt_handlers[] = {
 	[IMG_MGMT_ID_STATE] = {
 		.mh_read = img_mgmt_state_read,
+#ifdef CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+		.mh_write = NULL
+#else
 		.mh_write = img_mgmt_state_write,
+#endif
 	},
 	[IMG_MGMT_ID_UPLOAD] = {
 		.mh_read = NULL,

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -124,13 +124,18 @@ img_mgmt_state_any_pending(void)
 int
 img_mgmt_slot_in_use(int slot)
 {
-	uint8_t state_flags;
 	int active_slot = img_mgmt_active_slot(img_mgmt_active_image());
 
-	state_flags = img_mgmt_state_flags(slot);
-	return slot == active_slot				||
-		   state_flags & IMG_MGMT_STATE_F_CONFIRMED	||
-		   state_flags & IMG_MGMT_STATE_F_PENDING;
+#ifndef CONFIG_MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+	uint8_t state_flags = img_mgmt_state_flags(slot);
+
+	if (state_flags & IMG_MGMT_STATE_F_CONFIRMED ||
+	    state_flags & IMG_MGMT_STATE_F_PENDING) {
+		return 1;
+	}
+#endif
+
+	return (active_slot == slot);
 }
 
 /**


### PR DESCRIPTION
Five commits:
    1) Separating MCUboot options to Kconfig.mcuboot
    2) introducing Kconfig options that allow to inform application regarding MCUboot mode the application will be boot with;
    3) disabling MCUmgr image management when MCUboot has been configured for single application mode;
    4) disabling setting of image state, to confirm or test, when MCUboot has been configured for DirectXIP
    5) commit form additional PR (https://github.com/zephyrproject-rtos/zephyr/pull/57794) that corrects image list for DirectXIP


