### PR TITLE
[nrf fromtree] net: sockets: prevent null pointer dereference

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -681,7 +681,9 @@ int z_impl_zsock_accept(int sock, struct sockaddr *addr, socklen_t *addrlen)
 
 	new_sock = VTABLE_CALL(accept, sock, addr, addrlen);
 
-	(void)sock_obj_core_alloc_find(sock, new_sock, addr->sa_family, SOCK_STREAM);
+	if (addr) {
+		(void)sock_obj_core_alloc_find(sock, new_sock, addr->sa_family, SOCK_STREAM);
+	}
 
 	return new_sock;
 }


### PR DESCRIPTION
According to the POSIX specification, null pointer is a valid value for the `address` argument
of the `accept` function.
This commit adds a check to prevent a null pointer dereference inside `z_impl_zsock_accept`.

Signed-off-by: Mirko Covizzi <mirko.covizzi@nordicsemi.no>
(cherry picked from commit f3b2c04661370ac595faf32d2cafb43506704671)