### PR TITLE
[nrf fromtree] Hci iso data packets fragmentation fix

### DIFF
--- a/subsys/bluetooth/Kconfig.iso
+++ b/subsys/bluetooth/Kconfig.iso
@@ -99,6 +99,10 @@ config BT_ISO_TX_MTU
 	range 1 4095
 	help
 	  Maximum MTU for Isochronous channels TX buffers.
+	  This is the actual data payload. It doesn't include the optional
+	  HCI ISO Data packet fields (e.g. `struct bt_hci_iso_ts_data_hdr`).
+	  Set this value to 247 to fit 247 bytes of data within a single
+	  HCI ISO Data packet with a size of 255, without utilizing timestamps.
 
 config BT_ISO_RX_BUF_COUNT
 	int "Number of Isochronous RX buffers"
@@ -113,6 +117,8 @@ config BT_ISO_RX_MTU
 	range 23 4095
 	help
 	  Maximum MTU for Isochronous channels RX buffers.
+	  This is the actual data payload. It doesn't include the optional
+	  HCI ISO Data packet fields (e.g. `struct bt_hci_iso_ts_data_hdr`)
 
 config BT_ISO_ADVANCED
 	bool "Advanced ISO parameters"

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -2582,18 +2582,10 @@ static uint8_t tx_cmplt_get(uint16_t *handle, uint8_t *first, uint8_t last)
 			/* We must count each SDU HCI fragment */
 			tx_node = tx->node;
 			if (IS_NODE_TX_PTR(tx_node)) {
-				if (IS_ADV_ISO_HANDLE(tx->handle)) {
-					/* FIXME: ADV_ISO shall be updated to
-					 * use ISOAL for TX. Until then, assume
-					 * 1 node equals 1 fragment.
-					 */
-					sdu_fragments = 1U;
-				} else {
-					/* We count each SDU fragment completed
-					 * by this PDU.
-					 */
-					sdu_fragments = tx_node->sdu_fragments;
-				}
+				/* We count each SDU fragment completed
+				 * by this PDU.
+				 */
+				sdu_fragments = tx_node->sdu_fragments;
 
 				/* Replace node reference with fragments
 				 * count

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -711,6 +711,7 @@ static struct net_buf *create_frag(struct bt_conn *conn, struct net_buf *buf)
 	/* Fragments never have a TX completion callback */
 	tx_data(frag)->tx = NULL;
 	tx_data(frag)->is_cont = false;
+	tx_data(frag)->iso_has_ts = tx_data(buf)->iso_has_ts;
 
 	return frag;
 }


### PR DESCRIPTION
PR contains four commits:

1st commit fixes Zephyr LL controller to pass bsim tests after the following changes in Host
2nd commit fixes calculations of HCI ISO Data packet length
3rd commit fixes timestamp value for SDUs fragmented to several HCI ISO Data packets
4th commit fixes KConfig descriptions of BT_ISO_TX_MTU and BT_ISO_RX_MTU
