### PR TITLE
[nrf fromtree] libc/picolibc: Remove -T /dev/null linker arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,8 +469,9 @@ if(CONFIG_USERSPACE)
 endif()
 
 get_property(TOPT GLOBAL PROPERTY TOPT)
-set_ifndef(  TOPT -Wl,-T) # clang doesn't pick -T for some reason and complains,
-                          # while -Wl,-T works for both, gcc and clang
+get_property(COMPILER_TOPT TARGET compiler PROPERTY linker_script)
+set_ifndef(  TOPT "${COMPILER_TOPT}")
+set_ifndef(  TOPT -Wl,-T) # Use this if the compiler driver doesn't set a value
 
 if(CONFIG_HAVE_CUSTOM_LINKER_SCRIPT)
   set(LINKER_SCRIPT ${APPLICATION_SOURCE_DIR}/${CONFIG_CUSTOM_LINKER_SCRIPT})

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -23,6 +23,9 @@ set_compiler_property(PROPERTY diagnostic -fcolor-diagnostics)
 # clang flag to save temporary object files
 set_compiler_property(PROPERTY save_temps -save-temps)
 
+# clang doesn't handle the -T flag
+set_compiler_property(PROPERTY linker_script -Wl,-T)
+
 #######################################################
 # This section covers flags related to warning levels #
 #######################################################

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -106,6 +106,9 @@ set_compiler_property(PROPERTY debug)
 # Flags to save temporary object files
 set_compiler_property(PROPERTY save_temps)
 
+# Flag to specify linker script
+set_compiler_property(PROPERTY linker_script)
+
 set_compiler_property(PROPERTY no_common)
 
 # Flags for imacros. The specific header must be appended by user.

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -182,6 +182,9 @@ set_compiler_property(PROPERTY debug -g)
 # Flags to save temporary object files
 set_compiler_property(PROPERTY save_temps -save-temps=obj)
 
+# Flag to specify linker script
+set_compiler_property(PROPERTY linker_script -T)
+
 # GCC 11 by default emits DWARF version 5 which cannot be parsed by
 # pyelftools. Can be removed once pyelftools supports v5.
 check_set_compiler_property(APPEND PROPERTY debug -gdwarf-4)

--- a/lib/libc/picolibc/CMakeLists.txt
+++ b/lib/libc/picolibc/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT CONFIG_PICOLIBC_USE_MODULE)
 
   zephyr_compile_options(--specs=picolibc.specs)
   zephyr_compile_definitions(_POSIX_C_SOURCE=200809)
-  zephyr_libc_link_libraries(-T/dev/null --specs=picolibc.specs c -lgcc)
+  zephyr_libc_link_libraries(--specs=picolibc.specs c -lgcc)
   if(CONFIG_PICOLIBC_IO_FLOAT)
     zephyr_compile_definitions(PICOLIBC_DOUBLE_PRINTF_SCANF)
     zephyr_link_libraries(-DPICOLIBC_DOUBLE_PRINTF_SCANF)


### PR DESCRIPTION
Now that the gcc compiler driver uses the -T flag instead of -Wl,-T, we can remove the hack here that kept the picolibc specs file from inserting the picolibc linker script.

Signed-off-by: Keith Packard <keithp@keithp.com>
(cherry picked from commit 4e7930b099771ecc5ad5c05b95a158cc0ceee0d2)