### PR TITLE
[nrf fromlist] net: wifi: Fix typo in event

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -114,7 +114,6 @@ enum net_event_wifi_cmd {
 	NET_EVENT_WIFI_CMD_TWT,
 	NET_EVENT_WIFI_CMD_TWT_SLEEP_STATE,
 	NET_EVENT_WIFI_CMD_RAW_SCAN_RESULT,
-	NET_EVENT_WIFI_CMD_DISCONNECT_COMPLETE,
 };
 
 #define NET_EVENT_WIFI_SCAN_RESULT				\
@@ -140,9 +139,6 @@ enum net_event_wifi_cmd {
 
 #define NET_EVENT_WIFI_RAW_SCAN_RESULT                          \
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_RAW_SCAN_RESULT)
-
-#define NET_EVENT_WIFI_DISCONNECT_COMPLETE			\
-	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_DISCONNECT_COMPLETE)
 /* Each result is provided to the net_mgmt_event_callback
  * via its info attribute (see net_mgmt.h)
  */
@@ -348,7 +344,6 @@ void wifi_mgmt_raise_twt_sleep_state(struct net_if *iface, int twt_sleep_state);
 void wifi_mgmt_raise_raw_scan_result_event(struct net_if *iface,
 		struct wifi_raw_scan_result *raw_scan_info);
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
-void wifi_mgmt_raise_disconnect_complete_event(struct net_if *iface, int status);
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -114,6 +114,7 @@ enum net_event_wifi_cmd {
 	NET_EVENT_WIFI_CMD_TWT,
 	NET_EVENT_WIFI_CMD_TWT_SLEEP_STATE,
 	NET_EVENT_WIFI_CMD_RAW_SCAN_RESULT,
+	NET_EVENT_WIFI_CMD_DISCONNECT_COMPLETE,
 };
 
 #define NET_EVENT_WIFI_SCAN_RESULT				\
@@ -139,6 +140,9 @@ enum net_event_wifi_cmd {
 
 #define NET_EVENT_WIFI_RAW_SCAN_RESULT                          \
 	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_RAW_SCAN_RESULT)
+
+#define NET_EVENT_WIFI_DISCONNECT_COMPLETE			\
+	(_NET_WIFI_EVENT | NET_EVENT_WIFI_CMD_DISCONNECT_COMPLETE)
 /* Each result is provided to the net_mgmt_event_callback
  * via its info attribute (see net_mgmt.h)
  */
@@ -344,6 +348,7 @@ void wifi_mgmt_raise_twt_sleep_state(struct net_if *iface, int twt_sleep_state);
 void wifi_mgmt_raise_raw_scan_result_event(struct net_if *iface,
 		struct wifi_raw_scan_result *raw_scan_info);
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+void wifi_mgmt_raise_disconnect_complete_event(struct net_if *iface, int status);
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -401,15 +401,3 @@ void wifi_mgmt_raise_raw_scan_result_event(struct net_if *iface,
 					sizeof(*raw_scan_result));
 }
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
-
-void wifi_mgmt_raise_disconnect_complete_event(struct net_if *iface,
-					       int status)
-{
-	struct wifi_status cnx_status = {
-		.status = status,
-	};
-
-	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_CMD_DISCONNECT_COMPLETE,
-					iface, &cnx_status,
-					sizeof(struct wifi_status));
-}

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -409,7 +409,7 @@ void wifi_mgmt_raise_disconnect_complete_event(struct net_if *iface,
 		.status = status,
 	};
 
-	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_CMD_DISCONNECT_COMPLETE,
+	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_DISCONNECT_COMPLETE,
 					iface, &cnx_status,
 					sizeof(struct wifi_status));
 }

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -401,3 +401,15 @@ void wifi_mgmt_raise_raw_scan_result_event(struct net_if *iface,
 					sizeof(*raw_scan_result));
 }
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+
+void wifi_mgmt_raise_disconnect_complete_event(struct net_if *iface,
+					       int status)
+{
+	struct wifi_status cnx_status = {
+		.status = status,
+	};
+
+	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_CMD_DISCONNECT_COMPLETE,
+					iface, &cnx_status,
+					sizeof(struct wifi_status));
+}


### PR DESCRIPTION
Wrong macro was copied, this causes the event to fail.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/57943