### PR TITLE
[nrf noup]: ci: Only run lwm2m tests when needed

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -21,7 +21,7 @@
   - "subsys/testsuite/ztest/**/*"
 
 "CI-lwm2m-test":
-  - "**/*"
+# Not necessary to run tests on changes to this repo.
 
 "CI-boot-dfu-test":
   - "subsys/mgmt/mcumgr/**/*"


### PR DESCRIPTION
There is no need to run those for all PRs.
For example: When there are only changes to Bluetooth, we don't want this CI to run.

Adding these filters may speedup the time to merge for PRs to sdk-nrf