### PR TITLE
[nrf fromlist] drivers: ieee802154: fix nRF5 Rx error handling

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -763,6 +763,7 @@ static int nrf5_init(const struct device *dev)
 
 	nrf5_get_capabilities_at_boot();
 
+	nrf5_radio->rx_on_when_idle = true;
 	nrf5_radio_cfg->irq_config_func(dev);
 
 	k_thread_create(&nrf5_radio->rx_thread, nrf5_radio->rx_stack,
@@ -1003,6 +1004,7 @@ static int nrf5_configure(const struct device *dev,
 
 	case IEEE802154_CONFIG_RX_ON_WHEN_IDLE:
 		nrf_802154_rx_on_when_idle_set(config->rx_on_when_idle);
+		nrf5_data.rx_on_when_idle = config->rx_on_when_idle;
 		break;
 
 	default:
@@ -1083,7 +1085,13 @@ void nrf_802154_receive_failed(nrf_802154_rx_error_t error, uint32_t id)
 
 #if defined(CONFIG_IEEE802154_CSL_ENDPOINT)
 	if (id == DRX_SLOT_RX && error == NRF_802154_RX_ERROR_DELAYED_TIMEOUT) {
-		return;
+		if (!nrf5_data.rx_on_when_idle) {
+			/* Transition to RxOff done automatically by the driver */
+			return;
+		} else if (nrf5_data.event_handler) {
+			/* Notify the higher layer to allow it to transition if needed */
+			nrf5_data.event_handler(dev, IEEE802154_EVENT_RX_OFF, NULL);
+		}
 	}
 #else
 	ARG_UNUSED(id);

--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -110,6 +110,9 @@ struct nrf5_802154_data {
 	/* The last configured value of CSL phase time in nanoseconds. */
 	net_time_t csl_rx_time;
 #endif /* CONFIG_NRF_802154_SER_HOST && CONFIG_IEEE802154_CSL_ENDPOINT */
+
+	/* Indicates if RxOnWhenIdle mode is enabled. */
+	bool rx_on_when_idle;
 };
 
 #endif /* ZEPHYR_DRIVERS_IEEE802154_IEEE802154_NRF5_H_ */


### PR DESCRIPTION
The current implementation implicitly assumes that if the device is configured to have the capability of acting as a CSL endpoint then in case a delayed reception with matching ID finishes with a timeout no action is needed. This assumption is correct when RxOnWhenIdle mode is disabled because the transition to sleep is done automatically by the driver below. However, it's wrong when RxOnWhenIdle is enabled. This commit fixes that case by adding a call to event handler that notifies the higher layer about the event and allows it to transition to RxOff if needed.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/67774