### PR TITLE
net: wifi: Fix power save timeout data type

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -203,7 +203,13 @@ struct wifi_ps_params {
 	unsigned short listen_interval;
 	enum wifi_ps_wakeup_mode wakeup_mode;
 	enum wifi_ps_mode mode;
-	int timeout_ms;
+	/* This is the time out to wait after sending a TX packet
+	 * before going back to power save (in ms) to receive any replies
+	 * from the AP. Zero means this feature is disabled.
+	 *
+	 * It's a tradeoff between power consumption and latency.
+	 */
+	unsigned int timeout_ms;
 	enum ps_param_type type;
 	enum wifi_config_ps_param_fail_reason fail_reason;
 };

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -593,8 +593,13 @@ static int cmd_wifi_ps(const struct shell *sh, size_t argc, char *argv[])
 		shell_fprintf(sh, SHELL_NORMAL, "PS wake up mode: %s\n",
 				config.ps_params.wakeup_mode ? "Listen interval" : "DTIM");
 
-		shell_fprintf(sh, SHELL_NORMAL, "PS timeout: %d ms\n",
-				config.ps_params.timeout_ms);
+		if (config.ps_params.timeout_ms) {
+			shell_fprintf(sh, SHELL_NORMAL, "PS timeout: %d ms\n",
+					config.ps_params.timeout_ms);
+		} else {
+			shell_fprintf(sh, SHELL_NORMAL, "PS timeout: disabled\n");
+		}
+
 
 		if (config.num_twt_flows == 0) {
 			shell_fprintf(sh, SHELL_NORMAL, "No TWT flows\n");
@@ -695,8 +700,11 @@ static int cmd_wifi_ps_timeout(const struct shell *sh, size_t argc, char *argv[]
 		return -ENOEXEC;
 	}
 
-	shell_fprintf(sh, SHELL_NORMAL,
-		"PS timeout %d ms\n", params.timeout_ms);
+	if (params.timeout_ms) {
+		shell_fprintf(sh, SHELL_NORMAL, "PS timeout: %d ms\n", params.timeout_ms);
+	} else {
+		shell_fprintf(sh, SHELL_NORMAL, "PS timeout: disabled\n");
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This should be an unsigned integer. Also, add a comment to explain this feature.

Upstream-Pr: https://github.com/zephyrproject-rtos/zephyr/pull/59638