### PR TITLE
[nrf fromtree] bluetooth: host: Fix NULL pointer dereference in bt_co…

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -3108,10 +3108,14 @@ int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb)
 #if defined(CONFIG_BT_SMP)
 int bt_conn_auth_cb_overlay(struct bt_conn *conn, const struct bt_conn_auth_cb *cb)
 {
+	CHECKIF(conn == NULL) {
+		return -EINVAL;
+	}
+
 	/* The cancel callback must always be provided if the app provides
 	 * interactive callbacks.
 	 */
-	if (!cb->cancel &&
+	if (cb && !cb->cancel &&
 	    (cb->passkey_display || cb->passkey_entry || cb->passkey_confirm ||
 	     cb->pairing_confirm)) {
 		return -EINVAL;


### PR DESCRIPTION
…nn_auth_cb_overlay

There is a check in bt_conn_auth_cb_overlay function which validates if content of the callback structure is correct, but there is no NULL-check on the structure pointer itself, which could result in NULL pointer dereference.

It should be possible to set the callback structure pointer to `NULL` using bt_conn_auth_cb_overlay function if the application requires ex. Just Works pairing for one Bluetooth identity and global callbacks are configured for advanced pairing scheme (like Passkey Display) for other Bluetooth identity.

Signed-off-by: Mateusz Kapala <mateusz.kapala@nordicsemi.no>
(cherry picked from commit 15bd8b256f933d322d29dce0505049be1331a5d7)