### PR TITLE
[nrf fromlist] boards: nordic: nrf54h20pdk: add debugging support usi…

### DIFF
--- a/boards/arm/nrf54h20pdk_nrf54h20/board.cmake
+++ b/boards/arm/nrf54h20pdk_nrf54h20/board.cmake
@@ -1,3 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+
+if(CONFIG_BOARD_NRF54H20PDK_NRF54H20_CPUAPP OR CONFIG_BOARD_NRF54H20PDK_NRF54H20_CPURAD)
+  if(CONFIG_BOARD_NRF54H20PDK_NRF54H20_CPURAD)
+    set(
+      JLINK_TOOL_OPT
+      "-jlinkscriptfile ${CMAKE_CURRENT_LIST_DIR}/support/nrf54h20_cpurad.JLinkScript"
+    )
+  endif()
+
+  board_runner_args(jlink "--device=CORTEX-M33" "--speed=4000" "--tool-opt=${JLINK_TOOL_OPT}")
+  include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+endif()

--- a/boards/arm/nrf54h20pdk_nrf54h20/support/nrf54h20_cpurad.JLinkScript
+++ b/boards/arm/nrf54h20pdk_nrf54h20/support/nrf54h20_cpurad.JLinkScript
@@ -1,0 +1,4 @@
+void ConfigTargetSettings(void) {
+  JLINK_ExecCommand("CORESIGHT_AddAP = Index=1 Type=AHB-AP");
+  CORESIGHT_IndexAHBAPToUse = 1;
+}


### PR DESCRIPTION
…ng J-Link

cpuapp/cpurad can be debugged using the J-Link runner.

Note:
This feature is still experimental and has known issues. For example, setting a breakpoint to main requires to patch init.c with a loop polling a variable so that we stop there until unset from GDB.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/69960

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>
(cherry picked from commit 3ad88d7d5d26dfe8eedf386d128d6f1c3649a88c)