### PR TITLE
[nrf fromtree] doc: gsg: macOS: Include instructions to add homebrew …

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -118,11 +118,31 @@ The current minimum required version for the main dependencies are:
 
             /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
+      #. After the Homebrew installation script completes, follow the on-screen
+         instructions to add the Homebrew installation to the path.
+
+         * On macOS running on Apple Silicon, this is achieved with:
+
+           .. code-block:: bash
+
+              (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> ~/.zprofile
+              source ~/.zprofile
+
+         * On macOS running on Intel, use the command for Apple Silicon, but replace ``/opt/homebrew/`` with ``/usr/local/``.
+
       #. Use ``brew`` to install the required dependencies:
 
          .. code-block:: bash
 
             brew install cmake ninja gperf python3 ccache qemu dtc wget libmagic
+
+      #. Add the Homebrew Python folder to the path, in order to be able to
+         execute ``python`` and ``pip`` as well ``python3`` and ``pip3``.
+
+           .. code-block:: bash
+
+              (echo; echo 'export PATH="'$(brew --prefix)'/opt/python/libexec/bin:$PATH"') >> ~/.zprofile
+              source ~/.zprofile
 
    .. group-tab:: Windows
 


### PR DESCRIPTION
…to the path

Multiple users have failed to read the output from the Homebrew installation script, which instructs the user how to add it to the path. Include the instructions in the guide.

Also add a step to include the Homebrew Python executable to the path, which allows then for invocation of python and pip as well as python3 and pip3.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
(cherry picked from commit 318836af23aa1607342a019c01580fd87442f32b)