### PR TITLE
[nrf fromtree] net: openthread: Initialize PSA crypto when random is initializing

### DIFF
--- a/modules/openthread/platform/crypto_psa.c
+++ b/modules/openthread/platform/crypto_psa.c
@@ -415,6 +415,7 @@ otError otPlatCryptoSha256Finish(otCryptoContext *aContext, uint8_t *aHash, uint
 
 void otPlatCryptoRandomInit(void)
 {
+	psa_crypto_init();
 }
 
 void otPlatCryptoRandomDeinit(void)


### PR DESCRIPTION
The psa_generate_random function requires the psa_crypto_init call before the usage. This can be ensured by calling the psa_crypto_init in otPlatCryptoRandomInitfunction.
