### PR TITLE
[nrf fromtree] dts: nrf5340: add missing `easydma-maxcnt-bits` for nrf5340_cpunet

### DIFF
--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -192,6 +192,7 @@
 			reg = <0x41013000 0x1000>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <19 NRF_DEFAULT_IRQ_PRIORITY>;
+			easydma-maxcnt-bits = <16>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
The required property `easydma-maxcnt-bits` was missing for nrf5340_cpunet.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/67600