### PR TITLE
[nrf noup] ci: Allow non-github upstream PRs

### DIFF
--- a/scripts/gitlint/ncs.py
+++ b/scripts/gitlint/ncs.py
@@ -46,7 +46,7 @@ class NCSSauceTags(CommitRule):
                     commit.message.title):
                 return [RuleViolation(self.id, 'Invalid mergeup commit title')]
         elif tag == 'fromlist':
-            regex = r'^Upstream PR: https://github\.com/.*/pull/\d+'
+            regex = r'^Upstream PR: .*'
             matches = re.findall(regex, '\n'.join(commit.message.body), re.MULTILINE)
             if len(matches) == 0:
                 return [RuleViolation(self.id,


### PR DESCRIPTION
fixup! [nrf noup] ci: NCS-specific CI tweaks

OSS projects still use mailing-lists, so, using a URL for patchwork or a mailing should be allowed instead of failing.

The regex is made too wide intentionally to allow all sorts, even the http URLs.