### PR TITLE
[nrf fromtree] net: openthread: Fix `OPENTHREAD_FTD` dependency.

### DIFF
--- a/modules/openthread/Kconfig.features
+++ b/modules/openthread/Kconfig.features
@@ -286,3 +286,4 @@ config OPENTHREAD_UDP_FORWARD
 
 config OPENTHREAD_UPTIME
 	bool "Openthread uptime counter"
+	default y if OPENTHREAD_FTD


### PR DESCRIPTION
Thic commit fixes `OPENTHREAD_FTD` dependency to `OPENTHREAD_UPTIME`.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>
(cherry picked from commit 499bf552fb14050946fee94836fdc815b30f7621)