### PR TITLE
[nrf fromtree] twister: pytest: Add --pytest-args to Twister command line

### DIFF
--- a/doc/develop/test/pytest.rst
+++ b/doc/develop/test/pytest.rst
@@ -67,6 +67,8 @@ For instance, one can use a command:
    --pytest-args='-k test_shell_print_version'
 
 
+Note that ``--pytest-args`` can be passed multiple times to pass several arguments to the pytest.
+
 Helpers & fixtures
 ==================
 

--- a/doc/develop/test/pytest.rst
+++ b/doc/develop/test/pytest.rst
@@ -56,6 +56,16 @@ Pytest scans the given locations looking for tests, following its default
 `discovery rules <https://docs.pytest.org/en/7.1.x/explanation/goodpractices.html#conventions-for-python-test-discovery>`_
 One can also pass some extra arguments to the pytest from yaml file using ``pytest_args`` keyword
 under ``harness_config``, e.g.: ``pytest_args: [‘-k=test_method’, ‘--log-level=DEBUG’]``.
+There is also an option to pass ``--pytest-args`` through Twister command line parameters.
+This can be particularly useful when one wants to select a specific testcase from a test suite.
+For instance, one can use a command:
+
+.. code-block:: console
+
+   $ ./scripts/twister --platform native_sim -T samples/subsys/testsuite/pytest/shell \
+   -s samples/subsys/testsuite/pytest/shell/sample.pytest.shell \
+   --pytest-args='-k test_shell_print_version'
+
 
 Helpers & fixtures
 ==================

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -211,7 +211,8 @@ Artificially long but functional example:
         and 'fifo_loop' is a name of a function found in main.c without test prefix.
         """)
 
-    parser.add_argument("--pytest-args",
+    parser.add_argument(
+        "--pytest-args", action="append",
         help="""Pass additional arguments to the pytest subprocess. This parameter
         will override the pytest_args from the harness_config in YAML file.
         """)

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -211,6 +211,11 @@ Artificially long but functional example:
         and 'fifo_loop' is a name of a function found in main.c without test prefix.
         """)
 
+    parser.add_argument("--pytest-args",
+        help="""Pass additional arguments to the pytest subprocess. This parameter
+        will override the pytest_args from the harness_config in YAML file.
+        """)
+
     valgrind_asan_group.add_argument(
         "--enable-valgrind", action="store_true",
         help="""Run binary through valgrind and check for several memory access

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -245,8 +245,9 @@ class Pytest(Harness):
 
     def generate_command(self):
         config = self.instance.testsuite.harness_config
+        handler: Handler = self.instance.handler
         pytest_root = config.get('pytest_root', ['pytest']) if config else ['pytest']
-        pytest_args = config.get('pytest_args', []) if config else []
+        pytest_args_yaml = config.get('pytest_args', []) if config else []
         pytest_dut_scope = config.get('pytest_dut_scope', None) if config else None
         command = [
             'pytest',
@@ -260,11 +261,18 @@ class Pytest(Harness):
         ]
         command.extend([os.path.normpath(os.path.join(
             self.source_dir, os.path.expanduser(os.path.expandvars(src)))) for src in pytest_root])
-        command.extend(pytest_args)
+
+        if handler.options.pytest_args:
+            command.append(handler.options.pytest_args)
+            if pytest_args_yaml:
+                logger.warning(f'The pytest_args ({handler.options.pytest_args}) specified '
+                               'in the command line will override the pytest_args defined '
+                               f'in the YAML file {pytest_args_yaml}')
+        else:
+            command.extend(pytest_args_yaml)
+
         if pytest_dut_scope:
             command.append(f'--dut-scope={pytest_dut_scope}')
-
-        handler: Handler = self.instance.handler
 
         if handler.options.verbose > 1:
             command.extend([
@@ -425,6 +433,9 @@ class Pytest(Harness):
                         tc.status = 'error'
                     tc.reason = elem.get('message')
                     tc.output = elem.text
+        else:
+            self.state = 'skipped'
+            self.instance.reason = 'No tests collected'
 
 
 class Gtest(Harness):

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -262,15 +262,6 @@ class Pytest(Harness):
         command.extend([os.path.normpath(os.path.join(
             self.source_dir, os.path.expanduser(os.path.expandvars(src)))) for src in pytest_root])
 
-        if handler.options.pytest_args:
-            command.append(handler.options.pytest_args)
-            if pytest_args_yaml:
-                logger.warning(f'The pytest_args ({handler.options.pytest_args}) specified '
-                               'in the command line will override the pytest_args defined '
-                               f'in the YAML file {pytest_args_yaml}')
-        else:
-            command.extend(pytest_args_yaml)
-
         if pytest_dut_scope:
             command.append(f'--dut-scope={pytest_dut_scope}')
 
@@ -290,6 +281,16 @@ class Pytest(Harness):
             command.append('--device-type=custom')
         else:
             raise PytestHarnessException(f'Handling of handler {handler.type_str} not implemented yet')
+
+        if handler.options.pytest_args:
+            command.extend(handler.options.pytest_args)
+            if pytest_args_yaml:
+                logger.warning(f'The pytest_args ({handler.options.pytest_args}) specified '
+                               'in the command line will override the pytest_args defined '
+                               f'in the YAML file {pytest_args_yaml}')
+        else:
+            command.extend(pytest_args_yaml)
+
         return command
 
     def _generate_parameters_for_hardware(self, handler: Handler):

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -71,12 +71,13 @@ def test_pytest_command_extra_args(testinstance: TestInstance):
 def test_pytest_command_extra_args_in_options(testinstance: TestInstance):
     pytest_harness = Pytest()
     pytest_args_from_yaml = '-k test_from_yaml'
-    pytest_args_from_cmd = '-k test_from_cmd'
+    pytest_args_from_cmd = ['-k', 'test_from_cmd']
     testinstance.testsuite.harness_config['pytest_args'] = [pytest_args_from_yaml]
     testinstance.handler.options.pytest_args = pytest_args_from_cmd
     pytest_harness.configure(testinstance)
     command = pytest_harness.generate_command()
-    assert pytest_args_from_cmd in command
+    assert pytest_args_from_cmd[0] in command
+    assert pytest_args_from_cmd[1] in command
     assert pytest_args_from_yaml not in command
 
 


### PR DESCRIPTION
Cherry-pick changes from twister to pass parameters to pytest subprocess. It allows to select a specific testcase from a test suite.