### PR TITLE
[nrf noup] modules: mbedtls: Add missing PSA key types configurations

### DIFF
--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -36,6 +36,10 @@ config PSA_HAS_KEY_SUPPORT
 	default y
 	depends on PSA_WANT_KEY_TYPE_DERIVE		|| \
 		   PSA_WANT_KEY_TYPE_HMAC		|| \
+		   PSA_WANT_KEY_TYPE_RAW_DATA		|| \
+		   PSA_WANT_KEY_TYPE_PASSWORD		|| \
+		   PSA_WANT_KEY_TYPE_PASSWORD_HASH	|| \
+		   PSA_WANT_KEY_TYPE_PEPPER             || \
 		   PSA_WANT_KEY_TYPE_AES 		|| \
 		   PSA_WANT_KEY_TYPE_CHACHA20		|| \
 		   PSA_WANT_KEY_TYPE_ECC_KEY_PAIR	|| \
@@ -61,6 +65,21 @@ config PSA_WANT_KEY_TYPE_HMAC
 	bool "PSA HMAC key type support"
 	help
 	  HMAC key.
+
+config PSA_WANT_KEY_TYPE_PASSWORD
+	bool "PSA password key type support"
+	help
+	  A low-entropy secret for password hashing or key derivation.
+
+config PSA_WANT_KEY_TYPE_PASSWORD_HASH
+	bool "PSA password hash key type support"
+	help
+	  A secret value that can be used to verify a password hash.
+
+config PSA_WANT_KEY_TYPE_PEPPER
+	bool "PSA pepper key type support"
+	help
+	  A secret value that can be used when computing a password hash.
 
 config PSA_WANT_KEY_TYPE_AES
 	bool "PSA AES key type support"


### PR DESCRIPTION
fixup! [nrf noup] modules: mbedtls: add PSA configurations

Add missing PSA key types configurations.
These configurations are needed to satisfy the PSA_HAS_KEY_TYPE_SUPPORT hidden configuration.

NCSDK-22424