### PR TITLE
[nrf noup] ci: NCS-specific CI tweaks

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -58,7 +58,7 @@ jobs:
         ls -la
         git log  --pretty=oneline | head -n 10
         ./scripts/ci/check_compliance.py --annotate -e KconfigBasic -e Kconfig \
-        -e KconfigBasicNoModules -c origin/${BASE_REF}..
+        -e KconfigBasicNoModules -e ModulesMaintainers -c origin/${BASE_REF}..
 
     - name: upload-results
       uses: actions/upload-artifact@v3

--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -78,7 +78,7 @@ class TitleMaxLengthRevert(LineRule):
     name = "title-max-length-no-revert"
     id = "UC5"
     target = CommitMessageTitle
-    options_spec = [IntOption('line-length', 75, "Max line length")]
+    options_spec = [IntOption('line-length', 120, "Max line length")]
     violation_message = "Commit title exceeds max length ({0}>{1})"
 
     def validate(self, line, _commit):
@@ -103,7 +103,7 @@ class MaxLineLengthExceptions(LineRule):
     name = "max-line-length-with-exceptions"
     id = "UC4"
     target = CommitMessageBody
-    options_spec = [IntOption('line-length', 75, "Max line length")]
+    options_spec = [IntOption('line-length', 120, "Max line length")]
     violation_message = "Commit message body line exceeds max length ({0}>{1})"
 
     def validate(self, line, _commit):


### PR DESCRIPTION
squash! [nrf noup] ci: NCS-specific CI tweaks

Necessary changes for NCS CI.

- Add a Jenkinsfile
- Add a commit-tags workflow: This enables sauce tag checking in sdk-zephyr
- compliance.yml: Disable check for merge commits, since we have upmerges downstream. Also, since in the code we refer to Kconfig symbols that are defined in the sdk-nrf repository, the Kconfig checks (Kconfig, KconfigBasic and KconfigBasicNoModules) will not pass so exclude them. Also, disable any maintainers-related checks
- scripts/gitlint: Extend the max commit line lengths for Gitlint to account for sauce tags






(cherry picked from commit d34b035bcc569431b7008c72edc55db1b29bccf3) (cherry picked from commit 4a6d5fc57fe7589b2585ee5e44341f50821cc653) (cherry picked from commit a01c3a4caccb6964a29078172ba7f590bcdbe790) (cherry picked from commit 9b9ec58b0c575e15c57cb1e5de2d1c4ac5266a1f)