### PR TITLE
modules: mbedtls: Align Kconfig options with Oberon PSA core

### DIFF
--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -453,8 +453,7 @@ config PSA_WANT_ALG_SPAKE2P
 	prompt "PSA SPAKE2+ support" if !PSA_PROMPTLESS
 	select EXPERIMENTAL
 
-config PSA_WANT_ALG_SRP
+config PSA_WANT_ALG_SRP_6
 	bool
-	prompt "PSA SRP support" if !PSA_PROMPTLESS
-	default n
+	prompt "PSA SRP-6 support" if !PSA_PROMPTLESS
 	select EXPERIMENTAL

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -472,3 +472,15 @@ config PSA_WANT_ALG_SRP_6
 	bool
 	prompt "PSA SRP-6 support" if !PSA_PROMPTLESS
 	select EXPERIMENTAL
+
+config PSA_WANT_ALG_PURE_EDDSA
+	bool
+	prompt "PSA PURE_EDDSA support" if !PSA_PROMPTLESS
+
+config PSA_WANT_ALG_ED25519PH
+	bool
+	prompt "PSA ED25519PH support" if !PSA_PROMPTLESS
+
+config PSA_WANT_ALG_ED448PH
+	bool
+	prompt "PSA ED448PH support" if !PSA_PROMPTLESS

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -116,6 +116,7 @@ config PSA_HAS_AEAD_SUPPORT
 	bool
 	default y
 	depends on PSA_WANT_ALG_CCM || \
+		   PSA_WANT_ALG_CCM_STAR_NO_TAG || \
 		   PSA_WANT_ALG_GCM || \
 		   PSA_WANT_ALG_CHACHA20_POLY1305
 	help
@@ -124,6 +125,10 @@ config PSA_HAS_AEAD_SUPPORT
 config PSA_WANT_ALG_CCM
 	bool
 	prompt "PSA CCM support" if !PSA_PROMPTLESS
+
+config PSA_WANT_ALG_CCM_STAR_NO_TAG
+	bool
+	prompt "PSA AES CCM star with no tag support" if !PSA_PROMPTLESS
 
 config PSA_WANT_ALG_GCM
 	bool
@@ -272,6 +277,8 @@ config PSA_HAS_KEY_DERIVATION
 	bool
 	default y
 	depends on PSA_WANT_ALG_HKDF 		|| \
+		   PSA_WANT_ALG_HKDF_EXPAND     || \
+		   PSA_WANT_ALG_HKDF_EXTRACT    || \
 		   PSA_WANT_ALG_PBKDF2_HMAC	|| \
 		   PSA_WANT_ALG_PBKDF2_AES_CMAC_PRF_128 || \
 		   PSA_WANT_ALG_TLS12_PRF	|| \
@@ -284,6 +291,14 @@ config PSA_WANT_ALG_HKDF
 	bool
 	prompt "PSA HKDF support" if !PSA_PROMPTLESS
 	depends on PSA_WANT_ALG_HMAC
+
+config PSA_WANT_ALG_HKDF_EXTRACT
+	bool
+	prompt "PSA HKDF extract support" if !PSA_PROMPTLESS
+
+config PSA_WANT_ALG_HKDF_EXPAND
+	bool
+	prompt "PSA HKDF expand support" if !PSA_PROMPTLESS
 
 config PSA_WANT_ALG_PBKDF2_HMAC
 	bool


### PR DESCRIPTION
Add Kconfig options:
    PSA_WANT_ALG_CCM_STAR_NO_TAG
    PSA_WANT_ALG_PURE_EDDSA
    PSA_WANT_ALG_HKDF_EXTRACT
    PSA_WANT_ALG_HKDF_EXPAND

since they exist in the Oberon PSA core.

Rename:
PSA_WANT_ALG_SRP -> PSA_WANT_ALG_SRP_6

To align with the Oberon PSA core.


