### PR TITLE
[nrf fromlist] wifi: thingy53: Update dts and dtsi files to support n…

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common-pinctrl.dtsi
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common-pinctrl.dtsi
@@ -108,4 +108,22 @@
 		};
 	};
 
+	spi4_default: spi4_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 9)>,
+				<NRF_PSEL(SPIM_MISO, 0, 10)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
+		};
+	};
+
+	spi4_sleep: spi4_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 5)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 9)>,
+				<NRF_PSEL(SPIM_MISO, 0, 10)>;
+			low-power-enable;
+		};
+	};
+
 };

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -64,6 +64,20 @@
 		};
 	};
 
+	edge_connector: connector {
+		compatible = "nordic,thingy53-edge-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <8 0 &gpio0 5 0>,	/* P8, P0.05/AIN1 */
+			   <9 0 &gpio0 4 0>,	/* P9, P0.04/AIN0 */
+			   <15 0 &gpio0 8 0>,	/* P15, P0.08/TRACEDATA3 */
+			   <16 0 &gpio0 9 0>,	/* P16, P0.09/TRACEDATA2 */
+			   <17 0 &gpio0 10 0>,	/* P17, P0.10/TRACEDATA1 */
+			   <18 0 &gpio0 11 0>,	/* P18, P0.11/TRACEDATA0 */
+			   <19 0 &gpio0 12 0>;	/* P19, P0.12/TRACECLK */
+	};
+
 	npm1100_force_pwm_mode: npm1100_force_pwm_mode {
 		compatible = "regulator-fixed";
 		regulator-name = "npm1100_force_pwm_mode";
@@ -248,6 +262,15 @@
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <35000>;
 	};
+};
+
+edge_connector_spi: &spi4 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	cs-gpios = <&edge_connector 18 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&spi4_default>;
+	pinctrl-1 = <&spi4_sleep>;
+	pinctrl-names = "default", "sleep";
 };
 
 &flash0 {

--- a/dts/bindings/gpio/nordic,thingy53-edge-connector.yaml
+++ b/dts/bindings/gpio/nordic,thingy53-edge-connector.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2023 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  This binding provides a nexus mapping for 20 pins (HW rev 1.1.0) as depicted below
+        P1   VLi-Ion
+        P2   VBat
+        P3   VOUTB
+        P4   VDD_nRF53
+        P5   P1.01/GRANT
+        P6   P1.00/REQ
+        P7   RESET
+        P8   P0.05/AIN1
+        P9   P0.04/AIN0
+        P10  LOAD_SW_DISABLE
+        P11  VOUTB_2
+        P12  VDD_nRF21540
+        P13  VDD_EXP_BRD
+        P14  3V3
+        P15  P0.08/TRACEDATA3
+        P16  P0.09/TRACEDATA2
+        P17  P0.10/TRACEDATA1
+        P18  P0.11/TRACEDATA0
+        P19  P0.12/TRACECLK
+        P20  GND
+
+compatible: "nordic,thingy53-edge-connector"
+
+include: [gpio-nexus.yaml, base.yaml]


### PR DESCRIPTION
…rf7002 eval board

- Add SPI4 pin definitions to the dtsi files
- Add edge connector node for nrf7002 eval board

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/57636