### PR TITLE
[nrf fromtree] Bluetooth: Mesh: enable access responses randomization

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -639,6 +639,7 @@ config BT_MESH_LABEL_NO_RECOVER
 
 menuconfig BT_MESH_ACCESS_DELAYABLE_MSG
 	bool "Access layer tx delayable message"
+	default y
 	help
 	  Enable following of the message transmitting recommendations, the Access layer
 	  specification. The recommendations are optional.
@@ -646,6 +647,16 @@ menuconfig BT_MESH_ACCESS_DELAYABLE_MSG
 	  intensive communication where the device receives a lot of requests that require responses.
 
 if BT_MESH_ACCESS_DELAYABLE_MSG
+
+config BT_MESH_ACCESS_DELAYABLE_MSG_CTX_ENABLED
+	bool "The delayable message in the notification message context"
+	default y
+	help
+	  Controls whether the delayable message feature is enabled by default in
+	  the message context of the opcode notifications. This allows the server part of any
+	  model to not bother about additional context configuration to enable the delayable message.
+	  Note that if this is disabled then all foundation models stop using the delayable message
+	  functionality.
 
 config BT_MESH_ACCESS_DELAYABLE_MSG_COUNT
 	int "Number of simultaneously delayed messages"
@@ -657,14 +668,14 @@ config BT_MESH_ACCESS_DELAYABLE_MSG_COUNT
 
 config BT_MESH_ACCESS_DELAYABLE_MSG_CHUNK_SIZE
 	int "Maximum delayable message storage chunk"
-	default 20
+	default 10
 	help
 	  Size of memory that Access layer uses to split model message to. It allocates
 	  a sufficient number of these chunks from the pool to store the full model payload.
 
 config BT_MESH_ACCESS_DELAYABLE_MSG_CHUNK_COUNT
 	int "Maximum number of available chunks"
-	default 20
+	default 40
 	help
 	  The maximum number of available chunks the Access layer allocates to store model payload.
 	  It is recommended to keep chunk size equal to the reasonable small value to prevent

--- a/subsys/bluetooth/mesh/delayable_msg.c
+++ b/subsys/bluetooth/mesh/delayable_msg.c
@@ -167,12 +167,14 @@ static bool push_msg_from_delayable_msgs(void)
 	sys_snode_t *node;
 	struct delayable_msg_chunk *chunk;
 	struct delayable_msg_ctx *msg = peek_pending_msg();
-	uint16_t len = msg->len;
+	uint16_t len;
 	int err;
 
 	if (!msg) {
 		return false;
 	}
+
+	len = msg->len;
 
 	NET_BUF_SIMPLE_DEFINE(buf, BT_MESH_TX_SDU_MAX);
 

--- a/tests/bsim/bluetooth/mesh/src/test_persistence.c
+++ b/tests/bsim/bluetooth/mesh/src/test_persistence.c
@@ -455,12 +455,6 @@ static void provisioner_setup(void)
 		FAIL("Failed to add test_netkey (err: %d, status: %d)", err, status);
 	}
 
-	err = bt_mesh_cfg_cli_net_transmit_set(test_netkey_idx, TEST_PROV_ADDR,
-					       BT_MESH_TRANSMIT(3, 50), &status);
-	if (err || status != BT_MESH_TRANSMIT(3, 50)) {
-		FAIL("Net transmit set failed (err %d, transmit %x)", err, status);
-	}
-
 	provisioner_ready = true;
 }
 

--- a/tests/bsim/bluetooth/mesh/src/test_provision.c
+++ b/tests/bsim/bluetooth/mesh/src/test_provision.c
@@ -1205,7 +1205,6 @@ static void test_provisioner_pb_remote_client_nppi_robustness(void)
 	uint16_t pb_remote_server_addr;
 	uint8_t status;
 	struct bt_mesh_cdb_node *node;
-	int err;
 
 	provisioner_pb_remote_client_setup();
 
@@ -1218,15 +1217,6 @@ static void test_provisioner_pb_remote_client_nppi_robustness(void)
 		.net_idx = 0,
 		.ttl = 3,
 	};
-
-	/* Set Network Transmit Count state on the remote client greater than on the remote server
-	 * to increase probability of reception responses.
-	 */
-	err = bt_mesh_cfg_cli_net_transmit_set(0, current_dev_addr, BT_MESH_TRANSMIT(3, 50),
-					       &status);
-	if (err || status != BT_MESH_TRANSMIT(3, 50)) {
-		FAIL("Net transmit set failed (err %d, transmit %x)", err, status);
-	}
 
 	ASSERT_OK(provision_remote(&srv, 2, &srv.addr));
 

--- a/tests/bsim/bluetooth/mesh/tests_scripts/access/access_transmit_delayable.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/access/access_transmit_delayable.sh
@@ -14,4 +14,4 @@ RunTest mesh_access_pub_transmit_delayable_retr_1d1 \
 conf=prj_mesh1d1_conf
 overlay=overlay_psa_conf
 RunTest mesh_access_pub_transmit_delayable_retr_psa \
-	access_tx_period_delayable access_rx_period_delayable
+	access_tx_transmit_delayable access_rx_transmit_delayable

--- a/tests/bsim/bluetooth/mesh/tests_scripts/priv_beacon/proxy_adv_multi_subnet_coex.sh
+++ b/tests/bsim/bluetooth/mesh/tests_scripts/priv_beacon/proxy_adv_multi_subnet_coex.sh
@@ -22,6 +22,10 @@ source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
 # window. The Mesh Protocol specification does not specify exactly the
 # timing for Proxy ADV messages.
 
+# Note 3: The proxy transmitting device mandates emitting of the secure
+# network beacons. This allows to check that proxy goes back to normal
+# behavior after the device advertises the secure network beacons.
+
 # Test procedure:
 # 1. (0-20 seconds) A single subnet is active on the TX device with GATT
 #    Proxy enabled. RX device verifies that the single subnet has exclusive


### PR DESCRIPTION
Enable by default the access layer responses random delays. Commit also adapts all mesh models, samples and
babblesim tests to use random delay functionality correctly.


(cherry picked from commit 4e7d64b1b45247de1e1d71a4402f5637b0fd0afe)