### PR TITLE
mgmt: mcumgr: Supress false error log output

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -255,6 +255,11 @@ img_mgmt_state_read(struct smp_streamer *ctxt)
 	     zcbor_list_start_encode(zse, 2 * CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER);
 
 	for (i = 0; ok && i < 2 * CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER; i++) {
+		/* Slot 2 mcuboot_primary_1 only exists when ram_flash is enabled*/
+		if (i == 2 && !IS_ENABLED(CONFIG_FLASH_SIMULATOR)) {
+			continue;
+		}
+
 		int rc = img_mgmt_read_info(i, &ver, hash, &flags);
 		if (rc != 0) {
 			continue;

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c
@@ -709,7 +709,7 @@ img_mgmt_erased_val(int slot, uint8_t *erased_val)
 
 	rc = flash_area_open(area_id, &fa);
 	if (rc != 0) {
-		LOG_ERR("Failed to open flash area ID %u: %d", area_id, rc);
+		LOG_WRN("Failed to open flash area ID %u: %d", area_id, rc);
 		return MGMT_ERR_EUNKNOWN;
 	}
 


### PR DESCRIPTION
img_mgmt_state_read try to open mcuboot_primary_1 (ram_flash partition) without checking whether it exists or not in application.
We don't enable CONFIG_FLASH_SIMULATOR in application in order to save ram usage.

This commit introduces error log output.
nrfconnect/sdk-zephyr@df0fa6d

Generally it would failed when [opening slot2 partition](https://github.com/nrfconnect/sdk-zephyr/blob/main/subsys/mgmt/mcumgr/grp/img_mgmt/src/zephyr_img_mgmt.c#L712) which makes CI failed when test DFU.
This error message could be founded on thingy53 and nrf5340 when https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/working_with_nrf/nrf53/nrf5340.html#simultaneous-multi-image-dfu feature is used.
![2023_05_15_mcumgr_img_grp_failed_to_open_slot2](https://github.com/nrfconnect/sdk-zephyr/assets/1169294/85bdb4e7-9664-4ede-a480-77c46323cb45)

We have two options.
1. Skipped opening slot 2 image when CONFIG_FLASH_SIMULATOR is not enabled.
2. Change `img_mgmt_erased_val` error to warning message.


