### PR TITLE
[nrf fromtree] net: l2: wifi: Fix Print of SSID in WIFI status

### DIFF
--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -643,7 +643,7 @@ static int cmd_wifi_status(const struct shell *sh, size_t argc, char *argv[])
 				wifi_mode_txt(status.iface_mode));
 		shell_fprintf(sh, SHELL_NORMAL, "Link Mode: %s\n",
 				wifi_link_mode_txt(status.link_mode));
-		shell_fprintf(sh, SHELL_NORMAL, "SSID: %-32s\n", status.ssid);
+		shell_fprintf(sh, SHELL_NORMAL, "SSID: %.32s\n", status.ssid);
 		shell_fprintf(sh, SHELL_NORMAL, "BSSID: %s\n",
 					  net_sprint_ll_addr_buf(status.bssid,
 					  WIFI_MAC_ADDR_LEN, mac_string_buf,


### PR DESCRIPTION
While printing SSID in wifi status command, If the length is maximum(32 character). It leads to buffer overflow. It required one character for null
terminator ‘\0’. Changing the Format Specifiers to print proper SSID.

Signed-off-by: Kapil Bhatt <kapil.bhatt@nordicsemi.no>
(cherry picked from commit cb7b650b923f160540943f0724b79b79fd8e51f4)