### PR TITLE
[nrf fromlist] manifest: update hal_nordic to fix nRF52820 nrfx_gpiote

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 568a5e90b858a2e5b640b3fe6ab9b59dd2ce9f7f
+      revision: 427ee1a519e8a0844d0f78f7cbc8cdfc134ef00d
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
New hal_nordic revision contains updated nrfx
with a fix to GPIOTE driver array out-of-bounds
access on nRF52820.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/64014