### PR TITLE
[nrf noup] drivers: ieee802154: temporary fix for ACK header IE config

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -886,6 +886,19 @@ static int nrf5_configure(const struct device *dev,
 		uint8_t short_addr_le[SHORT_ADDRESS_SIZE];
 		uint8_t element_id;
 
+		if (config->ack_ie.ext_addr == NULL &&
+		    config->ack_ie.header_ie == NULL &&
+		    config->ack_ie.short_addr == IEEE802154_NO_SHORT_ADDRESS_ASSIGNED) {
+			/* Hotfix for case when `EnableCsl()` has been called with arguments:
+			 * - `aCslPeriod` == 0
+			 * - `aShortAddr` == IEEE802154_NO_SHORT_ADDRESS_ASSIGNED
+			 * - `aExtAddr` == NULL
+			 * In this case skip configuring ACK header IE until proper resetting of
+			 * configuration is implemented.
+			 */
+			break;
+		}
+
 		if (config->ack_ie.short_addr == IEEE802154_BROADCAST_ADDRESS ||
 		    config->ack_ie.ext_addr == NULL) {
 			return -ENOTSUP;


### PR DESCRIPTION
Skip configuring ACK header IE if `EnableCsl()`
has been called with arguments:

- `aCslPeriod` == 0
- `aShortAddr` == IEEE802154_NO_SHORT_ADDRESS_ASSIGNED
- `aExtAddr` == NULL

This happens during RCP startup in `Radio::Init()` implementation.
It will be fixed on OT and Zephyr level, but this commit is needed
to prevent coprocessor samples from asserting on boot.