### PR TITLE
[nrf noup] ci: Add CI-run-zephyr-twister test spec

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -1,4 +1,19 @@
 # This is the Jenkins ci variant of the .github/labler.yaml
+
+"CI-run-zephyr-twister":
+  - any:
+      - "!.github/**/*"
+      - "!doc/**/*"
+      - "!CODEOWNERS"
+      - "!LICENSE"
+      - "!**/*.rst"
+      - "!VERSION"
+      - "!submanifests/**/*"
+      - "!MAINTAINERS.yml"
+      - "!version.h.in"
+      - "!Jenkinsfile"
+      - "!**/*.md"
+
 "CI-iot-zephyr-lwm2m-test":
   - "drivers/console/**/*"
   - "drivers/flash/**/*"


### PR DESCRIPTION
CI-run-zephyr-twister is used to determine if twister tests from sdk-zephyr should be run on PR to sdk-nrf repository.