### PR TITLE
Lwm2m: upstream updates

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -110,6 +110,13 @@ config LWM2M_QUEUE_MODE_UPTIME
 	  defaults to 93 seconds, see RFC 7252), it does not forbid other
 	  values though.
 
+config LWM2M_QUEUE_MODE_NO_MSG_BUFFERING
+	bool "Disable buffering notifications and messages on queue mode"
+	select EXPERIMENTAL
+	help
+	  Messages are sent right away instead of waiting for next registration update.
+	  This might not be supported on all servers.
+
 config LWM2M_TLS_SESSION_CACHING
 	bool "TLS session caching"
 	help

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1060,7 +1060,7 @@ int lwm2m_set_default_sockopt(struct lwm2m_ctx *ctx)
 		}
 		if (IS_ENABLED(CONFIG_LWM2M_DTLS_CID)) {
 			/* Enable CID */
-			int cid = TLS_DTLS_CID_ENABLED;
+			int cid = TLS_DTLS_CID_SUPPORTED;
 
 			ret = zsock_setsockopt(ctx->sock_fd, SOL_TLS, TLS_DTLS_CID, &cid,
 					       sizeof(cid));

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -645,7 +645,7 @@ cleanup:
  */
 static void hint_socket_state(struct lwm2m_ctx *ctx, struct lwm2m_message *ongoing_tx)
 {
-	if (!ctx->set_socket_state) {
+	if (!ctx || !ctx->set_socket_state) {
 		return;
 	}
 

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -244,6 +244,7 @@ int lwm2m_push_queued_buffers(struct lwm2m_ctx *client_ctx)
 			break;
 		}
 		msg = SYS_SLIST_CONTAINER(msg_node, msg, node);
+		msg->pending->t0 = k_uptime_get();
 		sys_slist_append(&msg->ctx->pending_sends, &msg->node);
 	}
 #endif

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -726,6 +726,13 @@ int lwm2m_information_interface_send(struct lwm2m_message *msg)
 		return ret;
 	}
 
+	if (IS_ENABLED(CONFIG_LWM2M_QUEUE_MODE_NO_MSG_BUFFERING)) {
+		sys_slist_append(&msg->ctx->pending_sends, &msg->node);
+		lwm2m_engine_wake_up();
+		lwm2m_engine_connection_resume(msg->ctx);
+		return 0;
+	}
+
 	if (msg->ctx->buffer_client_messages) {
 		sys_slist_append(&msg->ctx->queued_messages, &msg->node);
 		lwm2m_engine_wake_up();

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1726,7 +1726,12 @@ int lwm2m_rd_client_connection_resume(struct lwm2m_ctx *client_ctx)
 		     IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_LISTEN_AT_IDLE)) ||
 		    !IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT)) {
 			client.engine_state = ENGINE_REGISTRATION_DONE;
-			client.trigger_update = true;
+			if (IS_ENABLED(CONFIG_LWM2M_QUEUE_MODE_NO_MSG_BUFFERING)) {
+				/* Force online for a short period */
+				engine_update_tx_time();
+			} else {
+				client.trigger_update = true;
+			}
 		} else {
 			client.engine_state = ENGINE_DO_REGISTRATION;
 		}

--- a/tests/net/lib/lwm2m/lwm2m_engine/src/main.c
+++ b/tests/net/lib/lwm2m/lwm2m_engine/src/main.c
@@ -260,11 +260,13 @@ ZTEST(lwm2m_engine, test_push_queued_buffers)
 	int ret;
 	struct lwm2m_ctx ctx;
 	struct lwm2m_message msg;
+	struct coap_pending pending;
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
 	sys_slist_init(&ctx.queued_messages);
 	msg.ctx = &ctx;
+	msg.pending = &pending;
 	sys_slist_append(&ctx.queued_messages, &msg.node);
 	ret = lwm2m_push_queued_buffers(&ctx);
 	zassert_equal(ret, 0);
@@ -391,6 +393,7 @@ ZTEST(lwm2m_engine, test_socket_send)
 	int ret;
 	struct lwm2m_ctx ctx;
 	struct lwm2m_message msg;
+	struct coap_pending pending;
 
 	(void)memset(&ctx, 0x0, sizeof(ctx));
 
@@ -398,6 +401,7 @@ ZTEST(lwm2m_engine, test_socket_send)
 	ctx.sock_fd = -1;
 	sys_slist_init(&ctx.queued_messages);
 	msg.ctx = &ctx;
+	msg.pending = &pending;
 	msg.type = COAP_TYPE_CON;
 	sys_slist_append(&ctx.queued_messages, &msg.node);
 


### PR DESCRIPTION
* 992936300bf - net: lwm2m: Use CID_SUPPORTED instead of CID_ENABLED (2 weeks ago) <Seppo Takalo>
* bf872870eab - net: lwm2m: Fix segfault on failed bootstrap (3 weeks ago) <Seppo Takalo>
* 9eee8d2be59 - net: lwm2m: Allow send operations when sleeping (3 weeks ago) <Juha Ylinen>


One critical fix (segfault) needed for the 2.6.0 release, so I'll pull in few other changes to keep in synch.
ZCBOR changes are in separate PR https://github.com/nrfconnect/sdk-zephyr/pull/1471 so I'll skip those.
