### PR TITLE
[nrf noup] modules: mbedtls: Update PSA naming and fix dependencies

### DIFF
--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -5,6 +5,7 @@
 
 config ZEPHYR_MBEDTLS_MODULE
 	bool
+
 config MBEDTLS_PROMPTLESS
 	bool
 	help

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -9,19 +9,25 @@ config PSA_WANT_GENERATE_RANDOM
 	bool
 	prompt "PSA RNG support"
 	default y
+	help
+	  Provide random number generator (RNG) support.
 
 config PSA_WANT_ALG_CTR_DRBG
 	bool
-	prompt "PSA RNG using CTR_DRBG"
+	prompt "PSA RNG using CTR-DRBG as PRNG"
 	help
-	  Provide CTR_DRBG as the random number generator.
+	  Provide random number generator (RNG) using CTR-DRBG as the
+	  pseudo-random number generator (PRNG), seeded by a true random
+	  number generator (TRNG).
 	  Note: This configuration is currently not described and has no effect.
 
 config PSA_WANT_ALG_HMAC_DRBG
 	bool
-	prompt "PSA RNG using HMAC_DRBG"
+	prompt "PSA RNG using HMAC-DRBG as PRNG"
 	help
-	  Provide HMAC_DRBG as the random number generator.
+	  Provide random number generator (RNG) using HMAC-DRBG as the
+	  pseudo-random number generator (PRNG), seeded by a true random
+	  number generator (TRNG).
 	  Note: This configuration is currently not described and has no effect.
 
 endmenu # RNG support

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -248,8 +248,7 @@ config PSA_WANT_ALG_OFB
 
 config PSA_WANT_ALG_XTS
 	bool
-	help
-	  PSA XTS is currently not supported
+	prompt "PSA XTS mode support" if !PSA_PROMPTLESS
 
 endmenu # PSA Cipher Support
 

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -19,7 +19,6 @@ config PSA_WANT_ALG_CTR_DRBG
 	  Provide random number generator (RNG) using CTR-DRBG as the
 	  pseudo-random number generator (PRNG), seeded by a true random
 	  number generator (TRNG).
-	  Note: This configuration is currently not described and has no effect.
 
 config PSA_WANT_ALG_HMAC_DRBG
 	bool
@@ -28,7 +27,6 @@ config PSA_WANT_ALG_HMAC_DRBG
 	  Provide random number generator (RNG) using HMAC-DRBG as the
 	  pseudo-random number generator (PRNG), seeded by a true random
 	  number generator (TRNG).
-	  Note: This configuration is currently not described and has no effect.
 
 endmenu # RNG support
 

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -197,7 +197,7 @@ config PSA_WANT_ALG_SHA_224
 
 config PSA_WANT_ALG_SHA_256
 	bool
-	prompt "PSA SSH-256 support" if !PSA_PROMPTLESS
+	prompt "PSA SHA-256 support" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 
 config PSA_WANT_ALG_SHA_384

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -73,7 +73,8 @@ config PSA_WANT_KEY_TYPE_AES
 config PSA_WANT_KEY_TYPE_CHACHA20
 	bool
 	default y
-	depends on PSA_WANT_ALG_CHACHA20_POLY1305
+	depends on PSA_WANT_ALG_CHACHA20_POLY1305 || \
+		   PSA_WANT_ALG_STREAM_CIPHER
 	help
 	  Prompt-less configuration that states that CHACHA20 key type is used.
 

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -107,12 +107,12 @@ config PSA_HAS_AEAD_SUPPORT
 
 config PSA_WANT_ALG_CCM
 	bool
-	prompt "PSA AES CCM support" if !PSA_PROMPTLESS
+	prompt "PSA CCM support" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 
 config PSA_WANT_ALG_GCM
 	bool
-	prompt "PSA AES GCM support" if !PSA_PROMPTLESS
+	prompt "PSA GCM support" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 
 config PSA_WANT_ALG_CHACHA20_POLY1305
@@ -141,7 +141,7 @@ config PSA_WANT_ALG_CBC_MAC
 
 config PSA_WANT_ALG_CMAC
 	bool
-	prompt "PSA AES CMAC support" if !PSA_PROMPTLESS
+	prompt "PSA CMAC support" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 
 config PSA_WANT_ALG_HMAC
@@ -220,7 +220,7 @@ config PSA_HAS_CIPHER_SUPPORT
 
 config PSA_WANT_ALG_ECB_NO_PADDING
 	bool
-	prompt "PSA AES ECB (no padding)" if !PSA_PROMPTLESS
+	prompt "PSA ECB (no padding)" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 
 config PSA_WANT_ALG_CBC_NO_PADDING
@@ -235,21 +235,21 @@ config PSA_WANT_ALG_CBC_PKCS7
 
 config PSA_WANT_ALG_CFB
 	bool
-	prompt "PSA AES CFB support" if !PSA_PROMPTLESS
+	prompt "PSA CFB support" if !PSA_PROMPTLESS
 
 config PSA_WANT_ALG_CTR
 	bool
-	prompt "PSA AES CTR mode support" if !PSA_PROMPTLESS
+	prompt "PSA CTR mode support" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 
 config PSA_WANT_ALG_OFB
 	bool
-	prompt "PSA AES OFB mode support" if !PSA_PROMPTLESS
+	prompt "PSA OFB mode support" if !PSA_PROMPTLESS
 
 config PSA_WANT_ALG_XTS
 	bool
 	help
-	  AES XTS is currently not supported
+	  PSA XTS is currently not supported
 
 endmenu # PSA Cipher Support
 

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -117,7 +117,7 @@ config PSA_WANT_ALG_GCM
 
 config PSA_WANT_ALG_CHACHA20_POLY1305
 	bool
-	prompt "PSA ChaCha20/Poly1305 support" if !PSA_PROMPTLESS
+	prompt "PSA ChaCha20-Poly1305 support" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 
 endmenu # PSA AEAD support

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -55,7 +55,18 @@ config PSA_WANT_KEY_TYPE_HMAC
 config PSA_WANT_KEY_TYPE_AES
 	bool
 	default y
-	depends on PSA_HAS_CIPHER_SUPPORT || PSA_HAS_AEAD_SUPPORT
+	depends on PSA_WANT_ALG_ECB_NO_PADDING	|| \
+		   PSA_WANT_ALG_CBC_NO_PADDING	|| \
+		   PSA_WANT_ALG_CBC_PKCS7	|| \
+		   PSA_WANT_ALG_CFB 		|| \
+		   PSA_WANT_ALG_CTR		|| \
+		   PSA_WANT_ALG_OFB		|| \
+		   PSA_WANT_ALG_CTR		|| \
+		   PSA_WANT_ALG_XTS             || \
+		   PSA_WANT_ALG_CCM             || \
+		   PSA_WANT_ALG_GCM             || \
+		   PSA_WANT_ALG_CBC_MAC	        || \
+		   PSA_WANT_ALG_CMAC
 	help
 	  Prompt-less configuration that states that AES key type is used.
 

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -226,7 +226,8 @@ config PSA_HAS_CIPHER_SUPPORT
 		   PSA_WANT_ALG_CTR		|| \
 		   PSA_WANT_ALG_OFB		|| \
 		   PSA_WANT_ALG_CTR		|| \
-		   PSA_WANT_ALG_XTS
+		   PSA_WANT_ALG_XTS             || \
+		   PSA_WANT_ALG_STREAM_CIPHER
 	help
 	  Prompt-less configuration that states that cipher is supported.
 

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -220,35 +220,40 @@ config PSA_HAS_CIPHER_SUPPORT
 
 config PSA_WANT_ALG_ECB_NO_PADDING
 	bool
-	prompt "PSA ECB (no padding)" if !PSA_PROMPTLESS
+	prompt "PSA ECB block cipher mode support (with no padding)" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 
 config PSA_WANT_ALG_CBC_NO_PADDING
 	bool
-	prompt "PSA CBC support (without padding)" if !PSA_PROMPTLESS
+	prompt "PSA CBC block cipher mode support (with no padding)" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 
 config PSA_WANT_ALG_CBC_PKCS7
 	bool
-	prompt "PSA CBC support (padded with PKCS#7)" if !PSA_PROMPTLESS
+	prompt "PSA CBC block cipher mode support (with PKCS#7 padding)" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 
 config PSA_WANT_ALG_CFB
 	bool
-	prompt "PSA CFB support" if !PSA_PROMPTLESS
+	prompt "PSA stream cipher using CFB block cipher mode support" if !PSA_PROMPTLESS
 
 config PSA_WANT_ALG_CTR
 	bool
-	prompt "PSA CTR mode support" if !PSA_PROMPTLESS
+	prompt "PSA stream cipher using CTR block cipher mode support" if !PSA_PROMPTLESS
 	default y if !PSA_DEFAULT_OFF
 
 config PSA_WANT_ALG_OFB
 	bool
-	prompt "PSA OFB mode support" if !PSA_PROMPTLESS
+	prompt "PSA stream cipher using OFB block cipher mode support" if !PSA_PROMPTLESS
 
 config PSA_WANT_ALG_XTS
 	bool
-	prompt "PSA XTS mode support" if !PSA_PROMPTLESS
+	prompt "PSA XTS block cipher mode support" if !PSA_PROMPTLESS
+
+config PSA_WANT_ALG_STREAM_CIPHER
+	bool
+	prompt "PSA stream cipher support" if !PSA_PROMPTLESS
+	default y if !PSA_DEFAULT_OFF
 
 endmenu # PSA Cipher Support
 
@@ -424,11 +429,6 @@ config PSA_WANT_ALG_RSA_PSS
 	prompt "PSA RSA (PSS mode)" if !PSA_PROMPTLESS
 
 endmenu # PSA Asymmetric support
-
-config PSA_WANT_ALG_STREAM_CIPHER
-	bool
-	prompt "PSA stream cipher support" if !PSA_PROMPTLESS
-	default y if !PSA_DEFAULT_OFF
 
 config PSA_WANT_ALG_JPAKE
 	bool

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -414,11 +414,11 @@ config PSA_WANT_ALG_RSA_OAEP
 
 config PSA_WANT_ALG_RSA_PKCS1V15_CRYPT
 	bool
-	prompt "PSA RSA crypt support (PKCS1V15 mode)" if !PSA_PROMPTLESS
+	prompt "PSA RSA crypt support (PKCS#1 v1.5 mode)" if !PSA_PROMPTLESS
 
 config PSA_WANT_ALG_RSA_PKCS1V15_SIGN
 	bool
-	prompt "PSA RSA signature support (PKCS1V15 mode)" if !PSA_PROMPTLESS
+	prompt "PSA RSA signature support (PKCS#1 v1.5 mode)" if !PSA_PROMPTLESS
 
 config PSA_WANT_ALG_RSA_PSS
 	bool

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -323,7 +323,7 @@ config PSA_HAS_ASYM_ENCRYPT_SUPPORT
 	bool
 	default y
 	depends on PSA_WANT_ALG_RSA_OAEP || \
-			   PSA_WANT_ALG_RSA_PKCS1V15_CRYPT
+		   PSA_WANT_ALG_RSA_PKCS1V15_CRYPT
 	help
 	  Prompt-less configuration that states that asymmetric encryption
 	  is supported.
@@ -336,7 +336,6 @@ config PSA_HAS_ASYM_SIGN_SUPPORT
 		   PSA_WANT_ALG_ECDSA 			|| \
 		   PSA_WANT_ALG_RSA_PKCS1V15_SIGN	|| \
 		   PSA_WANT_ALG_RSA_PSS
-
 	help
 	  Prompt-less configuration that states that asymmetric signing
 	  is supported.

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -354,13 +354,13 @@ config PSA_WANT_ECC_BRAINPOOL_P_R1_512
 	bool "PSA ECC Brainpool512r1 support"
 
 config PSA_WANT_ECC_MONTGOMERY_255
-	bool "PSA ECC Curve X25519 support"
+	bool "PSA ECC Curve25519 (X25519) support"
 
 config PSA_WANT_ECC_MONTGOMERY_448
-	bool "PSA ECC Curve X448 support"
+	bool "PSA ECC Curve448 (X448) support"
 
 config PSA_WANT_ECC_TWISTED_EDWARDS_255
-	bool "PSA ECC Curve Ed25519 support"
+	bool "PSA ECC Edwards25519 (Ed25519) support"
 
 config PSA_WANT_ECC_SECP_K1_192
 	bool "PSA ECC secp192k1 support"


### PR DESCRIPTION
This PR addresses a mix of issues.

Using the same naming as the official PSA documentation for PSA algorithms.

Fixes missing missing dependency auto-enabling of PSA key types.

Fix missing dependency for cipher module with PSA stream cipher.

Various other small fixes, see commit messages.