### PR TITLE
[nrf fromlist] Bluetooth: Mesh: FU Server should not update internal …

### DIFF
--- a/subsys/bluetooth/mesh/dfu_srv.c
+++ b/subsys/bluetooth/mesh/dfu_srv.c
@@ -302,10 +302,10 @@ static int handle_start(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 			status = BT_MESH_DFU_ERR_WRONG_PHASE;
 		} else {
 			status = BT_MESH_DFU_SUCCESS;
+			srv->update.ttl = ttl;
+			srv->blob.state.xfer.id = blob_id;
 		}
 
-		srv->update.ttl = ttl;
-		srv->blob.state.xfer.id = blob_id;
 		LOG_WRN("Busy. Phase: %u", srv->update.phase);
 		goto rsp;
 	}


### PR DESCRIPTION
…state on error

According to conditions in the DFU spec section 6.1.3.7 (Sending a Firmware Update Status message) and in 'Idempotency' part of section 6.1.3.4 (Receiving a Firmware Update Start message), the FU Server should not update internal state when 'Wrong Phase' error condition is triggered.


(cherry picked from commit 4eb401769d9ea1063f2a31f99c7780f303e4855b)