### PR TITLE
testspec: remove HomeKit from NCS

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -131,17 +131,6 @@
 "CI-rs-test":
   - "**/*"
 
-"CI-homekit-test":
-  - "modules/openthread/**/*"
-  - "samples/bluetooth/hci_rpmsg/**/*"
-  - "soc/arm/nordic_nrf/**/*"
-  - "subsys/net/**/*"
-  - "subsys/settings/**/*"
-  - any:
-      - "subsys/bluetooth/**/*"
-      - "!subsys/bluetooth/mesh/**/*"
-      - "!subsys/bluetooth/audio/**/*"
-
 "CI-thread-test":
   - "include/zephyr/net/**/*"
   - "modules/mbedtls/**/*"


### PR DESCRIPTION
HomeKit Accessory Development Kit has been deprecated and removed from NCS.