### PR TITLE
[nrf fromtree] net: openthread: upmerge to `6edb06e`

### DIFF
--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -148,6 +148,12 @@ else()
   set(OT_CSL_RECEIVER OFF CACHE BOOL "Enable CSL receiver feature for Thread 1.2" FORCE)
 endif()
 
+if(CONFIG_OPENTHREAD_CSL_RECEIVER_LOCAL_TIME_SYNC)
+  set(OT_CSL_RECEIVER_LOCAL_TIME_SYNC ON CACHE BOOL "Use local time for CSL sync" FORCE)
+else()
+  set(OT_CSL_RECEIVER_LOCAL_TIME_SYNC OFF CACHE BOOL "Use local time for CSL sync" FORCE)
+endif()
+
 if(CONFIG_OPENTHREAD_DATASET_UPDATER)
   set(OT_DATASET_UPDATER ON CACHE BOOL "Enable Dataset updater" FORCE)
 else()

--- a/modules/openthread/Kconfig.features
+++ b/modules/openthread/Kconfig.features
@@ -92,6 +92,13 @@ config OPENTHREAD_CSL_RECEIVER
 	help
 	  Enable CSL Receiver support for Thread 1.2
 
+config OPENTHREAD_CSL_RECEIVER_LOCAL_TIME_SYNC
+	bool "Use local time for CSL synchronization"
+	help
+	  Use host time rather than radio platform time to track elapsed time
+	  since last CSL synchronization. This reduces the usage of radio API
+	  calls, and it is useful for platforms in which those are costly.
+
 config OPENTHREAD_DEVICE_PROP_LEADER_WEIGHT
 	bool "Device props for leader weight"
 	default n if (OPENTHREAD_THREAD_VERSION_1_1 || \

--- a/west.yml
+++ b/west.yml
@@ -303,7 +303,7 @@ manifest:
       revision: 42b7c577714b8f22ce82a901e19c1814af4609a8
       path: modules/lib/open-amp
     - name: openthread
-      revision: d62167ee34b091e7025c9ec2820aae71e17a3944
+      revision: 6edb06e4e0472411200ce2a084a783eaf3faffe3
       path: modules/lib/openthread
     - name: picolibc
       path: modules/lib/picolibc


### PR DESCRIPTION
Regular OpenThread upmerge to `6edb06e`.

Also add `OPENTHREAD_CSL_RECEIVER_LOCAL_TIME_SYNC` config.


(cherry picked from commit https://github.com/zephyrproject-rtos/zephyr/commit/3508cd609c9e13b21b10d592ee4ef5f3817f787e)