### PR TITLE
[nrf noup] ci: Only run crypto and tf-m tests when needed

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -31,7 +31,13 @@
   - "samples/subsys/mgmt/mcumgr/smp_svr/**/*"
 
 "CI-tfm-test":
-  - "**/*"
+  - "boards/arm/nrf5340dk_nrf5340/**/*"
+  - "boards/arm/nrf9160dk_nrf9160/**/*"
+  - "drivers/entropy/*"
+  - "dts/arm/nordic/nrf5340*"
+  - "dts/arm/nordic/nrf9160*"
+  - "modules/trusted-firmware-m/**/*"
+  - "samples/tfm_integration/**/*"
 
 "CI-ble-test":
   - "**/*"
@@ -58,7 +64,16 @@
   - "**/*"
 
 "CI-crypto-test":
-  - "**/*"
+  - "boards/arm/nrf52840dk_nrf52840/**/*"
+  - "boards/arm/nrf5340dk_nrf5340/**/*"
+  - "boards/arm/nrf9160dk_nrf9160/**/*"
+  - "drivers/entropy/*"
+  - "drivers/serial/**/*"
+  - "dts/arm/nordic/nrf52840*"
+  - "dts/arm/nordic/nrf5340*"
+  - "dts/arm/nordic/nrf9160*"
+  - "include/drivers/serial/**/*"
+  - "modules/mbedtls/**/*"
 
 "CI-fem-test":
   - "**/*"


### PR DESCRIPTION
Extended the github CI filter for crypto and TF-M tests to reduce the CI load and possibly speed up PRs.