### PR TITLE
test-spec: descope samples and tests from many CIs

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -35,7 +35,7 @@
   - "include/net/socket_ncs.h"
   - "subsys/testsuite/ztest/**/*"
 
-"CI-lwm2m-test":
+"CI-lwm2m-test": null
 # Not necessary to run tests on changes to this repo.
 
 "CI-boot-dfu-test":
@@ -66,16 +66,7 @@
   - any:
       - "include/zephyr/bluetooth/**/*"
       - "!include/zephyr/bluetooth/mesh/**/*"
-  - any:
-      - "samples/bluetooth/**/*"
-      - "!samples/bluetooth/mesh/**/*"
-      - "!samples/bluetooth/mesh_demo/**/*"
-      - "!samples/bluetooth/mesh_provisioner/**/*"
-  - any:
-      - "tests/bluetooth/**/*"
-      - "!tests/bluetooth/mesh/**/*"
-      - "!tests/bluetooth/mesh_shell/**/*"
-      - "!tests/bluetooth/audio/**/*"
+  - "samples/bluetooth/hci_rpc/**/*"
 
 "CI-mesh-test":
   - "subsys/bluetooth/mesh/**/*"
@@ -126,7 +117,10 @@
   - "subsys/tracing/**/*"
 
 "CI-desktop-test":
-  - "**/*"
+  - any:
+      - "**/*"
+      - "!samples/bluetooth/**/*"
+      - "!tests/bluetooth/**/*"
 
 "CI-crypto-test":
   - "boards/arm/nrf52840dk_nrf52840/**/*"
@@ -141,10 +135,16 @@
   - "modules/mbedtls/**/*"
 
 "CI-fem-test":
-  - "**/*"
+  - any:
+      - "**/*"
+      - "!samples/bluetooth/**/*"
+      - "!tests/bluetooth/**/*"
 
 "CI-rs-test":
-  - "**/*"
+  - any:
+      - "**/*"
+      - "!samples/bluetooth/**/*"
+      - "!tests/bluetooth/**/*"
 
 "CI-thread-test":
   - "include/zephyr/net/**/*"
@@ -156,7 +156,10 @@
   - "subsys/settings/**/*"
 
 "CI-nfc-test":
-  - "**/*"
+  - any:
+      - "**/*"
+      - "!samples/bluetooth/**/*"
+      - "!tests/bluetooth/**/*"
 
 "CI-matter-test":
   - "include/dfu/**/*"
@@ -167,20 +170,29 @@
   - "subsys/net/**/*"
   - "subsys/mgmt/mcumgr/**/*"
   - "drivers/net/**/*"
-  - "samples/bluetooth/hci_rpmsg/**/*"
+  - "samples/bluetooth/hci_rpc/**/*"
   - any:
       - "subsys/bluetooth/**/*"
       - "!subsys/bluetooth/mesh/**/*"
       - "!subsys/bluetooth/audio/**/*"
 
 "CI-find-my-test":
-  - "**/*"
+  - any:
+      - "**/*"
+      - "!samples/bluetooth/**/*"
+      - "!tests/bluetooth/**/*"
 
 "CI-gazell-test":
-  - "**/*"
+  - any:
+      - "**/*"
+      - "!samples/bluetooth/**/*"
+      - "!tests/bluetooth/**/*"
 
 "CI-rpc-test":
-  - "**/*"
+  - any:
+      - "**/*"
+      - "!samples/bluetooth/**/*"
+      - "!tests/bluetooth/**/*"
 
 "CI-modemshell-test":
   - "include/net/**/*"
@@ -228,7 +240,7 @@
   - "subsys/dfu/**/*"
   - "subsys/settings/**/*"
   - "subsys/mgmt/mcumgr/**/*"
-  - "samples/bluetooth/hci_rpmsg/**/*"
+  - "samples/bluetooth/hci_rpc/**/*"
   - any:
       - "subsys/bluetooth/**/*"
       - "!subsys/bluetooth/mesh/**/*"
@@ -243,7 +255,7 @@
   - "drivers/watchdog/**/*"
   - "include/dfu/**/*"
   - "include/mgmt/mcumgr/**/*"
-  - "samples/bluetooth/hci_rpmsg/**/*"
+  - "samples/bluetooth/hci_rpc/**/*"
   - "soc/arm/nordic_nrf/**/*"
   - "subsys/bluetooth/audio/**/*"
   - "subsys/bluetooth/host/**/*"


### PR DESCRIPTION
Descope samples and tests from many CIs, since the majority are not affecting the functionality of protocols and applications.
Samples that may affect the overall performance and functionality, should be enabled specifically.