### PR TITLE
[nrf fromtree] net: l2: ethernet: Fix IPv6 Kconfig

### DIFF
--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -98,7 +98,7 @@ static int ethernet_set_config(uint32_t mgmt_request,
 		 * generated from old MAC address, from network interface if
 		 * needed.
 		 */
-		if (IS_ENABLED(CONFIG_NET_IPV6)) {
+		if (IS_ENABLED(CONFIG_NET_NATIVE_IPV6)) {
 			struct in6_addr iid;
 
 			net_ipv6_addr_create_iid(&iid,


### PR DESCRIPTION
Function net_if_ipv6_addr_rm is only defined for NATIVE_IPV6.

Upstream-Pr: https://github.com/zephyrproject-rtos/zephyr/pull/59108