### PR TITLE
[nrf fromlist] kconfig: shell: increase shell stack size for OpenThread

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -40,9 +40,8 @@ endif
 
 config SHELL_STACK_SIZE
 	int "Shell thread stack size"
-	default 3168 if OPENTHREAD_SHELL && OPENTHREAD_JOINER
+	default 3168 if OPENTHREAD_SHELL
 	default 3072 if 64BIT
-	default 2616 if OPENTHREAD_SHELL
 	default 2048 if MULTITHREADING
 	default 0 if !MULTITHREADING
 	help


### PR DESCRIPTION
Shell stack size is too low for OpenThread without joiner functionality, causing overflow. This commit increases it.

upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/69783

Signed-off-by: Maciej Baczmanski <maciej.baczmanski@nordicsemi.no>
(cherry picked from commit 4fb493e49fef245e62df21620382e027a7200907)