### PR TITLE
[nrf fromlist] scripts: runners: nrf: Check device family

### DIFF
--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -95,6 +95,17 @@ class NrfJprogBinaryRunner(NrfBinaryRunner):
         else:
             raise RuntimeError(f'Invalid operation: {op_type}')
 
+        # Make sure the device is in the expected family
+        try:
+            output = self.check_output(['nrfjprog', '--deviceversion', '--snr', self.dev_id])
+            if families[self.family] not in output.decode("ASCII"):
+                raise RuntimeError(f'Family mismatch: {families[self.family]} expected, but got {output.decode("ASCII")}')
+        except subprocess.CalledProcessError as cpe:
+            if cpe.returncode == UnavailableOperationBecauseProtectionError:
+                cpe.returncode = ErrNotAvailableBecauseProtection
+            raise cpe
+
+        # Execute the flash command
         try:
             self.check_call(cmd + ['-f', families[self.family]] + core_opt +
                             ['--snr', self.dev_id] + self.tool_opt)


### PR DESCRIPTION
This patch makes the nrfjprog runner check the device family before flashing. Otherwise, it is very easy to break some devices that have multiple different chips.

(cherry picked from commit e0aa35d74a5aaa6b2fa9f684385c8e8fcda2ad30)
Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>