### PR TITLE
[nrf fromlist] modules: hal_nordic: cmake: Fix checking if uicr DT no…

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -116,7 +116,7 @@ endif()
 # doing the proper configuration sequence during system init
 
 dt_nodelabel(uicr_path NODELABEL "uicr")
-if(${uicr_path})
+if(DEFINED uicr_path)
   dt_prop(nfct_pins_as_gpios PATH ${uicr_path} PROPERTY "nfct-pins-as-gpios")
   if(${nfct_pins_as_gpios})
     zephyr_library_compile_definitions(CONFIG_NFCT_PINS_AS_GPIOS)


### PR DESCRIPTION
…de is accessible

According to cmake documentation, in the `if(<string>)` expression the string evaluates to false unless its value is one of the true constants. Thus, the commands under `if(${uicr_path})` are never executed. Use `if(DEFINED uicr_path)` instead, since `uicr_path` is returned by `dt_nodelabel()` and it will be undefined if such node does not exist.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/63929