### PR TITLE
[nrf fromlist] scripts: snippets: Fix path output on windows

### DIFF
--- a/scripts/snippets.py
+++ b/scripts/snippets.py
@@ -56,7 +56,7 @@ class Snippet:
                 path = pathobj.parent / value
                 if not path.is_file():
                     _err(f'snippet file {pathobj}: {variable}: file not found: {path}')
-                return f'"{path}"'
+                return f'"{path.as_posix()}"'
             if variable in ('DTS_EXTRA_CPPFLAGS'):
                 return f'"{value}"'
             _err(f'unknown append variable: {variable}')


### PR DESCRIPTION
Fixes an issue with paths being output in windows-style with back slashes, this causes issues for certain escape sequences when cmake interprets them. Replace these paths with posix paths so that they are not treated as possible escape sequences.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/69963