### PR TITLE
[nrf fromlist] manifest: update hal_nordic rev to fix nRF91 anomaly 7

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 092eb78ed1b1551d8f480019b9c05d7371784578
+      revision: 568a5e90b858a2e5b640b3fe6ab9b59dd2ce9f7f
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
New hal_nordic revision contains updated nrfx with an improvement to nRF91 anomaly 7 workaround.

Upstream PR: zephyrproject-rtos/zephyr#63841