### PR TITLE
[nrf fromtree] drivers: uart: nrf: rx_timeout_slab incorrectly set

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -844,15 +844,7 @@ static int uarte_nrfx_rx_enable(const struct device *dev, uint8_t *buf,
 	}
 
 	data->async->rx_timeout = timeout;
-	/* Set minimum interval to 3 RTC ticks. 3 is used due to RTC limitation
-	 * which cannot set timeout for next tick. Assuming delay in processing
-	 * 3 instead of 2 is used. Note that lower value would work in a similar
-	 * way but timeouts would always occur later than expected,  most likely
-	 * after ~3 ticks.
-	 */
-	data->async->rx_timeout_slab =
-		MAX(timeout / RX_TIMEOUT_DIV,
-		    NRFX_CEIL_DIV(3 * 1000000, CONFIG_SYS_CLOCK_TICKS_PER_SEC));
+	data->async->rx_timeout_slab = timeout / RX_TIMEOUT_DIV;
 
 	data->async->rx_buf = buf;
 	data->async->rx_buf_len = len;


### PR DESCRIPTION
Upstream commit: https://github.com/zephyrproject-rtos/zephyr/commit/52c55177ba71af328c6069ea56c007e6eb5cdf1d

Upstream Issue: https://github.com/zephyrproject-rtos/zephyr/issues/62828

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/64094