### PR TITLE
[nrf fromlist] manifest: hal_nordic: Update revision with fixed worka…

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 2ff8ce6e6ca131d87699dba260f3c0cc4a6cc365
+      revision: b9633ecea67bf52925d4c61455046223b46402b1
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
…round in nrfx_qspi

Pulls update in nrfx_qspi driver with fixed order of applying workaround for anomaly 215 on nRF52840 and anomaly 43 on nRF5340.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/66034

Signed-off-by: Adam Wojasinski <adam.wojasinski@nordicsemi.no>