### PR TITLE
net: l2: wifi: Fix Wi-Fi mode get command bug

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1302,7 +1302,7 @@ void parse_mode_args_to_params(const struct shell *sh, int argc,
 			mode->mode |= WIFI_SOFTAP_MODE;
 			break;
 		case 'g':
-			mode->oper = true;
+			mode->oper = WIFI_MGMT_GET;
 			break;
 		case 'i':
 			mode->if_index = (uint8_t)atoi(optarg);


### PR DESCRIPTION
The mode command operation has to be set to WIFI_MGMT_GET when the option -g is provided. It was mistakenly set to true. Correcting the same

This PR fixes #63424 and sets the proper value for the get command

Signed-off-by: Vivekananda Uppunda <vivekananda.uppunda@nordicsemi.no>
(cherry picked from commit b0c96580298ac47715fdb1d1ba5ede766676d643)