### PR TITLE
[nrf fromtree] Patches for ISO datapath issue

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -209,6 +209,7 @@ enum bt_audio_metadata_type {
 	((struct bt_audio_codec_cfg){                                                              \
 		/* Use HCI data path as default, can be overwritten by application */              \
 		.path_id = BT_ISO_DATA_PATH_HCI,                                                   \
+		.ctlr_transcode = false,                                                           \
 		.id = _id,                                                                         \
 		.cid = _cid,                                                                       \
 		.vid = _vid,                                                                       \
@@ -231,6 +232,7 @@ enum bt_audio_metadata_type {
 	((struct bt_audio_codec_cap){                                                              \
 		/* Use HCI data path as default, can be overwritten by application */              \
 		.path_id = BT_ISO_DATA_PATH_HCI,                                                   \
+		.ctlr_transcode = false,                                                           \
 		.id = (_id),                                                                       \
 		.cid = (_cid),                                                                     \
 		.vid = (_vid),                                                                     \
@@ -316,6 +318,12 @@ struct bt_audio_codec_cap {
 	 * vendor specific ID.
 	 */
 	uint8_t path_id;
+	/** Whether or not the local controller should transcode
+	 *
+	 * This effectively sets the coding format for the ISO data path to @ref
+	 * BT_HCI_CODING_FORMAT_TRANSPARENT if false, else uses the @ref bt_audio_codec_cfg.id.
+	 */
+	bool ctlr_transcode;
 	/** Codec ID */
 	uint8_t id;
 	/** Codec Company ID */
@@ -344,6 +352,12 @@ struct bt_audio_codec_cfg {
 	 * vendor specific ID.
 	 */
 	uint8_t path_id;
+	/** Whether or not the local controller should transcode
+	 *
+	 * This effectively sets the coding format for the ISO data path to @ref
+	 * BT_HCI_CODING_FORMAT_TRANSPARENT if false, else uses the @ref bt_audio_codec_cfg.id.
+	 */
+	bool ctlr_transcode;
 	/** Codec ID */
 	uint8_t  id;
 	/** Codec Company ID */

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1820,11 +1820,7 @@ static int ase_stream_qos(struct bt_bap_stream *stream, struct bt_audio_codec_qo
 	 * we have the ISO <-> EP coupling completed (due to setting
 	 * the CIS ID in the QoS procedure).
 	 */
-	if (ep->dir == BT_AUDIO_DIR_SINK) {
-		bt_audio_codec_cfg_to_iso_path(&ep->iso->rx.path, stream->codec_cfg);
-	} else {
-		bt_audio_codec_cfg_to_iso_path(&ep->iso->tx.path, stream->codec_cfg);
-	}
+	bt_bap_iso_configure_data_path(ep, stream->codec_cfg);
 
 	ep->cig_id = cig_id;
 	ep->cis_id = cis_id;

--- a/subsys/bluetooth/audio/bap_broadcast_sink.c
+++ b/subsys/bluetooth/audio/bap_broadcast_sink.c
@@ -764,7 +764,7 @@ static int bt_bap_broadcast_sink_setup_stream(struct bt_bap_broadcast_sink *sink
 	bt_bap_iso_bind_ep(iso, ep);
 
 	bt_audio_codec_qos_to_iso_qos(iso->chan.qos->rx, &sink->codec_qos);
-	bt_audio_codec_cfg_to_iso_path(iso->chan.qos->rx->path, codec_cfg);
+	bt_bap_iso_configure_data_path(ep, codec_cfg);
 
 	bt_bap_iso_unref(iso);
 

--- a/subsys/bluetooth/audio/bap_broadcast_source.c
+++ b/subsys/bluetooth/audio/bap_broadcast_source.c
@@ -288,7 +288,7 @@ static int broadcast_source_setup_stream(uint8_t index, struct bt_bap_stream *st
 	bt_bap_iso_bind_ep(iso, ep);
 
 	bt_audio_codec_qos_to_iso_qos(iso->chan.qos->tx, qos);
-	bt_audio_codec_cfg_to_iso_path(iso->chan.qos->tx->path, codec_cfg);
+	bt_bap_iso_configure_data_path(ep, codec_cfg);
 #if defined(CONFIG_BT_ISO_TEST_PARAMS)
 	iso->chan.qos->num_subevents = qos->num_subevents;
 #endif /* CONFIG_BT_ISO_TEST_PARAMS */
@@ -878,7 +878,7 @@ int bt_bap_broadcast_source_reconfig(struct bt_bap_broadcast_source *source,
 
 			iso_qos = stream->ep->iso->chan.qos->tx;
 			bt_bap_stream_attach(NULL, stream, stream->ep, codec_cfg);
-			bt_audio_codec_cfg_to_iso_path(iso_qos->path, codec_cfg);
+			bt_bap_iso_configure_data_path(stream->ep, codec_cfg);
 		}
 	}
 

--- a/subsys/bluetooth/audio/bap_iso.h
+++ b/subsys/bluetooth/audio/bap_iso.h
@@ -41,6 +41,7 @@ void bt_bap_iso_foreach(bt_bap_iso_func_t func, void *user_data);
 struct bt_bap_iso *bt_bap_iso_find(bt_bap_iso_func_t func, void *user_data);
 void bt_bap_iso_init(struct bt_bap_iso *iso, struct bt_iso_chan_ops *ops);
 void bt_bap_iso_bind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep);
+void bt_bap_iso_configure_data_path(struct bt_bap_ep *ep, struct bt_audio_codec_cfg *codec_cfg);
 void bt_bap_iso_unbind_ep(struct bt_bap_iso *iso, struct bt_bap_ep *ep);
 struct bt_bap_ep *bt_bap_iso_get_ep(bool unicast_client, struct bt_bap_iso *iso,
 				    enum bt_audio_dir dir);

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -31,28 +31,6 @@
 
 LOG_MODULE_REGISTER(bt_bap_stream, CONFIG_BT_BAP_STREAM_LOG_LEVEL);
 
-void bt_audio_codec_cfg_to_iso_path(struct bt_iso_chan_path *path,
-				    struct bt_audio_codec_cfg *codec_cfg)
-{
-	path->pid = codec_cfg->path_id;
-
-	if (codec_cfg->ctlr_transcode) {
-		path->format = codec_cfg->id;
-		path->cid = codec_cfg->cid;
-		path->vid = codec_cfg->vid;
-		path->delay = 0;
-		path->cc_len = codec_cfg->data_len;
-		path->cc = codec_cfg->data;
-	} else {
-		path->format = BT_HCI_CODING_FORMAT_TRANSPARENT;
-		path->cid = 0;
-		path->vid = 0;
-		path->delay = 0;
-		path->cc_len = 0;
-		path->cc = NULL;
-	}
-}
-
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT) || defined(CONFIG_BT_BAP_BROADCAST_SOURCE) ||            \
 	defined(CONFIG_BT_BAP_BROADCAST_SINK)
 void bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_io_qos *io,

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -35,12 +35,22 @@ void bt_audio_codec_cfg_to_iso_path(struct bt_iso_chan_path *path,
 				    struct bt_audio_codec_cfg *codec_cfg)
 {
 	path->pid = codec_cfg->path_id;
-	path->format = codec_cfg->id;
-	path->cid = codec_cfg->cid;
-	path->vid = codec_cfg->vid;
-	path->delay = 0; /* TODO: Add to bt_audio_codec_cfg? Use presentation delay? */
-	path->cc_len = codec_cfg->data_len;
-	path->cc = codec_cfg->data;
+
+	if (codec_cfg->ctlr_transcode) {
+		path->format = codec_cfg->id;
+		path->cid = codec_cfg->cid;
+		path->vid = codec_cfg->vid;
+		path->delay = 0;
+		path->cc_len = codec_cfg->data_len;
+		path->cc = codec_cfg->data;
+	} else {
+		path->format = BT_HCI_CODING_FORMAT_TRANSPARENT;
+		path->cid = 0;
+		path->vid = 0;
+		path->delay = 0;
+		path->cc_len = 0;
+		path->cc = NULL;
+	}
 }
 
 #if defined(CONFIG_BT_BAP_UNICAST_CLIENT) || defined(CONFIG_BT_BAP_BROADCAST_SOURCE) ||            \

--- a/subsys/bluetooth/audio/bap_stream.h
+++ b/subsys/bluetooth/audio/bap_stream.h
@@ -17,8 +17,6 @@ void bt_bap_stream_reset(struct bt_bap_stream *stream);
 void bt_bap_stream_attach(struct bt_conn *conn, struct bt_bap_stream *stream, struct bt_bap_ep *ep,
 			  struct bt_audio_codec_cfg *codec_cfg);
 
-void bt_audio_codec_cfg_to_iso_path(struct bt_iso_chan_path *path,
-				    struct bt_audio_codec_cfg *codec_cfg);
 void bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_io_qos *io,
 				   const struct bt_audio_codec_qos *codec_qos);
 

--- a/subsys/bluetooth/audio/bap_unicast_client.c
+++ b/subsys/bluetooth/audio/bap_unicast_client.c
@@ -774,17 +774,8 @@ static void unicast_client_ep_qos_state(struct bt_bap_ep *ep, struct net_buf_sim
 		 * we have the ISO <-> EP coupling completed (due to setting
 		 * the CIS ID in the QoS procedure).
 		 */
-		if (ep->dir == BT_AUDIO_DIR_SOURCE) {
-			/* If the endpoint is a source, then we need to
-			 * configure our RX parameters
-			 */
-			bt_audio_codec_cfg_to_iso_path(&ep->iso->rx.path, stream->codec_cfg);
-		} else {
-			/* If the endpoint is a sink, then we need to
-			 * configure our TX parameters
-			 */
-			bt_audio_codec_cfg_to_iso_path(&ep->iso->tx.path, stream->codec_cfg);
-		}
+
+		bt_bap_iso_configure_data_path(ep, stream->codec_cfg);
 	}
 
 	/* Notify upper layer */


### PR DESCRIPTION
Two patches from Zephyr upstream for bring transparent coding format and fixing issue for invalid ISO datapath issue.