### PR TITLE
[nrf fromtree] tfm: Enable TFM_EXCEPTION_INFO_DUMP by default

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -267,7 +267,6 @@ config FP_HARDABI
 	# TF-M build system does not build the NS app and libraries correctly with Hard ABI.
 	# This limitation should be removed in the next TF-M synchronization.
 	depends on !TFM_BUILD_NS
-	depends on !(BUILD_WITH_TFM && !TFM_IPC)
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated and uses FPU-specific calling

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -435,8 +435,8 @@ if (CONFIG_BUILD_WITH_TFM)
 
   else()
     zephyr_library_link_libraries(
-      ${TFM_API_NS_PATH}
       ${PLATFORM_NS_FILE}
+      ${TFM_API_NS_PATH}
       )
   endif()
 

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -446,6 +446,7 @@ endchoice
 
 config TFM_EXCEPTION_INFO_DUMP
 	bool "TF-M exception info dump"
+	default y
 	help
 	  On fatal errors in the secure firmware, capture info about the exception.
 	  Print the info if the SPM log level is sufficient.

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -323,6 +323,7 @@ config TFM_IPC
 
 config TFM_SFN
 	bool "SFN model"
+	depends on !FP_HARDABI
 	help
 	  Use the SFN Model as the SPM backend for the PSA API.
 	  The SFN model supports the SFN Partition model, and isolation level 1.


### PR DESCRIPTION
Exception info dump is a very basic feature so it should IMHO be enabled by default.

For instance, a simple null-pointer exception in the non-secure app will not be logged unless this option is enabled.


(cherry picked from commit a4e9aed68de223968e43f4ea4fa1abdda5b49c26)