### PR TITLE
[nrf fromtree] manifest: Upgrade to trusted-firmware-m 1.8.0

### DIFF
--- a/modules/mbedtls/CMakeLists.txt
+++ b/modules/mbedtls/CMakeLists.txt
@@ -52,7 +52,6 @@ zephyr_interface_library_named(mbedTLS)
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/cipher.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/cipher_wrap.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/cmac.c
-      ${ZEPHYR_CURRENT_MODULE_DIR}/library/code_share.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/ctr_drbg.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/debug.c
       ${ZEPHYR_CURRENT_MODULE_DIR}/library/des.c

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -214,7 +214,6 @@ if (CONFIG_BUILD_WITH_TFM)
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_platform_api.c
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_ps_api.c
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_psa_ns_api.c
-    ${TFM_INTERFACE_SOURCE_DIR}/tfm_psa_ns_connection_api.c
 
     # Specific to nordic_nrf platform
     ${TFM_INTERFACE_SOURCE_DIR}/tfm_ioctl_core_ns_api.c
@@ -409,7 +408,6 @@ if (CONFIG_BUILD_WITH_TFM)
     zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_INITIAL_ATTESTATION      ${TFM_INTERFACE_SOURCE_DIR}/tfm_attest_api.c)
     zephyr_library_sources_ifdef(CONFIG_TFM_PARTITION_FIRMWARE_UPDATE          ${TFM_INTERFACE_SOURCE_DIR}/tfm_fwu_api.c)
 
-    zephyr_library_sources_ifdef(CONFIG_TFM_CONNECTION_BASED_SERVICE_API       ${TFM_INTERFACE_SOURCE_DIR}/tfm_psa_ns_connection_api.c)
     zephyr_library_sources(${TFM_INTERFACE_SOURCE_DIR}/tfm_psa_ns_api.c)
 
     if(CONFIG_SOC_FAMILY_NRF)

--- a/modules/trusted-firmware-m/interface/interface.c
+++ b/modules/trusted-firmware-m/interface/interface.c
@@ -74,7 +74,7 @@ int32_t tfm_ns_interface_dispatch(veneer_fn fn,
 	return result;
 }
 
-enum tfm_status_e tfm_ns_interface_init(void)
+uint32_t tfm_ns_interface_init(void)
 {
 	/*
 	 * The static K_MUTEX_DEFINE handles mutex initialization,

--- a/west.yml
+++ b/west.yml
@@ -263,7 +263,7 @@ manifest:
       revision: 8e303c264fc21c2116dc612658003a22e933124d
       path: modules/lib/lz4
     - name: mbedtls
-      revision: 6e7841e5a08eb5da3c82dbc8b6b6d82ae4b7d2a0
+      revision: c38dc78d9a8dcbe43b898cc1171ab33ba3e6fc26
       path: modules/crypto/mbedtls
       groups:
         - crypto
@@ -318,7 +318,7 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      revision: 79a6115d3a8d0e04864ae8156c1dc8532b750f5a
+      revision: 8b6146261fe2c0ad61154e20c7e338601eae2208
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee
@@ -328,7 +328,7 @@ manifest:
       groups:
         - tee
     - name: tf-m-tests
-      revision: 0f80a65193ddbbe3f0ac38b33b07b26138c11fa7
+      revision: a878426da78fbd1486dfc29d6c6b82be4ee79e72
       path: modules/tee/tf-m/tf-m-tests
       groups:
         - tee


### PR DESCRIPTION
Update trusted-firmware-m to 1.8.0, mbedtls to 3.4.0, and tf-m-tests to 1.8.0.  Includes minor cmake changes due to file renames and such, as well as adjusting the return type of a callback function that has changed since the previous version of trusted-firmware-m.


(cherry picked from commit 3b3e28aedaf8f30b03eb1e1753d9ab34d34c5d99)