### PR TITLE
[nrf fromlist] net: shell: Early wake up for TWT power save

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -498,6 +498,12 @@ struct wifi_twt_params {
 			bool announce;
 			/** Wake up time */
 			uint32_t twt_wake_interval;
+			/* Wake ahead notification is sent earlier than
+			 * TWT Service period (SP) start based on this duration.
+			 * This should give applications ample time to
+			 * prepare the data before TWT SP starts.
+			 */
+			uint32_t twt_wake_ahead_duration;
 		} setup;
 		/** Teardown specific parameters */
 		struct {
@@ -514,6 +520,7 @@ struct wifi_twt_params {
 #define WIFI_MAX_TWT_INTERVAL_US (LONG_MAX - 1)
 /* 256 (u8) * 1TU */
 #define WIFI_MAX_TWT_WAKE_INTERVAL_US 262144
+#define WIFI_MAX_TWT_WAKE_AHEAD_DURATION_US (LONG_MAX - 1)
 
 /** Wi-Fi TWT flow information */
 struct wifi_twt_flow_info {
@@ -535,6 +542,8 @@ struct wifi_twt_flow_info {
 	bool announce;
 	/** Wake up time */
 	uint32_t twt_wake_interval;
+	/* wake ahead duration */
+	uint32_t twt_wake_ahead_duration;
 };
 
 /** Wi-Fi power save configuration */

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -975,6 +975,9 @@ static int cmd_wifi_ps(const struct shell *sh, size_t argc, char *argv[])
 					config.twt_flows[i].trigger,
 					config.twt_flows[i].twt_wake_interval,
 					config.twt_flows[i].twt_interval);
+				shell_fprintf(context.sh, SHELL_NORMAL,
+					      "TWT Wake ahead duration : %d us\n",
+					      config.twt_flows[i].twt_wake_ahead_duration);
 			}
 		}
 		return 0;
@@ -1133,7 +1136,7 @@ static int cmd_wifi_twt_setup(const struct shell *sh, size_t argc,
 
 	context.sh = sh;
 
-	if (argc != 11) {
+	if (argc != 12) {
 		shell_fprintf(sh, SHELL_WARNING, "Invalid number of arguments\n");
 		shell_help(sh);
 		return -ENOEXEC;
@@ -1192,6 +1195,11 @@ static int cmd_wifi_twt_setup(const struct shell *sh, size_t argc,
 		return -EINVAL;
 	}
 	params.setup.twt_interval = (uint64_t)value;
+
+	if (!parse_number(sh, &value, argv[idx++], 0, WIFI_MAX_TWT_WAKE_AHEAD_DURATION_US)) {
+		return -EINVAL;
+	}
+	params.setup.twt_wake_ahead_duration = (uint32_t)value;
 
 	if (net_mgmt(NET_REQUEST_WIFI_TWT, iface, &params, sizeof(params))) {
 		shell_fprintf(sh, SHELL_WARNING, "%s with %s failed. reason : %s\n",
@@ -1910,9 +1918,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_twt_ops,
 		"<negotiation_type, 0: Individual, 1: Broadcast, 2: Wake TBTT>\n"
 		"<setup_cmd: 0: Request, 1: Suggest, 2: Demand>\n"
 		"<dialog_token: 1-255> <flow_id: 0-7> <responder: 0/1> <trigger: 0/1> <implicit:0/1> "
-		"<announce: 0/1> <twt_wake_interval: 1-262144us> <twt_interval: 1us-2^31us>.\n",
+		"<announce: 0/1> <twt_wake_interval: 1-262144us> <twt_interval: 1us-2^31us>.\n"
+		"<twt_wake_ahead_duration>: 0us-2^31us>\n",
 		cmd_wifi_twt_setup,
-		11, 0),
+		12, 0),
 	SHELL_CMD_ARG(teardown, NULL, " Teardown a TWT flow:\n"
 		"<negotiation_type, 0: Individual, 1: Broadcast, 2: Wake TBTT>\n"
 		"<setup_cmd: 0: Request, 1: Suggest, 2: Demand>\n"


### PR DESCRIPTION
Provision of configurable parameter for generating unblock event ahead of TWT slot. Host application depending upon latencies can configure this to wakeup rpu ahead of the TWT slot.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull//67317