### PR TITLE
[nrf noup] tree-wide: Fix malloc heap-size with partition manager enabled

### DIFF
--- a/lib/libc/common/source/stdlib/malloc.c
+++ b/lib/libc/common/source/stdlib/malloc.c
@@ -23,6 +23,20 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
+#if USE_PARTITION_MANAGER
+
+#include <pm_config.h>
+
+#define RAM_SIZE PM_SRAM_SIZE
+#define RAM_ADDR PM_SRAM_ADDRESS
+
+#else /* ! USE_PARTITION_MANAGER */
+
+#define RAM_SIZE (KB((size_t) CONFIG_SRAM_SIZE))
+#define RAM_ADDR CONFIG_SRAM_BASE_ADDRESS
+
+#endif /* USE_PARTITION_MANAGER */
+
 #ifdef CONFIG_COMMON_LIBC_MALLOC
 
 #if (CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE != 0)
@@ -104,8 +118,8 @@ static POOL_SECTION unsigned char __aligned(HEAP_ALIGN) malloc_arena[HEAP_SIZE];
 extern char _heap_sentry[];
 #    define HEAP_SIZE  ROUND_DOWN((POINTER_TO_UINT(_heap_sentry) - HEAP_BASE), HEAP_ALIGN)
 #   else
-#    define HEAP_SIZE	ROUND_DOWN((KB((size_t) CONFIG_SRAM_SIZE) -	\
-		((size_t) HEAP_BASE - (size_t) CONFIG_SRAM_BASE_ADDRESS)), HEAP_ALIGN)
+#    define HEAP_SIZE	ROUND_DOWN((RAM_SIZE -	\
+		((size_t) HEAP_BASE - (size_t) RAM_ADDR)), HEAP_ALIGN)
 #   endif /* else CONFIG_XTENSA */
 
 #  endif /* else CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE > 0 */

--- a/lib/os/Kconfig.heap
+++ b/lib/os/Kconfig.heap
@@ -51,7 +51,7 @@ config HEAP_LISTENER
 choice
 	prompt "Supported heap sizes"
 	depends on !64BIT
-	default SYS_HEAP_SMALL_ONLY if (SRAM_SIZE <= 256)
+	default SYS_HEAP_SMALL_ONLY if (SRAM_SIZE <= 256) && !PARTITION_MANAGER_ENABLED
 	default SYS_HEAP_AUTO
 	help
 	  Heaps using reduced-size chunk headers can accommodate so called


### PR DESCRIPTION
fixup! [nrf noup] tree-wide: support NCS Partition Manager (PM) definitions

The configurations SRAM_SIZE and SRAM_BASE_ADDRESS use devicetree definitions. These are not matching the partition manager configuration. Use partition manager values in malloc heap size calculations. Don't trust the value of SRAM_SIZE to determine if only small heaps needs to be supported.