### PR TITLE
[nrf fromtree] tests: Bluetooth: Mesh: fix omitted names

### DIFF
--- a/tests/bsim/bluetooth/mesh/src/main.c
+++ b/tests/bsim/bluetooth/mesh/src/main.c
@@ -77,7 +77,7 @@ bst_test_install_t test_installers[] = {
 static struct k_thread bsim_mesh_thread;
 static K_KERNEL_STACK_DEFINE(bsim_mesh_thread_stack, 4096);
 
-static void bsim_mesh_entry_point(void *, void *, void *)
+static void bsim_mesh_entry_point(void *unused1, void *unused2, void *unused3)
 {
 	bst_main();
 }


### PR DESCRIPTION
PR fixes using of the parameter with omitted names.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>
(cherry picked from commit b8f7c81dd3930ae1dde60dcf1daba32d03176816)