### PR TITLE
[nrf fromtree] Bluetooth: ISO: Fix CIS peripheral disconnection durin…

### DIFF
--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1117,7 +1117,8 @@ void hci_le_cis_established(struct net_buf *buf)
 		bt_conn_set_state(iso, BT_CONN_CONNECTED);
 		bt_conn_unref(iso);
 		return;
-	} else if (evt->status != BT_HCI_ERR_OP_CANCELLED_BY_HOST) {
+	} else if (iso->role == BT_HCI_ROLE_PERIPHERAL ||
+		   evt->status != BT_HCI_ERR_OP_CANCELLED_BY_HOST) {
 		iso->err = evt->status;
 		bt_iso_disconnected(iso);
 	} /* else we wait for disconnect event */


### PR DESCRIPTION
…g setup

When the central aborts the CIS setup during the CIS Creation procedure after it has accepted the CIS request, the peripheral will receive the HCI LE CIS Established event with an error code. It does not receive a disconnection event.
See the message sequence chart in Core_v5.4, Vol 6, Part D, Section 6.23.

This commit ensures that the perirpheral disconnected callback gets called for this particular scenario.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>
(cherry picked from commit db588104921ac8bfd3f4c2b1b41c84cf5e710ec2)