### PR TITLE
[nrf fromtree] scripts: adjust WEST_PYTHON to posix path

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -497,7 +497,7 @@ class Build(Forceable):
         # to Just Work:
         #
         # west build -- -DOVERLAY_CONFIG=relative-path.conf
-        final_cmake_args = ['-DWEST_PYTHON={}'.format(sys.executable),
+        final_cmake_args = ['-DWEST_PYTHON={}'.format(pathlib.Path(sys.executable).as_posix()),
                             '-B{}'.format(self.build_dir),
                             '-G{}'.format(config_get('generator',
                                                      DEFAULT_CMAKE_GENERATOR))]


### PR DESCRIPTION
Adjust WEST_PYTHON to posix path to be consistent with other Python scripts which passes paths to the Zephyr CMake build system.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>
(cherry picked from commit c03e1900ae7faf2d64b9275735f59c585a028937)