### PR TITLE
manifest: Update hal_nordic to point to sdk-hal_nordic

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,8 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 427ee1a519e8a0844d0f78f7cbc8cdfc134ef00d
+      url: https://github.com/nrfconnect/sdk-hal_nordic
+      revision: f405ecf8133b87506ffb58f24cb0ce4a4551d2bf
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Due to the fact that hal_nordic hosted on zephyrproject-rtos github space already has nrfx 3.2.0 integrated into it there is a need to switch to sdk-hal_nordic for NCS 2.5.1 release. New hal_nordic revision has nrfx 3.1.0 with MDK 8.58.0 plus few minor fixes requested by upcomming NCS release.