### PR TITLE
net: openthread: Remove waiting for DTR in openthread UART.

### DIFF
--- a/modules/openthread/platform/uart.c
+++ b/modules/openthread/platform/uart.c
@@ -170,26 +170,11 @@ otError otPlatUartEnable(void)
 
 	if (DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_ot_uart), zephyr_cdc_acm_uart)) {
 		int ret;
-		uint32_t dtr = 0U;
 
 		ret = usb_enable(NULL);
 		if (ret != 0 && ret != -EALREADY) {
 			LOG_ERR("Failed to enable USB");
 			return OT_ERROR_FAILED;
-		}
-
-		LOG_INF("Waiting for host to be ready to communicate");
-
-		/* Data Terminal Ready - check if host is ready to communicate */
-		while (!dtr) {
-			ret = uart_line_ctrl_get(ot_uart.dev,
-						 UART_LINE_CTRL_DTR, &dtr);
-			if (ret) {
-				LOG_ERR("Failed to get Data Terminal Ready line state: %d",
-					ret);
-				continue;
-			}
-			k_msleep(100);
 		}
 
 		/* Data Carrier Detect Modem - mark connection as established */


### PR DESCRIPTION
Uart driver for openthread have been waiting for host to start communicating with coprocessor, during booting of the Zephyr and by that blocking start os OS. There is no longer a need for that since the stack will be soft rebooted after host connects to coprocessor, removing the need to wait on host communication.

Signed-off-by: Przemyslaw Bida <przemyslaw.bida@nordicsemi.no>
(cherry picked from commit cc85223ed4d5907bd457cb8145672c2167821cbf)