### PR TITLE
[nrf fromtree] A few upstream fixes for NCS 2.5

### DIFF
--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -170,6 +170,8 @@ static int transceive(const struct device *dev,
 {
 	struct spi_nrfx_data *dev_data = dev->data;
 	const struct spi_nrfx_config *dev_config = dev->config;
+	const struct spi_buf *tx_buf = tx_bufs ? tx_bufs->buffers : NULL;
+	const struct spi_buf *rx_buf = rx_bufs ? rx_bufs->buffers : NULL;
 	int error;
 
 	spi_context_lock(&dev_data->ctx, asynchronous, cb, userdata, spi_cfg);
@@ -181,8 +183,7 @@ static int transceive(const struct device *dev,
 		   (rx_bufs && rx_bufs->count > 1)) {
 		LOG_ERR("Scattered buffers are not supported");
 		error = -ENOTSUP;
-	} else if (tx_bufs && tx_bufs->buffers[0].len &&
-		   !nrfx_is_in_ram(tx_bufs->buffers[0].buf)) {
+	} else if (tx_buf && tx_buf->len && !nrfx_is_in_ram(tx_buf->buf)) {
 		LOG_ERR("Only buffers located in RAM are supported");
 		error = -ENOTSUP;
 	} else {
@@ -193,10 +194,10 @@ static int transceive(const struct device *dev,
 		}
 
 		error = prepare_for_transfer(dev,
-				tx_bufs ? tx_bufs->buffers[0].buf : NULL,
-				tx_bufs ? tx_bufs->buffers[0].len : 0,
-				rx_bufs ? rx_bufs->buffers[0].buf : NULL,
-				rx_bufs ? rx_bufs->buffers[0].len : 0);
+					     tx_buf ? tx_buf->buf : NULL,
+					     tx_buf ? tx_buf->len : 0,
+					     rx_buf ? rx_buf->buf : NULL,
+					     rx_buf ? rx_buf->len : 0);
 		if (error == 0) {
 			if (dev_config->wake_gpio.port) {
 				/* Set the WAKE line low (tie it to ground)

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -282,6 +282,7 @@ endif # BT_ASSERT
 
 config BT_MONITOR
 	bool
+	select LOG_OUTPUT
 
 choice BT_DEBUG_TYPE
 	prompt "Bluetooth debug type"

--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -121,6 +121,17 @@ static void do_test_using(void (*sample_collection_fn)(void))
 
 	periodic_idx = 0;
 	k_sem_init(&periodic_sem, 0, 1);
+
+	/* Align to tick boundary. Otherwise the first handler execution
+	 * might turn out to be significantly late and cause the test to
+	 * fail. This can happen if k_timer_start() is called right before
+	 * the upcoming tick boundary and in consequence the tick passes
+	 * between the moment when the kernel decides what tick to use for
+	 * the next timeout and the moment when the system timer actually
+	 * sets up that timeout.
+	 */
+	k_sleep(K_TICKS(1));
+
 	sample_collection_fn();
 	k_sem_take(&periodic_sem, K_FOREVER);
 


### PR DESCRIPTION
- drivers: spi_nrfx_spis: Handle empty spi_buf_set structures properly
- tests: kernel: timer: jitter_drift: Restore initial alignment to tick
- bluetooth: common: Kconfig: Add missing dependency for BT_MONITOR