### PR TITLE
[nrf fromtree] Patches to enable the nrf5340bsim

### DIFF
--- a/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
+++ b/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
@@ -49,6 +49,7 @@
 		zephyr,flash = &flash0;
 		zephyr,bt-hci-ipc = &ipc0;
 		nordic,802154-spinel-ipc = &ipc0;
+		zephyr,ieee802154 = &ieee802154;
 	};
 
 	soc {

--- a/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
+++ b/boards/posix/nrf_bsim/nrf5340bsim_nrf5340_cpuapp.dts
@@ -45,6 +45,7 @@
 	};
 
 	chosen {
+		zephyr,entropy = &rng_hci;
 		zephyr,flash = &flash0;
 		zephyr,bt-hci-ipc = &ipc0;
 		nordic,802154-spinel-ipc = &ipc0;

--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: a715dcc179f1a71f51c574165958b72fe932ae3f
+      revision: 9b985ea6bc237b6ae06f48eb228f2ac7f6e3b96b
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 214f9fc1539f8e5937c0474cb6ee29b6dcb2d4b8


### PR DESCRIPTION
3 patches directly from Zephyr upstream from a couple of days after the upmerge target.
Needed to have the nrf5340bsim targets be more usable with the SDC and 802154 drivers.

-------

    [nrf fromtree] boards nrf5340bsim_cpuapp: Select approprite 802154 radio in DT
    
    Set the chosen 802154 radio in DT for the
    nrf5340bsim_nrf5340_cpuapp so we can build with the
    radio driver built into the net core.
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
    (cherry picked from commit 47b7eaece9419214fb2065cba4b9c520dc807ca6)

-------

    [nrf fromtree] manifest: Update nrf hw models to latest
    
    * Update the HW models module to
    9b985ea6bc237b6ae06f48eb228f2ac7f6e3b96b
    
    Including the following:
    * 9b985ea nrf_ccm: Add RATEOVERRIDE subscribe support
    * 8592230 nrf_hack: Add comments
    * 5775f4c docs: Very minor typo and grammar fixes
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
    (cherry picked from commit c4e1807cdf4d4a868995bcbe51716ac7fef78d3d)

-------

    [nrf fromtree] boards nrf5340bsim_cpuapp: Define chosen entropy source
    
    Override the chosen entropy source irrespectively of what the
    SOC may chose.
    This is to avoid problems as the SOC may select the
    cryptocell, but we do not support it in the simulated
    target.
    
    Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
    (cherry picked from commit 25599df05e4b060d83d6ccf03ded7b2b411bb7a4)
