### PR TITLE
modules: hal_nordic: remove weak nrf_802154_clock_hfclk_ready

### DIFF
--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
@@ -109,11 +109,6 @@ bool nrf_802154_clock_lfclk_is_running(void)
 	return lfclk_is_running;
 }
 
-__WEAK void nrf_802154_clock_hfclk_ready(void)
-{
-	/* Intentionally empty. */
-}
-
 __WEAK void nrf_802154_clock_lfclk_ready(void)
 {
 	/* Intentionally empty. */


### PR DESCRIPTION
The __WEAK-tagged function `nrf_802154_clock_hfclk_ready` is removed. The implementation is provided by the nRF 802.15.4 Radio Driver. Existence of __WEAK-tagged version causes incorrect behavior when Link Time Optimization is used.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/69581