### PR TITLE
Use devicetree property to identify MS5837 type and correct MS5837-30BA conversion #60950

### DIFF
--- a/drivers/sensor/ms5837/ms5837.c
+++ b/drivers/sensor/ms5837/ms5837.c
@@ -348,18 +348,15 @@ static int ms5837_init(const struct device *dev)
 		return err;
 	}
 
-	const int type_id = (data->factory >> 5) & 0x7f;
-
-	switch (type_id) {
-	case  MS5837_02BA01:
-	case MS5837_02BA21:
+	switch (cfg->submodel_index) {
+	case MS5837_02BA_SUBMODEL_INDEX:
 		data->comp_func = ms5837_compensate_02;
 		break;
-	case MS5837_30BA26:
+	case MS5837_30BA_SUBMODEL_INDEX:
 		data->comp_func = ms5837_compensate_30;
 		break;
 	default:
-		LOG_WRN(" unrecognized type: '%2x', defaulting to MS5837-30", type_id);
+		LOG_WRN(" unsupported submodel index: '%i', defaulting to MS5837-30BA", cfg->submodel_index);
 		data->comp_func = ms5837_compensate_30;
 		break;
 	}
@@ -372,6 +369,7 @@ static int ms5837_init(const struct device *dev)
 											\
 	static const struct ms5837_config ms5837_config_##inst = {			\
 		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
+		.submodel_index = DT_ENUM_IDX(DT_DRV_INST(inst), submodel),					\
 	};										\
 											\
 	SENSOR_DEVICE_DT_INST_DEFINE(inst, ms5837_init, NULL,				\

--- a/drivers/sensor/ms5837/ms5837.c
+++ b/drivers/sensor/ms5837/ms5837.c
@@ -94,8 +94,10 @@ static void ms5837_compensate_30(const struct device *dev,
 	SENS -= SENSi;
 
 	data->temperature -= Ti;
-	data->pressure =
-	    (((SENS * adc_pressure) / (1ll << 21)) - OFF) / (1ll << 13);
+	int32_t pressure = (((SENS * adc_pressure) / (1ll << 21)) - OFF) / (1ll << 13);
+
+	// Convert to internal pressure (mbar * 100)
+	data->pressure = pressure * 10;
 }
 
 /*

--- a/drivers/sensor/ms5837/ms5837.h
+++ b/drivers/sensor/ms5837/ms5837.h
@@ -44,10 +44,10 @@
 #define MS5837_ADC_READ_DELAY_4086 10
 #define MS5837_ADC_READ_DELAY_8129 20
 
-enum ms5837_type {
-	MS5837_02BA01 = 0x00,
-	MS5837_02BA21 = 0x15,
-	MS5837_30BA26 = 0x1A
+enum ms5837_submodel_index {
+	/* Match the order of the subtype enum in meas,ms5837.yaml */
+	MS5837_02BA_SUBMODEL_INDEX = 0,
+	MS5837_30BA_SUBMODEL_INDEX = 1
 };
 
 typedef void (*ms5837_compensate_func)(const struct device *dev,
@@ -81,6 +81,7 @@ struct ms5837_data {
 
 struct ms5837_config {
 	struct i2c_dt_spec i2c;
+	int submodel_index;
 };
 
 #endif /* __SENSOR_MS5837_H__ */

--- a/dts/bindings/sensor/meas,ms5837.yaml
+++ b/dts/bindings/sensor/meas,ms5837.yaml
@@ -6,3 +6,12 @@ description: TE Connectivity MS5837 digital pressure sensor
 compatible: "meas,ms5837"
 
 include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+  submodel:
+    type: string
+    description: Specifies the MS5837 sub-model.
+    default: "02ba"
+    enum:
+     - "02ba"
+     - "30ba"

--- a/samples/sensor/ms5837/README.rst
+++ b/samples/sensor/ms5837/README.rst
@@ -9,6 +9,9 @@ Overview
 This sample application retrieves the pressure and temperature from a MS5837
 sensor every 10 seconds, and prints this information to the UART console.
 
+The driver supports MS5837-02BA and MS5827-30BA sensors. If you are using the
+MS5837-30BA sensor, add the devicetree property `submodel: "30ba";`.
+
 Requirements
 ************
 


### PR DESCRIPTION
The current device type determination using the factory ID is unable to differentiate MS5837-02BA01 and MS5837-30BA01 devices resulting in the 02BA compensation being used for a 30BA device. In addition, the 30BA conversion units don't match 02BA and the resulting pressure value is off by a factor of 10.

A `submodel` enum property is added to devicetree that is used to specify which specific device type is in use, "02ba" (default) or "30ba".

In addition, `ms5837_compensate_30`'s pressure result now matches the units of `ms5837_compensate_02` so the read pressure is as expected.

Refer to #60950 for more context.