### PR TITLE
net: lwm2m: Two more bootstrap related fixes

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -68,6 +68,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define CLIENT_EP_LEN		CONFIG_LWM2M_RD_CLIENT_ENDPOINT_NAME_MAX_LENGTH
 #define CLIENT_BINDING_LEN sizeof("UQ")
 #define CLIENT_QUEUE_LEN sizeof("Q")
+#define DELAY_BEFORE_CLOSING	(1 * MSEC_PER_SEC)
+#define DELAY_FOR_ACK		100U
 
 static void sm_handle_registration_update_failure(void);
 static int sm_send_registration_msg(void);
@@ -381,6 +383,8 @@ void engine_trigger_update(bool update_objects)
 	}
 
 	client.trigger_update = true;
+	/* short delay for Ack, then trigger an update */
+	next_event_at(k_uptime_get() + DELAY_FOR_ACK);
 
 	if (update_objects) {
 		client.update_objects = true;
@@ -464,7 +468,7 @@ int engine_trigger_bootstrap(void)
 	rd_client_message_free();
 	client.use_bootstrap = true;
 	client.trigger_update = false;
-	set_sm_state(ENGINE_INIT);
+	set_sm_state_delayed(ENGINE_INIT, DELAY_BEFORE_CLOSING);
 	k_mutex_unlock(&client.mutex);
 	return 0;
 #else
@@ -847,7 +851,7 @@ void engine_bootstrap_finish(void)
 	/* Delay the state transition, so engine have some time to send ACK
 	 * before we close the socket
 	 */
-	set_sm_state_delayed(ENGINE_BOOTSTRAP_TRANS_DONE, 1000);
+	set_sm_state_delayed(ENGINE_BOOTSTRAP_TRANS_DONE, DELAY_BEFORE_CLOSING);
 }
 
 static int sm_bootstrap_trans_done(void)
@@ -1100,13 +1104,13 @@ static int64_t next_update(void)
 	 * check for lifetime seconds - SECONDS_TO_UPDATE_EARLY
 	 * so that we can update early and avoid lifetime timeout
 	 */
-	return client.last_update + (client.lifetime - SECONDS_TO_UPDATE_EARLY) * 1000;
+	return client.last_update + (client.lifetime - SECONDS_TO_UPDATE_EARLY) * MSEC_PER_SEC;
 }
 
 static int64_t next_rx_off(void)
 {
 	if (IS_ENABLED(CONFIG_LWM2M_QUEUE_MODE_ENABLED)) {
-		return client.last_tx + CONFIG_LWM2M_QUEUE_MODE_UPTIME * 1000;
+		return client.last_tx + CONFIG_LWM2M_QUEUE_MODE_UPTIME * MSEC_PER_SEC;
 	} else {
 		return next_update();
 	}
@@ -1252,7 +1256,7 @@ static void sm_do_network_error(void)
 
 	if (client.retry_delay) {
 		client.retry_delay = 0;
-		next_event_at(k_uptime_get() + client.retry_delay * 1000);
+		next_event_at(k_uptime_get() + client.retry_delay * MSEC_PER_SEC);
 		return;
 	}
 
@@ -1264,7 +1268,8 @@ static void sm_do_network_error(void)
 	}
 #endif
 
-	if (!client.last_update || (k_uptime_get() - client.last_update) / 1000 > client.lifetime) {
+	if (!client.last_update ||
+	    (k_uptime_get() - client.last_update) / MSEC_PER_SEC > client.lifetime) {
 		/* do full registration as there is no active registration or lifetime exceeded */
 		lwm2m_engine_context_close(client.ctx);
 		set_sm_state(ENGINE_DO_REGISTRATION);
@@ -1516,7 +1521,7 @@ int lwm2m_rd_client_resume(void)
 	if (client.engine_state >= ENGINE_DO_REGISTRATION &&
 		client.engine_state <= ENGINE_SUSPENDED) {
 		if (!client.last_update ||
-			(client.lifetime <= (k_uptime_get() - client.last_update) / 1000)) {
+			(client.lifetime <= (k_uptime_get() - client.last_update) / MSEC_PER_SEC)) {
 			/* No lifetime left, register again */
 			client.engine_state = ENGINE_DO_REGISTRATION;
 		} else {
@@ -1535,7 +1540,6 @@ int lwm2m_rd_client_resume(void)
 void lwm2m_rd_client_update(void)
 {
 	engine_trigger_update(false);
-	next_event_at(0);
 }
 
 struct lwm2m_ctx *lwm2m_rd_client_ctx(void)

--- a/tests/net/lib/lwm2m/lwm2m_rd_client/src/main.c
+++ b/tests/net/lib/lwm2m/lwm2m_rd_client/src/main.c
@@ -21,7 +21,7 @@ DEFINE_FFF_GLOBALS;
 /* Maximum number of iterations within the state machine of RD Client
  * service that is waited for until a possible event occurs
  */
-static const uint8_t RD_CLIENT_MAX_LOOKUP_ITERATIONS = 10;
+static const uint8_t RD_CLIENT_MAX_LOOKUP_ITERATIONS = 100;
 
 FAKE_VOID_FUNC(show_lwm2m_event, enum lwm2m_rd_client_event);
 FAKE_VOID_FUNC(show_lwm2m_observe, enum lwm2m_observe_event);
@@ -143,7 +143,10 @@ static void my_suite_before(void *data)
 
 	RESET_FAKE(show_lwm2m_event);
 	RESET_FAKE(show_lwm2m_observe);
+}
 
+static void my_suite_after(void *data)
+{
 	test_lwm2m_engine_stop_service();
 }
 
@@ -165,7 +168,7 @@ void message_reply_timeout_cb_default(struct lwm2m_message *msg)
 	msg->message_timeout_cb(msg);
 }
 
-ZTEST_SUITE(lwm2m_rd_client, NULL, NULL, my_suite_before, NULL, NULL);
+ZTEST_SUITE(lwm2m_rd_client, NULL, NULL, my_suite_before, my_suite_after, NULL);
 
 ZTEST(lwm2m_rd_client, test_start_registration_ok)
 {

--- a/tests/net/lib/lwm2m/lwm2m_rd_client/src/stubs.c
+++ b/tests/net/lib/lwm2m/lwm2m_rd_client/src/stubs.c
@@ -94,10 +94,11 @@ int lwm2m_engine_call_at(k_work_handler_t work, int64_t timestamp)
 uint16_t counter = RD_CLIENT_MAX_SERVICE_ITERATIONS;
 struct lwm2m_message *pending_message;
 void *(*pending_message_cb)();
+static bool running;
 
 static void service_work_fn(struct k_work *work)
 {
-	while (true) {
+	while (running) {
 		if (pending_message != NULL && pending_message_cb != NULL) {
 			pending_message_cb(pending_message);
 			pending_message = NULL;
@@ -132,6 +133,7 @@ K_WORK_DEFINE(service_work, service_work_fn);
 
 void test_lwm2m_engine_start_service(void)
 {
+	running = true;
 	counter = RD_CLIENT_MAX_SERVICE_ITERATIONS;
 	k_work_submit(&service_work);
 }
@@ -139,6 +141,7 @@ void test_lwm2m_engine_start_service(void)
 void test_lwm2m_engine_stop_service(void)
 {
 	pending_message_cb = NULL;
+	running = false;
 	k_work_cancel(&service_work);
 }
 


### PR DESCRIPTION
Two more fixes for bootstrap timing issues.

Related sdk-nrf PR: https://github.com/nrfconnect/sdk-nrf/pull/12037
Original Zephyr PR: https://github.com/zephyrproject-rtos/zephyr/pull/61370
