### PR TITLE
[nrf fromtree] samples: hci_uart_async: Dont try to receive 0 bytes

### DIFF
--- a/samples/bluetooth/hci_uart_async/src/hci_uart_async.c
+++ b/samples/bluetooth/hci_uart_async/src/hci_uart_async.c
@@ -254,7 +254,9 @@ static void h2c_h4_transport(void)
 
 		LOG_DBG("h2c: payload_size %u", payload_size);
 
-		if (payload_size <= net_buf_tailroom(buf)) {
+		if (payload_size == 0) {
+			/* Done, dont rx zero bytes */
+		} else if (payload_size <= net_buf_tailroom(buf)) {
 			uint8_t *payload_dst = net_buf_add(buf, payload_size);
 
 			err = uart_h2c_rx(payload_dst, payload_size);


### PR DESCRIPTION
It is not necessary and it ends up in an nrfx assert.


(cherry picked from commit 976da5da5c0df600da199c8a622a43bc318162f8)