### PR TITLE
[nrf fromlist] scripts: Allow using quarantine mechanism with test_plan.py script

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -95,7 +95,7 @@ class Tag:
 
 class Filters:
     def __init__(self, modified_files, ignore_path, alt_tags, testsuite_root,
-                 pull_request=False, platforms=[], detailed_test_id=True):
+                 pull_request=False, platforms=[], detailed_test_id=True, quarantine_list=None):
         self.modified_files = modified_files
         self.testsuite_root = testsuite_root
         self.resolved_files = []
@@ -108,6 +108,7 @@ class Filters:
         self.detailed_test_id = detailed_test_id
         self.ignore_path = ignore_path
         self.tag_cfg_file = alt_tags
+        self.quarantine_list = quarantine_list
 
     def process(self):
         self.find_modules()
@@ -128,6 +129,9 @@ class Filters:
                 cmd+=["-T", root]
         if integration:
             cmd.append("--integration")
+        if self.quarantine_list:
+            for q in self.quarantine_list:
+                cmd += ["--quarantine-list", q]
 
         logging.info(" ".join(cmd))
         _ = subprocess.call(cmd)
@@ -415,6 +419,12 @@ def parse_args():
                 "testcase.yaml files under here will be processed. May be "
                 "called multiple times. Defaults to the 'samples/' and "
                 "'tests/' directories at the base of the Zephyr tree.")
+    parser.add_argument(
+            "--quarantine-list", action="append", metavar="FILENAME",
+            help="Load list of test scenarios under quarantine. The entries in "
+                "the file need to correspond to the test scenarios names as in "
+                "corresponding tests .yaml files. These scenarios "
+                "will be skipped with quarantine as the reason.")
 
     # Include paths in names by default.
     parser.set_defaults(detailed_test_id=True)
@@ -443,7 +453,7 @@ if __name__ == "__main__":
         print("=========")
 
     f = Filters(files, args.ignore_path, args.alt_tags, args.testsuite_root,
-                args.pull_request, args.platform, args.detailed_test_id)
+                args.pull_request, args.platform, args.detailed_test_id, args.quarantine_list)
     f.process()
 
     # remove dupes and filtered cases


### PR DESCRIPTION
In twister, applying quarantine is a part of apply_filters() function. However, this function is not called when --load-test is used. Therefore, if one wants to use quarantines in combination with dynamic scope from the test_plan.py script, one has to pass such info through the script.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/66659