### PR TITLE
[nrf noup] settings: nvs: use dedicated lookup cache hash function

### DIFF
--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -27,6 +27,15 @@ config NVS_LOOKUP_CACHE_SIZE
 	  Number of entries in Non-volatile Storage lookup cache.
 	  It is recommended that it be a power of 2.
 
+config NVS_LOOKUP_CACHE_FOR_SETTINGS
+	bool "Non-volatile Storage lookup cache optimized for settings"
+	depends on NVS_LOOKUP_CACHE
+	help
+	  Use the lookup cache hash function that results in the least number of
+	  collissions and, in turn, the best NVS performance provided that the NVS
+	  is used as the settings backend only. This option should NOT be enabled
+	  if the NVS is also written to directly, outside the settings layer.
+
 module = NVS
 module-str = nvs
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -13,6 +13,11 @@
 #include <zephyr/sys/crc.h>
 #include "nvs_priv.h"
 
+#ifdef CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS
+#include <zephyr/sys/util.h>
+#include <settings/settings_nvs.h>
+#endif
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(fs_nvs, CONFIG_NVS_LOG_LEVEL);
 
@@ -20,6 +25,45 @@ static int nvs_prev_ate(struct nvs_fs *fs, uint32_t *addr, struct nvs_ate *ate);
 static int nvs_ate_valid(struct nvs_fs *fs, const struct nvs_ate *entry);
 
 #ifdef CONFIG_NVS_LOOKUP_CACHE
+
+#ifdef CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS
+
+static inline size_t nvs_lookup_cache_pos(uint16_t id)
+{
+	/*
+	 * 1. The NVS settings backend uses up to (NVS_NAME_ID_OFFSET - 1) NVS IDs to
+	      store keys and equal number of NVS IDs to store values.
+	 * 2. For each key-value pair, the value is stored at NVS ID greater by exactly
+	 *    NVS_NAME_ID_OFFSET than NVS ID that holds the key.
+	 * 3. The backend tries to minimize the range of NVS IDs used to store keys.
+	 *    That is, NVS IDs are allocated sequentially, and freed NVS IDs are reused
+	 *    before allocating new ones.
+	 *
+	 * Therefore, to assure the least number of collisions in the lookup cache,
+	 * the least significant bit of the hash indicates whether the given NVS ID
+	 * represents a key or a value, and remaining bits of the hash are set to
+	 * the ordinal number of the key-value pair. Consequently, the hash function
+	 * provides the following mapping:
+	 *
+	 * 1st settings key   => hash 0
+	 * 1st settings value => hash 1
+	 * 2nd settings key   => hash 2
+	 * 2nd settings value => hash 3
+	 * ...
+	 */
+	BUILD_ASSERT(IS_POWER_OF_TWO(NVS_NAMECNT_ID), "NVS_NAMECNT_ID is not power of 2");
+	BUILD_ASSERT(IS_POWER_OF_TWO(NVS_NAME_ID_OFFSET), "NVS_NAME_ID_OFFSET is not power of 2");
+
+	uint16_t key_value_bit;
+	uint16_t key_value_ord;
+
+	key_value_bit = (id >> LOG2(NVS_NAME_ID_OFFSET)) & 1;
+	key_value_ord = id & (NVS_NAME_ID_OFFSET - 1);
+
+	return ((key_value_ord << 1) | key_value_bit) % CONFIG_NVS_LOOKUP_CACHE_SIZE;
+}
+
+#else /* CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS */
 
 static inline size_t nvs_lookup_cache_pos(uint16_t id)
 {
@@ -35,6 +79,8 @@ static inline size_t nvs_lookup_cache_pos(uint16_t id)
 
 	return hash % CONFIG_NVS_LOOKUP_CACHE_SIZE;
 }
+
+#endif /* CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS */
 
 static int nvs_lookup_cache_rebuild(struct nvs_fs *fs)
 {


### PR DESCRIPTION
Introduce `NVS_LOOKUP_CACHE_FOR_SETTINGS` Kconfig option that enables a dedicated hash function for the NVS lookup cache that takes advantage of the NVS ID allocation scheme used by the NVS settings backend. As such, this option should only be used if an application uses NVS via the settings layer.

The commit is a `noup` patch because the original change seems not generic enough to be accepted by the Zephyr community: https://github.com/zephyrproject-rtos/zephyr/pull/61619.
