### PR TITLE
[nrf fromtree] soc: arm: Remove CPU_HAS_NRF_IDAU's dependencies

### DIFF
--- a/soc/arm/Kconfig
+++ b/soc/arm/Kconfig
@@ -34,27 +34,11 @@ config CPU_HAS_ARM_SAU
 
 config CPU_HAS_NRF_IDAU
 	bool
-	depends on SOC_SERIES_NRF91X || SOC_NRF5340_CPUAPP
 	select CPU_HAS_TEE
 	help
 	  MCU implements the nRF (vendor-specific) Security Attribution Unit.
 	  (IDAU: "Implementation-Defined Attribution Unit", in accordance with
 	  ARM terminology).
-
-if CPU_HAS_NRF_IDAU
-config NRF_SPU_FLASH_REGION_SIZE
-	hex
-	default 0x8000 if SOC_SERIES_NRF91X
-	default 0x4000 if SOC_NRF5340_CPUAPP
-	help
-	  FLASH region size for the NRF_SPU peripheral
-
-config NRF_SPU_RAM_REGION_SIZE
-	hex
-	default 0x2000 if SOC_SERIES_NRF91X || SOC_NRF5340_CPUAPP
-	help
-	  RAM region size for the NRF_SPU peripheral
-endif
 
 config HAS_SWO
 	bool

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -98,6 +98,18 @@ config SOC_DCDC_NRF53X_HV
 	help
 	  Enable nRF53 series System on Chip High Voltage DC/DC converter.
 
+config NRF_SPU_FLASH_REGION_SIZE
+	hex
+	default 0x4000
+	help
+	  FLASH region size for the NRF_SPU peripheral
+
+config NRF_SPU_RAM_REGION_SIZE
+	hex
+	default 0x2000
+	help
+	  RAM region size for the NRF_SPU peripheral
+
 config SOC_NRF_GPIO_FORWARDER_FOR_NRF5340
 	bool
 	depends on NRF_SOC_SECURE_SUPPORTED

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -104,11 +104,25 @@ config NRF_SPU_FLASH_REGION_SIZE
 	help
 	  FLASH region size for the NRF_SPU peripheral
 
+config NRF_SPU_FLASH_REGION_ALIGNMENT
+	hex
+	default 0x4000
+	help
+	  FLASH regions must be aligned to this value due to SPU HW
+	  limitations.
+
 config NRF_SPU_RAM_REGION_SIZE
 	hex
 	default 0x2000
 	help
 	  RAM region size for the NRF_SPU peripheral
+
+config NRF_SPU_RAM_REGION_ALIGNMENT
+	hex
+	default 0x2000
+	help
+	  RAM regions must be aligned to this value due to SPU HW
+	  limitations.
 
 config SOC_NRF_GPIO_FORWARDER_FOR_NRF5340
 	bool

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.series
@@ -27,9 +27,23 @@ config NRF_SPU_FLASH_REGION_SIZE
 	help
 	  FLASH region size for the NRF_SPU peripheral
 
+config NRF_SPU_FLASH_REGION_ALIGNMENT
+	hex
+	default 0x8000
+	help
+	  FLASH regions must be aligned to this value due to SPU HW
+	  limitations.
+
 config NRF_SPU_RAM_REGION_SIZE
 	hex
 	default 0x2000
 	help
 	  RAM region size for the NRF_SPU peripheral
+
+config NRF_SPU_RAM_REGION_ALIGNMENT
+	hex
+	default 0x2000
+	help
+	  RAM regions must be aligned to this value due to SPU HW
+	  limitations.
 endif

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.series
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.series
@@ -19,3 +19,17 @@ config SOC_SERIES_NRF91X
 	select HAS_POWEROFF
 	help
 	  Enable support for NRF91 MCU series
+
+if SOC_SERIES_NRF91X
+config NRF_SPU_FLASH_REGION_SIZE
+	hex
+	default 0x8000
+	help
+	  FLASH region size for the NRF_SPU peripheral
+
+config NRF_SPU_RAM_REGION_SIZE
+	hex
+	default 0x2000
+	help
+	  RAM region size for the NRF_SPU peripheral
+endif


### PR DESCRIPTION
CPU_HAS_NRF_IDAU is depending on SOC_SERIES_NRF91X and SOC_NRF5340_CPUAPP.

This makes it more difficult to have an out-of-tree nrf SOC.

It is also an unnecessary dependency. There is no prompt for CPU_HAS_NRF_IDAU, so it will not show up in menuconfig and it won't be possible to enable it from a users Kconfig fragment.

The only way to enable it is to select it, and those that select this option can themselves make sure that they only do so when appropriate.

Also, move NRF_SPU options out to SOC Kconfig files to also make out-of-tree SoCs possible. With the added benefit of not polluting the common soc/arm/Kconfig.


(cherry picked from commit 6348a973c38eeed5e18e6821dcb38a1c2f78ac76)