### PR TITLE
[nrf fromlist] net: wifi_mgmt: Pass address instead of value

### DIFF
--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -381,7 +381,7 @@ void wifi_mgmt_raise_twt_sleep_state(struct net_if *iface,
 				     int twt_sleep_state)
 {
 	net_mgmt_event_notify_with_info(NET_EVENT_WIFI_TWT_SLEEP_STATE,
-					iface, INT_TO_POINTER(twt_sleep_state),
+					iface, &twt_sleep_state,
 					sizeof(twt_sleep_state));
 }
 


### PR DESCRIPTION
Fix for not getting expected event information at application. The passing of the address is required not the value, to net_mgmt_event_notify_with_info().

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/59155