### PR TITLE
[nrf noup] modules: openthread: Add PSA implementation for PBDKF2 genkey

### DIFF
--- a/modules/openthread/platform/crypto_psa.c
+++ b/modules/openthread/platform/crypto_psa.c
@@ -658,4 +658,67 @@ out:
 	return psaToOtError(status);
 }
 
+// otError otPlatCryptoPbkdf2GenerateKey(const uint8_t *aPassword,
+void    otPlatCryptoPbkdf2GenerateKey(const uint8_t *aPassword,
+				      uint16_t       aPasswordLen,
+				      const uint8_t *aSalt,
+				      uint16_t       aSaltLen,
+				      uint32_t       aIterationCounter,
+				      uint16_t       aKeyLen,
+				      uint8_t       *aKey)
+{
+	psa_status_t status = PSA_SUCCESS;
+	psa_key_id_t key_id = PSA_KEY_ID_NULL;
+	psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
+	psa_algorithm_t algorithm = PSA_ALG_PBKDF2_AES_CMAC_PRF_128;
+	psa_key_derivation_operation_t operation = PSA_KEY_DERIVATION_OPERATION_INIT;
+
+	psa_set_key_usage_flags(&attributes, PSA_KEY_USAGE_DERIVE);
+	psa_set_key_lifetime(&attributes, PSA_KEY_LIFETIME_VOLATILE);
+	psa_set_key_algorithm(&attributes, algorithm);
+	psa_set_key_type(&attributes, PSA_KEY_TYPE_PASSWORD);
+	psa_set_key_bits(&attributes, PSA_BYTES_TO_BITS(aPasswordLen));
+
+	status = psa_import_key(&attributes, aPassword, aPasswordLen, &key_id);
+	if (status != PSA_SUCCESS) {
+		goto out;
+	}
+
+	status = psa_key_derivation_setup(&operation, algorithm);
+	if (status != PSA_SUCCESS) {
+		goto out;
+	}
+
+	status = psa_key_derivation_input_integer(&operation, PSA_KEY_DERIVATION_INPUT_COST,
+						  aIterationCounter);
+	if (status != PSA_SUCCESS) {
+		goto out;
+	}
+
+	status = psa_key_derivation_input_bytes(&operation, PSA_KEY_DERIVATION_INPUT_SALT,
+						aSalt, aSaltLen);
+	if (status != PSA_SUCCESS) {
+		goto out;
+	}
+
+	status = psa_key_derivation_input_key(&operation, PSA_KEY_DERIVATION_INPUT_PASSWORD,
+					      key_id);
+	if (status != PSA_SUCCESS) {
+		goto out;
+	}
+
+	status = psa_key_derivation_output_bytes(&operation, aKey, aKeyLen);
+	if (status != PSA_SUCCESS) {
+		goto out;
+	}
+
+out:
+	psa_reset_key_attributes(&attributes);
+	psa_key_derivation_abort(&operation);
+	psa_destroy_key(key_id);
+
+	OT_ASSERT(status == PSA_SUCCESS);
+	// return psaToOtError(status);
+}
+
 #endif /* #if CONFIG_OPENTHREAD_ECDSA */


### PR DESCRIPTION
Add implementation of opentherad pbkdf2 generate key using PSA functions.

Using assert instead of return code until openthread function signature is changed.

noup: zephyr needs to be using mbedtls 3.5.0 to support PBKDF2.