### PR TITLE
[nrf fromtree] manifest: Update hal_nordic revision to fix APPROTECT on nRF91 and to fix nrfx samples build error

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: b55cfbbf0221d709560c2e438beef66842ada272
+      revision: dce8519f7da37b0a745237679fd3f88250b495ff
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Updated hal_nordic fixes APPROTECT handling on nRF91 target, as well as fixes missing alignment of nrfx samples to modified API of the GPIOTE driver.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/68800