### PR TITLE
Update bsim nRF HW models

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -197,7 +197,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: c8d2ecd25d6976d2d77eccf66878420fdb8ef5a1
+      revision: 37c571ef7c4a86dad852566fc43eb36f42534e9f
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: aedcc262f93bbb1b0c2f58026911575729b7465c

--- a/west.yml
+++ b/west.yml
@@ -197,7 +197,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: bad9877e997b2c2a78dd74eec8978181f4655d14
+      revision: c8d2ecd25d6976d2d77eccf66878420fdb8ef5a1
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: aedcc262f93bbb1b0c2f58026911575729b7465c


### PR DESCRIPTION
[[nrf fromlist] manifest: Update nRF HW models to latest](https://github.com/nrfconnect/sdk-zephyr/commit/e48fc94fc7d1bbf81e89d18968a44ffbb7397a2e)

The nRF HW models have been updated to include the following
fixes and improvements.

* PPI: add support for nrf_ppi_group_enable
* BLECrypt: Widen search for crypto library
* Makefile: Switch to gnu11 from c11 due to HAL
* NVMC: Minor fixes in command line options descriptions

Which enable more 15.4 functionality with the nrf driver

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/58745

-----------

[[nrf fromtree] manifest: nrf hw models: Use latest w flash](https://github.com/nrfconnect/sdk-zephyr/commit/3f6607c0a75b9a040814e47e5e9b2dfce7d5baf8)

Update to the latest NRF HW models which include
models of the NVMC and UICR peripherals,
as well as some other (very) minor fixes.

(cherry picked from commit https://github.com/nrfconnect/sdk-zephyr/commit/e7d658c91d19790f03d944b5f6a4581c1ea50522)