### PR TITLE
[nrf fromtree] dts: vendor-prefixes: Add OpenThread.io vendor prefix

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -438,6 +438,7 @@ opalkelly	Opal Kelly Incorporated
 opencores	OpenCores.org
 openisa	open-isa.org
 openrisc	OpenRISC.io
+openthread	OpenThread.io
 option	Option NV
 oranth	Shenzhen Oranth Technology Co., Ltd.
 ORCL	Oracle Corporation


### PR DESCRIPTION
Added OpenThread.io vendor prefix to enable
`openthread,config` dts binding for additional OpenThread configurations.

Signed-off-by: Maciej Baczmanski <maciej.baczmanski@nordicsemi.no>
(cherry picked from commit [9748250e7295495a18da29b4aa65eaf3eafc46e1](https://github.com/zephyrproject-rtos/zephyr/commit/9748250e7295495a18da29b4aa65eaf3eafc46e1))