### PR TITLE
[nrf fromtree] mcumgr: img_mgmt_client: Fix Image upload max len

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt_client/src/img_mgmt_client.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt_client/src/img_mgmt_client.c
@@ -345,9 +345,11 @@ int img_mgmt_client_upload(struct img_mgmt_client *client, const uint8_t *data, 
 
 	request_length = length;
 	wrote_length = 0;
-	/* Calculate max data length based on net_buf size - (SMP header + CBOR message_len) */
+	/* Calculate max data length based on
+	 * net_buf size - (SMP header + CBOR message_len + 16-bit CRC + 16-bit length)
+	 */
 	max_data_length = CONFIG_MCUMGR_TRANSPORT_NETBUF_SIZE -
-			  (active_client->upload.upload_header_size + MGMT_HDR_SIZE);
+			  (active_client->upload.upload_header_size + MGMT_HDR_SIZE + 2U + 2U);
 	/* Trim length based on CONFIG_MCUMGR_GRP_IMG_UPLOAD_DATA_ALIGNMENT_SIZE */
 	if (max_data_length % CONFIG_MCUMGR_GRP_IMG_UPLOAD_DATA_ALIGNMENT_SIZE) {
 		max_data_length -=


### PR DESCRIPTION
MCUmgr client upload max data payload length was missing Transport layer CRC + 16bit lenght. Full net buf packet was possible to send but receiver side it was blocked because there was not space for calculate CRC and length.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>
(cherry picked from commit ea84ef55dad978a026ee928c6b272098b657c9bf)