### PR TITLE
[nrf noup] Fix use of undefined Kconfig symbols

### DIFF
--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -6,6 +6,14 @@
 config ZEPHYR_MBEDTLS_MODULE
 	bool
 
+# Forward declare config symbols to pass Kconfig compliance
+config NORDIC_SECURITY_BACKEND
+	bool
+	depends on SOC_FAMILY_NRF
+config NRF_SECURITY
+	bool
+	depends on SOC_FAMILY_NRF
+
 config MBEDTLS_PROMPTLESS
 	bool
 	help

--- a/modules/mbedtls/Kconfig.psa
+++ b/modules/mbedtls/Kconfig.psa
@@ -3,6 +3,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
+
+# Forward declare config symbol to pass Kconfig compliance
+config PSA_PROMPTLESS
+	bool
+
 menu "PSA RNG support"
 
 config PSA_WANT_GENERATE_RANDOM

--- a/subsys/net/conn_mgr/Kconfig
+++ b/subsys/net/conn_mgr/Kconfig
@@ -1,6 +1,10 @@
 # Copyright (c) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+# Forward declare config symbol to pass Kconfig compliance
+config WPA_SUPP
+	bool
+
 menuconfig NET_CONNECTION_MANAGER
 	bool "Network connection manager [EXPERIMENTAL]"
 	depends on NET_IPV6 || NET_IPV4


### PR DESCRIPTION
Kconfig compliance is run with Zephyr Kconfig as the root Kconfig file.
Because of this a number of of Kconfig symbols applied in noup commits are not defined and compliance complains.

Fix this issue by forward declaring these Kconfig symbols.