### PR TITLE
[nrf fromlist] modules: hal_nordic: Add RRAM to NRFX_NVMC

### DIFF
--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -144,6 +144,7 @@ config NRFX_NVMC
 	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF51_FLASH_CONTROLLER)) \
 		|| $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF52_FLASH_CONTROLLER)) \
 		|| $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF53_FLASH_CONTROLLER)) \
+		|| $(dt_has_compat,$(DT_COMPAT_NORDIC_RRAM_CONTROLLER))        \
 		|| $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF91_FLASH_CONTROLLER))
 
 config NRFX_PDM


### PR DESCRIPTION
Add missing dependency on nodric,rram-controller compatible.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/69913