### PR TITLE
[nrf noup] modules: mbedtls: Disable mbedtls_hardware_poll with CC3xx…

### DIFF
--- a/modules/mbedtls/zephyr_init.c
+++ b/modules/mbedtls/zephyr_init.c
@@ -45,7 +45,7 @@ static void init_heap(void)
 #define init_heap(...)
 #endif /* CONFIG_MBEDTLS_ENABLE_HEAP && MBEDTLS_MEMORY_BUFFER_ALLOC_C */
 
-#if defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY)
+#if defined(CONFIG_MBEDTLS_ZEPHYR_ENTROPY) && !defined(CONFIG_NRF_CC3XX_PLATFORM)
 static const struct device *const entropy_dev =
 			DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_entropy));
 


### PR DESCRIPTION
… enabled

squash! [nrf noup] modules: mbedtls: Disable configurations in Kconfig.tls-generic

Precompiled CC3xx libraries silently provide mbedtls_hardware_poll function (used internally by the library on initialization), which creates ambiguity with Zephyr-provided implementation. In result, the CC3xx entropy source is broken when CONFIG_MBEDTLS_ZEPHYR_ENTROPY is enabled. Workaround this, by disabling the Zephyr implementation if CC3xx is enabled, and let mbed TLS use the implementation from the CC library instead.