### PR TITLE
net: wifi_mgmt: Fix size calculation for net_mgmt info

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -461,6 +461,19 @@ struct wifi_raw_scan_result {
 	uint8_t data[CONFIG_WIFI_MGMT_RAW_SCAN_RESULT_LENGTH];
 };
 #endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+
+/* for use in max info size calculations */
+union wifi_mgmt_events {
+	struct wifi_scan_result scan_result;
+	struct wifi_status connect_status;
+	struct wifi_iface_status iface_status;
+#ifdef CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS
+	struct wifi_raw_scan_result raw_scan_result;
+#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+	struct wifi_twt_params twt_params;
+};
+
+
 #include <zephyr/net/net_if.h>
 
 /** Scan result callback

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -20,7 +20,7 @@
 #include <zephyr/net/net_event.h>
 
 #ifdef CONFIG_NET_L2_WIFI_MGMT
-/* For struct wifi_scan_result */
+/* For union wifi_mgmt_events */
 #include <zephyr/net/wifi_mgmt.h>
 #endif /* CONFIG_NET_L2_WIFI_MGMT */
 
@@ -31,10 +31,7 @@ union net_mgmt_events {
 	struct net_if_dhcpv4 dhcpv4;
 #endif /* CONFIG_NET_DHCPV4 */
 #if defined(CONFIG_NET_L2_WIFI_MGMT)
-	struct wifi_scan_result wifi_scan_result;
-#if defined(CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS)
-	struct wifi_raw_scan_result raw_scan_result;
-#endif /* CONFIG_WIFI_MGMT_RAW_SCAN_RESULTS */
+	union wifi_mgmt_events wifi;
 #endif /* CONFIG_NET_L2_WIFI_MGMT */
 #if defined(CONFIG_NET_IPV6) && defined(CONFIG_NET_IPV6_MLD)
 	struct net_event_ipv6_route ipv6_route;


### PR DESCRIPTION
Bug: net_iface_status is larger than scan_result, causing net_iface events to be dropped due to info size exceeding NET_EVENT_INFO_MAX_SIZE.