### PR TITLE
ieee802154 nrf5 callout timeouts

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -78,6 +78,17 @@ config IEEE802154_NRF5_DELAY_TRX_ACC
 	  Accuracy of the clock used for scheduling radio delayed operations (delayed transmission
 	  or delayed reception), in ppm.
 
+config IEEE802154_NRF5_CALLOUT_TIMEOUT_MS
+	int "Timeout in milliseconds of waiting for a callout that finishes a requested operation"
+	default 10000
+	help
+	  This parameter limits the maximum time that can pass between
+	  a request to the nRF 802.15.4 Radio Driver to the corresponding asynchronous callout
+	  notifying the result of the operation. Reaching this timeout is a fatal error
+	  of the nRF 802.15.4 Radio Driver thus rather big values are advised.
+	  Set this value to 0 to have no limit (equivalent to K_FOREVER) which turns off the
+	  timing-out feature.
+
 config IEEE802154_NRF5_LOG_RX_FAILURES
 	bool "Frame reception failures logging"
 	help

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -89,6 +89,17 @@ config IEEE802154_NRF5_CALLOUT_TIMEOUT_MS
 	  Set this value to 0 to have no limit (equivalent to K_FOREVER) which turns off the
 	  timing-out feature.
 
+config IEEE802154_NRF5_RX_THREAD_HEARTBEAT_PERIOD_MS
+	int "Period in milliseconds of polling nRF 802.15.4 Radio Driver to detect potential malfunctions"
+	default 60000 if NRF_802154_SER_HOST
+	default 0
+	help
+	  The nRF 802.15.4 Radio Driver is polled with period set by this parameter in order to
+	  detect any potential malfunctions of the driver. This option is useful when
+	  the radio driver implementation is provided by separate core through serialization.
+	  To keep energy usage low the value should be set to big values.
+	  Value equal to 0 turns off the polling completely.
+
 config IEEE802154_NRF5_LOG_RX_FAILURES
 	bool "Frame reception failures logging"
 	help

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -1242,6 +1242,7 @@ void nrf_802154_energy_detection_failed(nrf_802154_ed_error_t error)
 void nrf_802154_serialization_error(const nrf_802154_ser_err_data_t *err)
 {
 	__ASSERT(false, "802.15.4 serialization error: %d", err->reason);
+	k_oops();
 }
 #endif
 

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -76,6 +76,11 @@ struct nrf5_802154_data {
 	 */
 	energy_scan_done_cb_t energy_scan_done;
 
+#if (CONFIG_IEEE802154_NRF5_CALLOUT_TIMEOUT_MS != 0)
+	/* Timer allowing to detect timeout of energy scan operation */
+	struct k_timer ed_timer;
+#endif
+
 	/* Callback handler to notify of any important radio events.
 	 * Can be NULL if event notification is not needed.
 	 */

--- a/samples/boards/nrf/ieee802154/802154_rpmsg/src/main.c
+++ b/samples/boards/nrf/ieee802154/802154_rpmsg/src/main.c
@@ -13,9 +13,11 @@ void nrf_802154_serialization_error(const nrf_802154_ser_err_data_t *err)
 {
 	(void)err;
 	__ASSERT(false, "802.15.4 serialization error");
+	k_oops();
 }
 
 void nrf_802154_sl_fault_handler(uint32_t id, int32_t line, const char *err)
 {
 	__ASSERT(false, "module_id: %u, line: %d, %s", id, line, err);
+	k_oops();
 }


### PR DESCRIPTION
Workaround for nRF5340 network core crashes. 

Added Kconfig IEEE802154_NRF5_CALLOUT_TIMEOUT_MS.

Waiting for callbacks ending tx and cca operations are limited by Kconfig-urable `CONFIG_IIEEE802154_NRF5_CALLOUT_TIMEOUT_MS`
Waiting for end of delayed transmission (nrf5_tx_at) is limited to `time_ahead + CONFIG_IEEE802154_NRF5_CALLBACK_TIMEOUT_MS` 
Waiting for end of energy detection is limited to `duration + CONFIG_IEEE802154_NRF5_CALLBACK_TIMEOUT_MS` 

When frames cease to be received, the radio driver is polled with period `IEEE802154_NRF5_RX_THREAD_HEARTBEAT_PERIOD_MS` (60s by default for serialized driver) to check if network core crashed.

Also:
Cherry-picked commit: https://github.com/zephyrproject-rtos/zephyr/commit/174b7f47757845e531c33583dde372671cc5b27c which ensures that `nrf_802154_serialization_error` never returns.

Related ticket: KRKNWK-17057