### PR TITLE
[nrf fromtree] manifest: Update nrf hw models to latest including UBSAN fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: a08acc7d3a853f890df2bf82167c02ab2153ffe7
+      revision: 6b6ae3652c92c95edd945dce6ad9ef9892aab89b
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 214f9fc1539f8e5937c0474cb6ee29b6dcb2d4b8

--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 6b6ae3652c92c95edd945dce6ad9ef9892aab89b
+      revision: d17c9d749c817d2522468fa3c0eee3705feb8951
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 214f9fc1539f8e5937c0474cb6ee29b6dcb2d4b8

--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: d17c9d749c817d2522468fa3c0eee3705feb8951
+      revision: 52d0b4b7b7431d8da6222cc3b17a8afdcb099baf
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 214f9fc1539f8e5937c0474cb6ee29b6dcb2d4b8

--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: c744f2c762aad79e59bd7e99002f2fcab0a2f288
+      revision: a08acc7d3a853f890df2bf82167c02ab2153ffe7
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 214f9fc1539f8e5937c0474cb6ee29b6dcb2d4b8

--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 9b985ea6bc237b6ae06f48eb228f2ac7f6e3b96b
+      revision: c744f2c762aad79e59bd7e99002f2fcab0a2f288
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 214f9fc1539f8e5937c0474cb6ee29b6dcb2d4b8


### PR DESCRIPTION
* Update the HW models module to 52d0b4b7b7431d8da6222cc3b17a8afdcb099baf
    Including the following:
    * 52d0b4b UART: FIFO backend: Do not error out if other side disconnects Rx
    * 3582b68 UART: FIFO backend: Avoid possible race
    * 414f160 AAR: Fix UBSAN warnings
    * 24f5d3d PPI: Fix UBSAN warning
    * d17c9d7 UART: Bugfix: Support STARTRX while Rx is stopping
    * d982e76 UART: Minor bugfix: Fix 2 warning messages
    * eda7af9 UART: Bugfix: Handle task STOPTX while stopping
    * b8ea63b UART: BugFix: Support STARTTx even if Tx is not Off
    * c0d28cc nrf_common: Add replacement for nrf_dma_accessible_check()
    * feb91bb nrfx_common replacement: nrfx_get_irq_number() Add missing peri
    * c95d9af Makefile: By default lets build both 52833 and 5340 targets
    * cf41110 UART: FIFO backend: Check for failure of fcntl
    * 6b6ae36 UART: Minor optimization
    * afe84c1 fake timer: Minor speed optimization for nrf52
    * a5a4dfd RTC: Fix counter value when CLEAR after STOP
    * 6b6ae36 UART: Minor optimization
    * afe84c1 fake timer: Minor speed optimization for nrf52
    * a5a4dfd RTC: Fix counter value when CLEAR after STOP
    * a08acc7 UART(E): Duty cycle warnings due to Rx while Rx Off
    * aa1f38d UART(E): FIFO backend Minor bugfix
    * 8b0819f UART(E): Add Loopback backend
    * bc648f2 UART(E): Update RTS pin level as soon as the conf is changed
    * b39e448 UART(E): Detect receiver opening mid frame
    * docs: UART: several minor fixes
    * UART(E): Add peripherals and connect to (D)PPI