### PR TITLE
[nrf fromtree] dts: arm: nordic: keep NFCT disabled by default

### DIFF
--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -177,7 +177,7 @@
 			compatible = "nordic,nrf-nfct";
 			reg = <0x40005000 0x1000>;
 			interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
-			status = "okay";
+			status = "disabled";
 		};
 
 		gpiote: gpiote0: gpiote@40006000 {

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -184,7 +184,7 @@
 			compatible = "nordic,nrf-nfct";
 			reg = <0x40005000 0x1000>;
 			interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
-			status = "okay";
+			status = "disabled";
 		};
 
 		gpiote: gpiote0: gpiote@40006000 {

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -179,7 +179,7 @@
 			compatible = "nordic,nrf-nfct";
 			reg = <0x40005000 0x1000>;
 			interrupts = <5 NRF_DEFAULT_IRQ_PRIORITY>;
-			status = "okay";
+			status = "disabled";
 		};
 
 		gpiote: gpiote0: gpiote@40006000 {

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -449,7 +449,7 @@ nfct: nfct@2d000 {
 	compatible = "nordic,nrf-nfct";
 	reg = <0x2d000 0x1000>;
 	interrupts = <45 NRF_DEFAULT_IRQ_PRIORITY>;
-	status = "okay";
+	status = "disabled";
 };
 
 mutex: mutex@30000 {


### PR DESCRIPTION
This is a fromtree commit that disables NFCT by default. 

This allow us use Kconfig option generated from device tree to configure the NFCT  as GPIOS in TF-M.

Ref: NCSDK-24437