### PR TITLE
[nrf fromtree] mcumgr/img_mgmt: Fix CONFIG_MCUBOOT_BOOTLOADER_NO_DOWN…

### DIFF
--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -472,7 +472,7 @@ os_mgmt_bootloader_info(struct smp_streamer *ctxt)
 
 		ok = zcbor_tstr_put_lit(zse, "mode") &&
 		     zcbor_int32_put(zse, BOOTLOADER_MODE);
-#if IS_ENABLED(MCUBOOT_BOOTLOADER_NO_DOWNGRADE)
+#if IS_ENABLED(CONFIG_MCUBOOT_BOOTLOADER_NO_DOWNGRADE)
 		ok = zcbor_tstr_put_lit(zse, "no-downgrade") &&
 		     zcbor_bool_encode(zse, true);
 #endif


### PR DESCRIPTION
…GRADE

Usage of the Kconfig, in code, has been missing CONFIG_, so selected or not it did nothing.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/69860