### PR TITLE
Add support to configure BSSID in Wi-Fi connect command

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -360,6 +360,8 @@ struct wifi_connect_req_params {
 	enum wifi_security_type security;
 	/** MFP options */
 	enum wifi_mfp_options mfp;
+	/** BSSID */
+	uint8_t bssid[WIFI_MAC_ADDR_LEN];
 	/** Connect timeout in seconds, SYS_FOREVER_MS for no timeout */
 	int timeout;
 };

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -565,7 +565,6 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			break;
 		case 'h':
 			return -ENOEXEC;
-			break;
 		default:
 			PR_ERROR("Invalid option %c\n", opt);
 			shell_help(sh);

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -477,7 +477,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 	params->security = WIFI_SECURITY_TYPE_NONE;
 	params->mfp = WIFI_MFP_OPTIONAL;
 
-	while ((opt = getopt_long(argc, argv, "s:p:k:w:b:c:h", long_options, &opt_index)) != -1) {
+	while ((opt = getopt_long(argc, argv, "s:p:k:w:b:c:m:h", long_options, &opt_index)) != -1) {
 		state = getopt_state_get();
 		switch (opt) {
 		case 's':
@@ -561,6 +561,12 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			}
 			params->mfp = atoi(optarg);
 			break;
+		case 'm':
+			sscanf(optarg, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+				&params->bssid[0], &params->bssid[1],
+				&params->bssid[2], &params->bssid[3],
+				&params->bssid[4], &params->bssid[5]);
+			break;
 		case 'h':
 			shell_help(sh);
 			break;
@@ -570,6 +576,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			return -EINVAL;
 		}
 	}
+
 	return 0;
 }
 
@@ -1858,9 +1865,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 		  "[-k, --key-mgmt]: Key Management type (valid only for secure SSIDs)\n"
 		  "0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE, 4:WAPI, 5:EAP, 6:WEP, 7: WPA-PSK\n"
 		  "[-w, --ieee-80211w]: MFP (optional: needs security type to be specified)\n"
-		  ": 0:Disable, 1:Optional, 2:Required.\n",
+		  ": 0:Disable, 1:Optional, 2:Required.\n"
+		  "[-m, --bssid]: MAC address of the AP (BSSID).\n"
+		  "[-h, --help]: Print out the help for the connect command.\n",
 		  cmd_wifi_connect,
-		  2, 5),
+		  2, 7),
 	SHELL_CMD_ARG(disconnect, NULL, "Disconnect from the Wi-Fi AP.\n",
 		  cmd_wifi_disconnect,
 		  1, 0),

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -496,12 +496,8 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			}
 			break;
 		case 'p':
-			if (secure_connection) {
-				params->psk = optarg;
-				params->psk_length = strlen(params->psk);
-			} else {
-				PR_WARNING("Passphrase provided without security configuration\n");
-			}
+			params->psk = optarg;
+			params->psk_length = strlen(params->psk);
 			break;
 		case 'c':
 			long channel = strtol(optarg, &endptr, 10);
@@ -568,7 +564,7 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 				&params->bssid[4], &params->bssid[5]);
 			break;
 		case 'h':
-			shell_help(sh);
+			return -ENOEXEC;
 			break;
 		default:
 			PR_ERROR("Invalid option %c\n", opt);
@@ -576,7 +572,9 @@ static int __wifi_args_to_params(const struct shell *sh, size_t argc, char *argv
 			return -EINVAL;
 		}
 	}
-
+	if (params->psk && !secure_connection) {
+		PR_WARNING("Passphrase provided without security configuration\n");
+	}
 	return 0;
 }
 
@@ -1242,7 +1240,7 @@ static int cmd_wifi_ap_enable(const struct shell *sh, size_t argc,
 	int ret;
 
 	context.sh = sh;
-	if (__wifi_args_to_params(sh, argc - 1, &argv[1], &cnx_params, WIFI_MODE_AP)) {
+	if (__wifi_args_to_params(sh, argc, &argv[0], &cnx_params, WIFI_MODE_AP)) {
 		shell_help(sh);
 		return -ENOEXEC;
 	}
@@ -1805,15 +1803,18 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_cmd_ap,
 		  cmd_wifi_ap_disable,
 		  1, 0),
 	SHELL_CMD_ARG(enable, NULL,
-		  "\"<SSID>\"\n"
-		  "<channel number>\n"
-		  "[PSK: valid only for secure SSIDs]\n"
-		  "[Security type: valid only for secure SSIDs]\n"
+		  "-s --ssid=<SSID>\n"
+		  "-c --channel=<channel number>\n"
+		  "-p --passphrase=<PSK> (valid only for secure SSIDs)\n"
+		  "-k --key-mgmt=<Security type> (valid only for secure SSIDs)\n"
 		  "0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE, 4:WAPI, 5:EAP, 6:WEP, 7: WPA-PSK\n"
-		  "[MFP (optional: needs security type to be specified)]\n"
-		  ": 0:Disable, 1:Optional, 2:Required.\n",
+		  "-w --ieee-80211w=<MFP> (optional: needs security type to be specified)\n"
+		  "0:Disable, 1:Optional, 2:Required\n"
+		  "-b --band=<band> (2 -2.6GHz, 5 - 5Ghz, 6 - 6GHz)\n"
+		  "-m --bssid=<BSSID>\n"
+		  "-h --help (prints help)",
 		  cmd_wifi_ap_enable,
-		  3, 3),
+		  2, 13),
 	SHELL_CMD_ARG(stations, NULL,
 		  "List stations connected to the AP",
 		  cmd_wifi_ap_stations,

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -1863,7 +1863,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 		  "[-c --channel]: Channel that needs to be scanned for connection. 0:any channel.\n"
 		  "[-b, --band] 0: any band (2:2.4GHz, 5:5GHz, 6:6GHz]\n"
 		  "[-p, --psk]: Passphrase (valid only for secure SSIDs)\n"
-		  "[-k, --key-mgmt]: Key Management type (valid only for secure SSIDs)\n"
+		  "[-k, --key-mgmt]: Key Management type\n"
 		  "0:None, 1:WPA2-PSK, 2:WPA2-PSK-256, 3:SAE, 4:WAPI, 5:EAP, 6:WEP, 7: WPA-PSK\n"
 		  "[-w, --ieee-80211w]: MFP (optional: needs security type to be specified)\n"
 		  ": 0:Disable, 1:Optional, 2:Required.\n"


### PR DESCRIPTION
1. Use getopt API to process the arguments passed with connect command.
2. Add support for BSSID configuration in connect call.