### PR TITLE
[nrf noup] net: Increase connection manager stack size

### DIFF
--- a/subsys/net/conn_mgr/Kconfig
+++ b/subsys/net/conn_mgr/Kconfig
@@ -24,6 +24,7 @@ source "subsys/net/Kconfig.template.log_config.net"
 
 config NET_CONNECTION_MANAGER_STACK_SIZE
 	int "Size of the stack allocated for the connection manager"
+	default 8192 if WPA_SUPP
 	default 512
 	help
 	  Sets the stack size which will be used by the connection manager


### PR DESCRIPTION
Connection manager L2 Wi-Fi calls internally invoke WPA supplicant calls which requires higher stack size. Update the default stack size for such cases.
Marking this "nrf noup" since supplicant is not upstream yet.