### PR TITLE
[nrf noup] boards: thingy53_nrf5340: Fix available RAM

### DIFF
--- a/boards/arm/thingy53_nrf5340/pm_static_thingy53_nrf5340_cpuapp.yml
+++ b/boards/arm/thingy53_nrf5340/pm_static_thingy53_nrf5340_cpuapp.yml
@@ -53,3 +53,7 @@ pcd_sram:
   address: 0x20000000
   size: 0x2000
   region: sram_primary
+shared_sram:
+  address: 0x20070000
+  size: 0x10000
+  region: sram_primary


### PR DESCRIPTION
fixup! [nrf noup] boards: thingy53_nrf5340: Add common partition map

Because of the missing shared RAM partition, the partition manager wrongly calcualted the usable RAM for applications (non-shared) showing as 504KB instead of 440KB.