### PR TITLE
[nrf fromtree] drivers: qspi: added operation timeout

### DIFF
--- a/drivers/flash/Kconfig.nordic_qspi_nor
+++ b/drivers/flash/Kconfig.nordic_qspi_nor
@@ -50,4 +50,13 @@ config NORDIC_QSPI_NOR_XIP
 	  QSPI NOR flash chip is executed until the driver has been setup.
 	  This will also disable power management for the QSPI NOR flash chip.
 
+config NORDIC_QSPI_NOR_TIMEOUT_MS
+	int "Timeout for QSPI operations (ms)"
+	default 500
+	help
+	  The QSPI peripheral operation timeout in milliseconds.
+	  Primarily intended for long running operations such as
+	  a flash sector erase. The 500 ms default allows for
+	  most typical NOR flash chips to erase a sector.
+
 endif # NORDIC_QSPI_NOR

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -1386,6 +1386,7 @@ static const struct qspi_nor_config qspi_nor_dev_config = {
 		.sck_delay = DT_INST_PROP(0, sck_delay),
 		.spi_mode = INST_0_SPI_MODE,
 	},
+	.nrfx_cfg.timeout = CONFIG_NORDIC_QSPI_NOR_TIMEOUT_MS,
 
 	.size = INST_0_BYTES,
 	.id = DT_INST_PROP(0, jedec_id),


### PR DESCRIPTION
Added Kconfig assignment of qspi timeout.
Per nrfx v3.2 addition of qspi timeout in config
struct.

Previous: https://github.com/nrfconnect/sdk-zephyr/pull/1428