### PR TITLE
[nrf fromtree] Revert "drivers: ieee802154: nrf: cache radio channel"

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.h
+++ b/drivers/ieee802154/ieee802154_nrf5.h
@@ -100,9 +100,6 @@ struct nrf5_802154_data {
 	/* The TX power in dBm. */
 	int8_t txpwr;
 
-	/* The radio channel. */
-	uint8_t channel;
-
 #if defined(CONFIG_NRF_802154_SER_HOST) && defined(CONFIG_IEEE802154_CSL_ENDPOINT)
 	/* The last configured value of CSL period in units of 10 symbols. */
 	uint32_t csl_period;


### PR DESCRIPTION
This reverts commit 780b12854c11f10f6b3e4b21ae02eaa1b2965736. "drivers: ieee802154: nrf: cache radio channel"

Implementation affected RCP devices in openthread as MAC layer does not call `Receive()` functions after transmit is done.

Additionally, after sending a frame to a new channel (for example while discovery operation), radio switches to RX state immediately after TX, but continues to listen on old channel for about 5ms, until MAC layer calls `Receive` operation, forcing to change the channel.

Signed-off-by: Maciej Baczmanski <maciej.baczmanski@nordicsemi.no>
(cherry picked from commit [dbe74b3299f1e247db8c33491ad932e1681c0efa](https://github.com/zephyrproject-rtos/zephyr/commit/dbe74b3299f1e247db8c33491ad932e1681c0efa))