### PR TITLE
[nrf fromtree] net: l2: wifi: wifi_utils: Resolve build warning with …

### DIFF
--- a/subsys/net/l2/wifi/wifi_utils.c
+++ b/subsys/net/l2/wifi/wifi_utils.c
@@ -241,8 +241,7 @@ int wifi_utils_parse_scan_bands(char *scan_bands_str, uint8_t *band_map)
 		return -EINVAL;
 	}
 
-	strncpy(parse_str, scan_bands_str, len);
-	parse_str[len] = '\0';
+	strncpy(parse_str, scan_bands_str, sizeof(parse_str));
 
 	band_str = strtok_r(parse_str, ",", &ctx);
 

--- a/subsys/net/lib/sockets/sockets_packet.c
+++ b/subsys/net/lib/sockets/sockets_packet.c
@@ -144,6 +144,10 @@ static void zpacket_set_eth_pkttype(struct net_if *iface,
 				    struct sockaddr_ll *addr,
 				    struct net_linkaddr *lladdr)
 {
+	if (lladdr == NULL || lladdr->addr == NULL) {
+		return;
+	}
+
 	if (net_eth_is_addr_broadcast((struct net_eth_addr *)lladdr->addr)) {
 		addr->sll_pkttype = PACKET_BROADCAST;
 	} else if (net_eth_is_addr_multicast(


### PR DESCRIPTION
…strncpy function

ARM GCC version 12.2.0 (Zephyr SDK 0.16.4) generates the following build warning from the strncpy call in "wifi_utils_parse_scan_bands":

warning: '__builtin_strncpy' output truncated before terminating nul copying as many bytes from a string as its length

To resolve this warning, pass the maximum length of the temporary parse_str buffer to strncpy. This also has the benefit of correctly null terminating parse_str, since we already verify the scan_bands_str is properly null terminated with the strlen() check in this function. We can therefore remove the line adding a null terminator to parse_str as well.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>
(cherry picked from commit 76f547e7633266c51a6e9c147da1658afa9e5b88)