### PR TITLE
[nrf fromtree] bluetooth: host: smp: Add bondable flag overlay per connection

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1081,6 +1081,26 @@ void bt_conn_cb_register(struct bt_conn_cb *cb);
  */
 void bt_set_bondable(bool enable);
 
+/** @brief Set/clear the bonding flag for a given connection.
+ *
+ *  Set/clear the Bonding flag in the Authentication Requirements of
+ *  SMP Pairing Request/Response data for a given connection.
+ *
+ *  The bonding flag for a given connection cannot be set/cleared if
+ *  security procedures in the SMP module have already started.
+ *  This function can be called only once per connection.
+ *
+ *  If the bonding flag is not set/cleared for a given connection,
+ *  the value will depend on global configuration which is set using
+ *  bt_set_bondable.
+ *  The default value of the global configuration is defined using
+ *  CONFIG_BT_BONDABLE Kconfig option.
+ *
+ *  @param conn Connection object.
+ *  @param enable Value allowing/disallowing to be bondable.
+ */
+int bt_conn_set_bondable(struct bt_conn *conn, bool enable);
+
 /** @brief Allow/disallow remote LE SC OOB data to be used for pairing.
  *
  *  Set/clear the OOB data flag for LE SC SMP Pairing Request/Response data.

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -600,6 +600,13 @@ config BT_BONDING_REQUIRED
 	  set the bondable flag in their pairing request. Any other kind of
 	  requests will be rejected.
 
+config BT_BONDABLE_PER_CONNECTION
+	bool "Set/clear the bonding flag per-connection [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  Enable support for the bt_conn_set_bondable API function that is
+	  used to set/clear the bonding flag on a per-connection basis.
+
 config BT_STORE_DEBUG_KEYS
 	bool "Store Debug Mode bonds"
 	help

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -209,6 +209,9 @@ struct bt_smp {
 
 	/* Used Bluetooth authentication callbacks. */
 	atomic_ptr_t			auth_cb;
+
+	/* Bondable flag */
+	atomic_t			bondable;
 };
 
 static unsigned int fixed_passkey = BT_PASSKEY_INVALID;
@@ -288,6 +291,11 @@ static K_SEM_DEFINE(sc_local_pkey_ready, 0, 1);
  */
 #define BT_SMP_AUTH_CB_UNINITIALIZED	((atomic_ptr_val_t)bt_smp_pool)
 
+/* Value used to mark that per-connection bondable flag is not initialized.
+ * Value false/true represent if flag is cleared or set and cannot be used for that purpose.
+ */
+#define BT_SMP_BONDABLE_UNINITIALIZED	((atomic_val_t)-1)
+
 static bool le_sc_supported(void)
 {
 	/*
@@ -308,6 +316,13 @@ static const struct bt_conn_auth_cb *latch_auth_cb(struct bt_smp *smp)
 	atomic_ptr_cas(&smp->auth_cb, BT_SMP_AUTH_CB_UNINITIALIZED, (atomic_ptr_val_t)bt_auth);
 
 	return atomic_ptr_get(&smp->auth_cb);
+}
+
+static bool latch_bondable(struct bt_smp *smp)
+{
+	atomic_cas(&smp->bondable, BT_SMP_BONDABLE_UNINITIALIZED, (atomic_val_t)bondable);
+
+	return atomic_get(&smp->bondable);
 }
 
 static uint8_t get_io_capa(struct bt_smp *smp)
@@ -2592,7 +2607,7 @@ static uint8_t get_auth(struct bt_smp *smp, uint8_t auth)
 		auth |= BT_SMP_AUTH_MITM;
 	}
 
-	if (bondable) {
+	if (latch_bondable(smp)) {
 		auth |= BT_SMP_AUTH_BONDING;
 	} else {
 		auth &= ~BT_SMP_AUTH_BONDING;
@@ -3977,7 +3992,7 @@ static uint8_t smp_security_request(struct bt_smp *smp, struct net_buf *buf)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_BONDING_REQUIRED) &&
-	    !(bondable && (auth & BT_SMP_AUTH_BONDING))) {
+	    !(latch_bondable(smp) && (auth & BT_SMP_AUTH_BONDING))) {
 		/* Reject security req if not both intend to bond */
 		LOG_DBG("Bonding required");
 		return BT_SMP_ERR_UNSPECIFIED;
@@ -4541,6 +4556,7 @@ static void bt_smp_connected(struct bt_l2cap_chan *chan)
 	smp_reset(smp);
 
 	atomic_ptr_set(&smp->auth_cb, BT_SMP_AUTH_CB_UNINITIALIZED);
+	atomic_set(&smp->bondable, BT_SMP_BONDABLE_UNINITIALIZED);
 }
 
 static void bt_smp_disconnected(struct bt_l2cap_chan *chan)
@@ -5288,6 +5304,24 @@ static int smp_self_test(void)
 static inline int smp_self_test(void)
 {
 	return 0;
+}
+#endif
+
+#if defined(CONFIG_BT_BONDABLE_PER_CONNECTION)
+int bt_conn_set_bondable(struct bt_conn *conn, bool enable)
+{
+	struct bt_smp *smp;
+
+	smp = smp_chan_get(conn);
+	if (!smp) {
+		return -EINVAL;
+	}
+
+	if (atomic_cas(&smp->bondable, BT_SMP_BONDABLE_UNINITIALIZED, (atomic_val_t)enable)) {
+		return 0;
+	} else {
+		return -EALREADY;
+	}
 }
 #endif
 


### PR DESCRIPTION
The current API for changing the bondable mode uses the global flag.
With Zephyr support for multiple Bluetooth identities, the API for
changing the bondable mode should be more fine-grained.
The bondable requirements of one identity should not have an impact on
another identity which can have a different set of requirements.
This change introduces function to overlay bondable flag per
connection.

Signed-off-by: Mateusz Kapala <mateusz.kapala@nordicsemi.no>
(cherry picked from commit 5b44ebe1595a8d4a46f5721271557d4159498673)