### PR TITLE
[nrf fromlist] dts: arm: nordic: "okay" status for wdt30 of nrf54l15_…

### DIFF
--- a/dts/arm/nordic/nrf54l15_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf54l15_cpuapp_peripherals.dtsi
@@ -379,7 +379,7 @@ wdt30: watchdog@108000 {
 	compatible = "nordic,nrf-wdt";
 	reg = <0x108000 0x620>;
 	interrupts = <264 NRF_DEFAULT_IRQ_PRIORITY>;
-	status = "disabled";
+	status = "okay";
 };
 
 wdt31: watchdog@109000 {


### PR DESCRIPTION
…cpuapp

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/69787

Change sets status of wdt30 to "okay". The wdt30 is used for watchdog0 alias. Change aligns behavior with our other SoCs.