### PR TITLE
[nrf fromlist] drivers/flash/nrf: Workaround for nrf91 errata 7

### DIFF
--- a/drivers/flash/soc_flash_nrf.c
+++ b/drivers/flash/soc_flash_nrf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018 Nordic Semiconductor ASA
+ * Copyright (c) 2017-2023 Nordic Semiconductor ASA
  * Copyright (c) 2016 Linaro Limited
  * Copyright (c) 2016 Intel Corporation
  *
@@ -121,6 +121,26 @@ static inline bool is_uicr_addr_valid(off_t addr, size_t len)
 #endif /* CONFIG_SOC_FLASH_NRF_UICR */
 }
 
+#if CONFIG_SOC_FLASH_NRF_UICR && IS_ENABLED(NRF91_ERRATA_7_ENABLE_WORKAROUND)
+static inline void nrf91_errata_7_enter(void)
+{
+	__disable_irq();
+}
+
+static inline void nrf91_errata_7_exit(void)
+{
+	__DSB();
+	__enable_irq();
+}
+
+static void nrf_buffer_read_91_uicr(void *data, off_t addr, size_t len)
+{
+	nrf91_errata_7_enter();
+	nrf_nvmc_buffer_read(data, (uint32_t)addr, len);
+	nrf91_errata_7_exit();
+}
+#endif
+
 static void nvmc_wait_ready(void)
 {
 	while (!nrfx_nvmc_write_done_check()) {
@@ -130,9 +150,11 @@ static void nvmc_wait_ready(void)
 static int flash_nrf_read(const struct device *dev, off_t addr,
 			    void *data, size_t len)
 {
+	const bool within_uicr = is_uicr_addr_valid(addr, len);
+
 	if (is_regular_addr_valid(addr, len)) {
 		addr += DT_REG_ADDR(SOC_NV_FLASH_NODE);
-	} else if (!is_uicr_addr_valid(addr, len)) {
+	} else if (!within_uicr) {
 		LOG_ERR("invalid address: 0x%08lx:%zu",
 				(unsigned long)addr, len);
 		return -EINVAL;
@@ -145,6 +167,12 @@ static int flash_nrf_read(const struct device *dev, off_t addr,
 #if CONFIG_TRUSTED_EXECUTION_NONSECURE && USE_PARTITION_MANAGER && PM_APP_ADDRESS
 	if (addr < PM_APP_ADDRESS) {
 		return soc_secure_mem_read(data, (void *)addr, len);
+	}
+#endif
+#if CONFIG_SOC_FLASH_NRF_UICR && IS_ENABLED(NRF91_ERRATA_7_ENABLE_WORKAROUND)
+	if (within_uicr) {
+		nrf_buffer_read_91_uicr(data, (uint32_t)addr, len);
+		return 0;
 	}
 #endif
 


### PR DESCRIPTION
Fix UICR read access.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/62873

(cherry picked from commit b9ffe72133e90453d275cc80b88f95b29002ec60)
Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>