### PR TITLE
[nrf fromtree] twister: pytest: Improve reporting and fixtures

### DIFF
--- a/doc/develop/test/pytest.rst
+++ b/doc/develop/test/pytest.rst
@@ -69,6 +69,9 @@ DUT (initialize logging, flash device, connect serial etc).
 This fixture yields a device prepared according to the requested type
 (native posix, qemu, hardware, etc.). All types of devices share the same API.
 This allows for writing tests which are device-type-agnostic.
+Scope of this fixture is determined by the ``pytest_dut_scope``
+keyword placed under ``harness_config`` section.
+
 
 .. code-block:: python
 
@@ -81,8 +84,10 @@ shell
 -----
 
 Provide an object with methods used to interact with shell application.
-It calls `wait_for_promt` method, to not start scenario until DUT is ready.
-Note that it uses `dut` fixture, so `dut` can be skipped when `shell` is used.
+It calls ``wait_for_promt`` method, to not start scenario until DUT is ready.
+Note that it uses ``dut`` fixture, so ``dut`` can be skipped when ``shell`` is used.
+Scope of this fixture is determined by the ``pytest_dut_scope``
+keyword placed under ``harness_config`` section.
 
 .. code-block:: python
 

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -501,6 +501,11 @@ harness_config: <harness configuration options>
     pytest_args: <list of arguments> (default empty)
         Specify a list of additional arguments to pass to ``pytest``.
 
+    pytest_dut_scope: <function|class|module|package|session> (default function)
+        The scope for which ``dut`` and ``shell`` pytest fixtures are shared.
+        If the scope is set to ``function``, DUT is launched for every test case
+        in python script. For ``session`` scope, DUT is launched only once.
+
     robot_test_path: <robot file path> (default empty)
         Specify a path to a file containing a Robot Framework test suite to be run.
 

--- a/samples/subsys/testsuite/pytest/shell/pytest/test_shell.py
+++ b/samples/subsys/testsuite/pytest/shell/pytest/test_shell.py
@@ -4,19 +4,9 @@
 
 import logging
 
-import pytest
-from twister_harness import DeviceAdapter, Shell
+from twister_harness import Shell
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope='function')
-def shell(dut: DeviceAdapter) -> Shell:
-    """Return ready to use shell interface"""
-    shell = Shell(dut, timeout=20.0)
-    logger.info('wait for prompt')
-    assert shell.wait_for_prompt()
-    return shell
 
 
 def test_shell_print_help(shell: Shell):

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/__init__.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/__init__.py
@@ -5,7 +5,7 @@
 # flake8: noqa
 
 from twister_harness.device.device_adapter import DeviceAdapter
-from twister_harness.fixtures.mcumgr import MCUmgr
+from twister_harness.helpers.mcumgr import MCUmgr
 from twister_harness.helpers.shell import Shell
 
 __all__ = ['DeviceAdapter', 'MCUmgr', 'Shell']

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -116,7 +116,6 @@ class HardwareAdapter(DeviceAdapter):
                 stdout_decoded = stdout.decode(errors='ignore')
                 with open(self.device_log_path, 'a+') as log_file:
                     log_file.write(stdout_decoded)
-                logger.debug(f'Flashing output:\n{stdout_decoded}')
             if self.device_config.post_flash_script:
                 self._run_custom_script(self.device_config.post_flash_script, self.base_timeout)
             if process is not None and process.returncode == 0:

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures.py
@@ -10,6 +10,8 @@ import pytest
 from twister_harness.device.device_adapter import DeviceAdapter
 from twister_harness.device.factory import DeviceFactory
 from twister_harness.twister_harness_config import DeviceConfig, TwisterHarnessConfig
+from twister_harness.helpers.shell import Shell
+from twister_harness.helpers.mcumgr import MCUmgr
 
 logger = logging.getLogger(__name__)
 
@@ -44,3 +46,23 @@ def dut(request: pytest.FixtureRequest, device_object: DeviceAdapter) -> Generat
         yield device_object
     finally:  # to make sure we close all running processes execution
         device_object.close()
+
+
+@pytest.fixture(scope='function')
+def shell(dut: DeviceAdapter) -> Shell:
+    """Return ready to use shell interface"""
+    shell = Shell(dut, timeout=20.0)
+    logger.info('Wait for prompt')
+    assert shell.wait_for_prompt()
+    return shell
+
+
+@pytest.fixture(scope='session')
+def is_mcumgr_available() -> None:
+    if not MCUmgr.is_available():
+        pytest.skip('mcumgr not available')
+
+
+@pytest.fixture()
+def mcumgr(is_mcumgr_available: None, dut: DeviceAdapter) -> Generator[MCUmgr, None, None]:
+    yield MCUmgr.create_for_serial(dut.device_config.serial)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures/__init__.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/fixtures/__init__.py
@@ -1,8 +1,0 @@
-# Copyright (c) 2023 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: Apache-2.0
-
-import pytest
-
-pytest.register_assert_rewrite('twister_harness.fixtures.dut')
-pytest.register_assert_rewrite('twister_harness.fixtures.mcumgr')

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/mcumgr.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/mcumgr.py
@@ -3,18 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
-import pytest
 import logging
 import re
 import shlex
 
-from typing import Generator
 from subprocess import check_output, getstatusoutput
 from pathlib import Path
 from dataclasses import dataclass
-
-from twister_harness.device.device_adapter import DeviceAdapter
-
 
 logger = logging.getLogger(__name__)
 
@@ -108,14 +103,3 @@ class MCUmgr:
             image_list = self.get_image_list()
             hash = image_list[0].hash
         self.run_command(f'image confirm {hash}')
-
-
-@pytest.fixture(scope='session')
-def is_mcumgr_available() -> None:
-    if not MCUmgr.is_available():
-        pytest.skip('mcumgr not available')
-
-
-@pytest.fixture()
-def mcumgr(is_mcumgr_available: None, dut: DeviceAdapter) -> Generator[MCUmgr, None, None]:
-    yield MCUmgr.create_for_serial(dut.device_config.serial)

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -100,6 +100,11 @@ def pytest_addoption(parser: pytest.Parser):
         metavar='PATH',
         help='Script executed after closing serial connection.'
     )
+    twister_harness_group.addoption(
+        '--dut-scope',
+        choices=('function', 'class', 'module', 'package', 'session'),
+        help='The scope for which `dut` and `shell` fixtures are shared.'
+    )
 
 
 def pytest_configure(config: pytest.Config):

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -14,8 +14,7 @@ from twister_harness.twister_harness_config import TwisterHarnessConfig
 logger = logging.getLogger(__name__)
 
 pytest_plugins = (
-    'twister_harness.fixtures.dut',
-    'twister_harness.fixtures.mcumgr'
+    'twister_harness.fixtures'
 )
 
 

--- a/scripts/pylib/pytest-twister-harness/tests/fixtures/mcumgr_fixture_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/fixtures/mcumgr_fixture_test.py
@@ -6,7 +6,7 @@ import pytest
 import textwrap
 
 from unittest import mock
-from twister_harness.fixtures.mcumgr import MCUmgr, MCUmgrException
+from twister_harness.helpers.mcumgr import MCUmgr, MCUmgrException
 
 
 @pytest.fixture(name='mcumgr')
@@ -14,7 +14,7 @@ def fixture_mcumgr() -> MCUmgr:
     return MCUmgr.create_for_serial('SERIAL_PORT')
 
 
-@mock.patch('twister_harness.fixtures.mcumgr.MCUmgr.run_command', return_value='')
+@mock.patch('twister_harness.helpers.mcumgr.MCUmgr.run_command', return_value='')
 def test_if_mcumgr_fixture_generate_proper_command(
     patched_run_command: mock.Mock, mcumgr: MCUmgr
 ) -> None:

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -247,6 +247,7 @@ class Pytest(Harness):
         config = self.instance.testsuite.harness_config
         pytest_root = config.get('pytest_root', ['pytest']) if config else ['pytest']
         pytest_args = config.get('pytest_args', []) if config else []
+        pytest_dut_scope = config.get('pytest_dut_scope', None) if config else None
         command = [
             'pytest',
             '--twister-harness',
@@ -260,6 +261,8 @@ class Pytest(Harness):
         command.extend([os.path.normpath(os.path.join(
             self.source_dir, os.path.expanduser(os.path.expandvars(src)))) for src in pytest_root])
         command.extend(pytest_args)
+        if pytest_dut_scope:
+            command.append(f'--dut-scope={pytest_dut_scope}')
 
         handler: Handler = self.instance.handler
 
@@ -406,7 +409,7 @@ class Pytest(Harness):
             self.instance.execution_time = float(elem_ts.get('time'))
 
             for elem_tc in elem_ts.findall('testcase'):
-                tc = self.instance.get_case_or_create(f"{self.id}.{elem_tc.get('name')}")
+                tc = self.instance.add_testcase(f"{self.id}.{elem_tc.get('name')}")
                 tc.duration = float(elem_tc.get('time'))
                 elem = elem_tc.find('*')
                 if elem is None:

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -400,8 +400,10 @@ class Pytest(Harness):
         if elem_ts := root.find('testsuite'):
             if elem_ts.get('failures') != '0':
                 self.state = 'failed'
+                self.instance.reason = f"{elem_ts.get('failures')}/{elem_ts.get('tests')} pytest scenario(s) failed"
             elif elem_ts.get('errors') != '0':
                 self.state = 'error'
+                self.instance.reason = 'Error during pytest execution'
             elif elem_ts.get('skipped') == elem_ts.get('tests'):
                 self.state = 'skipped'
             else:

--- a/scripts/pylib/twister/twisterlib/reports.py
+++ b/scripts/pylib/twister/twisterlib/reports.py
@@ -246,6 +246,7 @@ class Reporting:
         for instance in self.instances.values():
             suite = {}
             handler_log = os.path.join(instance.build_dir, "handler.log")
+            pytest_log = os.path.join(instance.build_dir, "twister_harness.log")
             build_log = os.path.join(instance.build_dir, "build.log")
             device_log = os.path.join(instance.build_dir, "device.log")
 
@@ -284,7 +285,9 @@ class Reporting:
                 suite['status'] = instance.status
                 suite["reason"] = instance.reason
                 # FIXME
-                if os.path.exists(handler_log):
+                if os.path.exists(pytest_log):
+                    suite["log"] = self.process_log(pytest_log)
+                elif os.path.exists(handler_log):
                     suite["log"] = self.process_log(handler_log)
                 elif os.path.exists(device_log):
                     suite["log"] = self.process_log(device_log)

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -40,6 +40,9 @@ if sys.platform == 'linux':
 
 from twisterlib.log_helper import log_command
 from twisterlib.testinstance import TestInstance
+from twisterlib.environment import TwisterEnv
+from twisterlib.testsuite import TestSuite
+from twisterlib.platform import Platform
 from twisterlib.testplan import change_skip_to_error_if_integration
 from twisterlib.harness import HarnessImporter, Pytest
 
@@ -220,7 +223,7 @@ class CMake:
     config_re = re.compile('(CONFIG_[A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
     dt_re = re.compile('([A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
 
-    def __init__(self, testsuite, platform, source_dir, build_dir, jobserver):
+    def __init__(self, testsuite: TestSuite, platform: Platform, source_dir, build_dir, jobserver):
 
         self.cwd = None
         self.capture_output = True
@@ -414,7 +417,7 @@ class CMake:
 
 class FilterBuilder(CMake):
 
-    def __init__(self, testsuite, platform, source_dir, build_dir, jobserver):
+    def __init__(self, testsuite: TestSuite, platform: Platform, source_dir, build_dir, jobserver):
         super().__init__(testsuite, platform, source_dir, build_dir, jobserver)
 
         self.log = "config-twister.log"
@@ -517,7 +520,7 @@ class FilterBuilder(CMake):
 
 class ProjectBuilder(FilterBuilder):
 
-    def __init__(self, instance, env, jobserver, **kwargs):
+    def __init__(self, instance: TestInstance, env: TwisterEnv, jobserver, **kwargs):
         super().__init__(instance.testsuite, instance.platform, instance.testsuite.source_dir, instance.build_dir, jobserver)
 
         self.log = "build.log"
@@ -527,8 +530,7 @@ class ProjectBuilder(FilterBuilder):
         self.env = env
         self.duts = None
 
-    @staticmethod
-    def log_info(filename, inline_logs):
+    def log_info(self, filename, inline_logs, log_testcases=False):
         filename = os.path.abspath(os.path.realpath(filename))
         if inline_logs:
             logger.info("{:-^100}".format(filename))
@@ -542,6 +544,17 @@ class ProjectBuilder(FilterBuilder):
             logger.error(data)
 
             logger.info("{:-^100}".format(filename))
+
+            if log_testcases:
+                for tc in self.instance.testcases:
+                    if not tc.reason:
+                        continue
+                    logger.info(
+                        f"\n{str(tc.name).center(100, '_')}\n"
+                        f"{tc.reason}\n"
+                        f"{100*'_'}\n"
+                        f"{tc.output}"
+                    )
         else:
             logger.error("see: " + Fore.YELLOW + filename + Fore.RESET)
 
@@ -551,9 +564,12 @@ class ProjectBuilder(FilterBuilder):
         b_log = "{}/build.log".format(build_dir)
         v_log = "{}/valgrind.log".format(build_dir)
         d_log = "{}/device.log".format(build_dir)
+        pytest_log = "{}/twister_harness.log".format(build_dir)
 
         if os.path.exists(v_log) and "Valgrind" in self.instance.reason:
             self.log_info("{}".format(v_log), inline_logs)
+        elif os.path.exists(pytest_log) and os.path.getsize(pytest_log) > 0:
+            self.log_info("{}".format(pytest_log), inline_logs, log_testcases=True)
         elif os.path.exists(h_log) and os.path.getsize(h_log) > 0:
             self.log_info("{}".format(h_log), inline_logs)
         elif os.path.exists(d_log) and os.path.getsize(d_log) > 0:

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -104,6 +104,10 @@ mapping:
             required: false
             sequence:
               - type: str
+          "pytest_dut_scope":
+            type: str
+            enum: ["function", "class", "module", "package", "session"]
+            required: false
           "regex":
             type: seq
             required: false
@@ -304,6 +308,10 @@ mapping:
                 required: false
                 sequence:
                   - type: str
+              "pytest_dut_scope":
+                type: str
+                enum: ["function", "class", "module", "package", "session"]
+                required: false
               "regex":
                 type: seq
                 required: false

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -48,6 +48,25 @@ def test_pytest_command(testinstance: TestInstance, device_type):
         assert c in command
 
 
+def test_pytest_command_dut_scope(testinstance: TestInstance):
+    pytest_harness = Pytest()
+    dut_scope = 'session'
+    testinstance.testsuite.harness_config['pytest_dut_scope'] = dut_scope
+    pytest_harness.configure(testinstance)
+    command = pytest_harness.generate_command()
+    assert f'--dut-scope={dut_scope}' in command
+
+
+def test_pytest_command_extra_args(testinstance: TestInstance):
+    pytest_harness = Pytest()
+    pytest_args = ['-k test1', '-m mark1']
+    testinstance.testsuite.harness_config['pytest_args'] = pytest_args
+    pytest_harness.configure(testinstance)
+    command = pytest_harness.generate_command()
+    for c in pytest_args:
+        assert c in command
+
+
 @pytest.mark.parametrize(
     ('pytest_root', 'expected'),
     [

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -188,6 +188,8 @@ def test_if_report_with_error(pytester, testinstance: TestInstance):
         assert tc.status == "failed"
         assert tc.output
         assert tc.reason
+    assert testinstance.reason
+    assert '2/2' in testinstance.reason
 
 
 def test_if_report_with_skip(pytester, testinstance: TestInstance):


### PR DESCRIPTION
Cherry-pick changes from twister to improve reporting of failed pytest scenarios and added parametrized scope of DUT fixture.