### PR TITLE
[nrf fromlist] net: socketpair: Fix use after free

### DIFF
--- a/subsys/net/lib/sockets/socketpair.c
+++ b/subsys/net/lib/sockets/socketpair.c
@@ -186,6 +186,10 @@ static void spair_delete(struct spair *spair)
 	res = k_poll_signal_raise(&spair->writeable, SPAIR_SIG_CANCEL);
 	__ASSERT(res == 0, "k_poll_signal_raise() failed: %d", res);
 
+	if (remote != NULL && have_remote_sem) {
+		k_sem_give(&remote->sem);
+	}
+
 	/* ensure no private information is released to the memory pool */
 	memset(spair, 0, sizeof(*spair));
 #ifdef CONFIG_USERSPACE
@@ -193,10 +197,6 @@ static void spair_delete(struct spair *spair)
 #else
 	k_free(spair);
 #endif
-
-	if (remote != NULL && have_remote_sem) {
-		k_sem_give(&remote->sem);
-	}
 }
 
 /**

--- a/tests/net/socket/socketpair/testcase.yaml
+++ b/tests/net/socket/socketpair/testcase.yaml
@@ -6,12 +6,15 @@ common:
   depends_on: netif
   min_ram: 21
 tests:
-  net.socket.socketpair: {}
+  net.socket.socketpair:
+    platform_exclude: vmu_rt1170 mimxrt1160_evk_cm7 # See #61246
   net.socket.socketpair.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
+    platform_exclude: vmu_rt1170 mimxrt1160_evk_cm7 # See #61246
   net.socket.socketpair.picolibc:
     filter: CONFIG_PICOLIBC_SUPPORTED
     extra_configs:
       - CONFIG_PICOLIBC=y
+    platform_exclude: vmu_rt1170 mimxrt1160_evk_cm7 # See #61246

--- a/tests/net/socket/socketpair/testcase.yaml
+++ b/tests/net/socket/socketpair/testcase.yaml
@@ -18,3 +18,10 @@ tests:
     extra_configs:
       - CONFIG_PICOLIBC=y
     platform_exclude: vmu_rt1170 mimxrt1160_evk_cm7 # See #61246
+  net.socket.socketpair.high_mem:
+    extra_configs:
+      # Low buffer sizes (e.g., 8192) will verify the crash fix, but tests will still
+      # fail due to insufficient memory. So, use high buffer sizes.
+      - CONFIG_NET_SOCKETPAIR_BUFFER_SIZE=4096
+      - CONFIG_HEAP_MEM_POOL_SIZE=32768
+    platform_exclude: vmu_rt1170 mimxrt1160_evk_cm7 # See #61246


### PR DESCRIPTION
    net: socketpair: Fix use after free
    
    In low memory conditions, its possible for socketpair memory allocation
    to fail and then the socketpair is freed but after that the remote
    semaphore is released causing a crash.
    
    Fix this by freeing the socketpair after releasing the semaphore. Add a
    test case to induce low memory conditions (low HEAP and high socketpair
    buffer size), with the fix issue is not seen.
