### PR TITLE
[nrf fromlist] net: wifi_mgmt: Reject TWT setup till IP address is configured

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -351,6 +351,7 @@ enum wifi_twt_fail_reason {
 	WIFI_TWT_FAIL_PEER_NOT_TWT_CAPAB,
 	WIFI_TWT_FAIL_OPERATION_IN_PROGRESS,
 	WIFI_TWT_FAIL_INVALID_FLOW_ID,
+	WIFI_TWT_FAIL_IP_NOT_ASSIGNED,
 };
 
 static const char * const twt_err_code_tbl[] = {
@@ -368,6 +369,8 @@ static const char * const twt_err_code_tbl[] = {
 		"Operation already in progress",
 	[WIFI_TWT_FAIL_INVALID_FLOW_ID] =
 		"Invalid negotiated flow id",
+	[WIFI_TWT_FAIL_IP_NOT_ASSIGNED] =
+		"IP address not assigned",
 };
 
 static inline const char *get_twt_err_code_str(int16_t err_no)

--- a/subsys/net/l2/wifi/Kconfig
+++ b/subsys/net/l2/wifi/Kconfig
@@ -27,3 +27,14 @@ config WIFI_MGMT_RAW_SCAN_RESULTS_ONLY
 	  to the application.
 
 endif # WIFI_MGMT_RAW_SCAN_RESULTS
+
+config WIFI_MGMT_TWT_CHECK_IP
+	bool "Check IP Assignment for TWT"
+	default y
+	help
+	  This option enables check for valid IP address before TWT setup.
+	  If TWT setup is triggered early in the connection, then device might
+	  enter deep sleep without having a valid IP, this can result in device
+	  being unreachable (IP Level) or unable to receive down link traffic
+	  even when it is awake intervals. Rejecting TWT setup till Wi-Fi
+	  interface has a valid IP address might be desirable in most scenarios.

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -301,6 +301,75 @@ static int wifi_get_power_save_config(uint32_t mgmt_request, struct net_if *ifac
 
 NET_MGMT_REGISTER_REQUEST_HANDLER(NET_REQUEST_WIFI_PS_CONFIG, wifi_get_power_save_config);
 
+#ifdef CONFIG_WIFI_MGMT_TWT_CHECK_IP
+static bool is_ip_assigned(struct net_if *iface)
+{
+	struct net_if_config *if_cfg = NULL;
+	struct net_if_ipv4 *ipv4_addr = NULL;
+	struct net_if_ipv6 *ipv6_addr = NULL;
+	struct net_if_addr *ifaddr = NULL;
+	struct in6_addr ipv6_in_addr;
+	struct in_addr  ipv4_in_addr;
+	bool ip_assigned = false;
+	int i = 0;
+
+	if_cfg = net_if_config_get(iface);
+
+	if (!if_cfg) {
+		return false;
+	}
+
+	ipv4_addr = if_cfg->ip.ipv4;
+	ipv6_addr = if_cfg->ip.ipv6;
+
+	if (ipv4_addr) {
+		for (i = 0; i < NET_IF_MAX_IPV4_ADDR; i++) {
+			if (ipv4_addr->unicast[i].is_used) {
+				memcpy(&ipv4_in_addr,
+				       &ipv4_addr->unicast[i].address.in_addr,
+				       sizeof(ipv4_in_addr));
+				break;
+			}
+		}
+
+		ifaddr = net_if_ipv4_addr_lookup(&ipv4_in_addr, &iface);
+
+		if (!ifaddr ||
+		    !(net_ipv4_addr_cmp(&ifaddr->address.in_addr,
+					&ipv4_in_addr) &&
+		      ifaddr->addr_state == NET_ADDR_PREFERRED)) {
+			ip_assigned = false;
+		} else {
+			ip_assigned = true;
+		}
+	}
+
+	if (!ip_assigned && ipv6_addr) {
+		for (i = 0; i < NET_IF_MAX_IPV6_ADDR; i++) {
+			if (ipv6_addr->unicast[i].is_used) {
+				memcpy(&ipv6_in_addr,
+				       &ipv6_addr->unicast[i].address.in6_addr,
+				       sizeof(ipv6_in_addr));
+				break;
+			}
+		}
+
+		ifaddr = net_if_ipv6_addr_lookup(&ipv6_in_addr, &iface);
+
+		if (!ifaddr ||
+		    !(net_ipv6_addr_cmp(&ifaddr->address.in6_addr,
+					&ipv6_in_addr) &&
+		      ifaddr->addr_state != NET_ADDR_PREFERRED)) {
+			ip_assigned = false;
+		} else {
+			ip_assigned = true;
+		}
+	}
+
+	return ip_assigned;
+}
+#endif /* CONFIG_WIFI_MGMT_TWT_CHECK_IP */
+
 static int wifi_set_twt(uint32_t mgmt_request, struct net_if *iface,
 			  void *data, size_t len)
 {
@@ -328,6 +397,17 @@ static int wifi_set_twt(uint32_t mgmt_request, struct net_if *iface,
 			WIFI_TWT_FAIL_DEVICE_NOT_CONNECTED;
 		goto fail;
 	}
+
+#ifdef CONFIG_WIFI_MGMT_TWT_CHECK_IP
+	if (!is_ip_assigned(iface)) {
+		twt_params->fail_reason =
+			WIFI_TWT_FAIL_IP_NOT_ASSIGNED;
+		goto fail;
+	}
+#else
+	NET_WARN("Check for valid IP address been disabled. "
+		 "Device might be unreachable or might not receive traffic.\n");
+#endif /* CONFIG_WIFI_MGMT_TWT_CHECK_IP */
 
 	if (info.link_mode < WIFI_6) {
 		twt_params->fail_reason =


### PR DESCRIPTION

If a user tries to enable TWT too early in the connection, then we might enter TWT sleep even before DHCP is completed, this can result in packet loss as when we wakeup we cannot receive traffic and completing DHCP itself can take multiple intervals. Though static ip address can be assigned too. Reject TWT till Wi-Fi interface has
a valid IP address.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/58728