### PR TITLE
Use help for DISABLE_MBEDTLS_BUILTIN info

### DIFF
--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -41,10 +41,11 @@ config MBEDTLS_LIBRARY
 
 endchoice
 
-# subsystems cannot deselect MBEDTLS_BUILTIN, but they can select
-# DISABLE_MBEDTLS_BUILTIN.
 config DISABLE_MBEDTLS_BUILTIN
 	bool
+	help
+	  Subsystems cannot deselect MBEDTLS_BUILTIN, but they can select
+	  DISABLE_MBEDTLS_BUILTIN.
 
 config CUSTOM_MBEDTLS_CFG_FILE
 	bool "Custom mbed TLS configuration file"


### PR DESCRIPTION
Using a comment to explain Kconfig options make them invisible to Kconfig search. Use help instead.