### PR TITLE
[nrf fromtree] tests: drivers: uart: uart_mix_fifo_poll: Add nRF54L15…

### DIFF
--- a/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
+++ b/tests/drivers/uart/uart_mix_fifo_poll/testcase.yaml
@@ -8,6 +8,7 @@ common:
     - nrf52840dk_nrf52840
     - nrf9160dk_nrf9160
     - nrf5340dk_nrf5340_cpuapp
+    - nrf54l15pdk_nrf54l15_cpuapp
     - nrf52_bsim
   integration_platforms:
     - nrf52840dk_nrf52840


### PR DESCRIPTION
… to platform allow

Add nRF54L15 to the platform allow list.
Overlay file already exists.

Signed-off-by: Sebastian Głąb <sebastian.glab@nordicsemi.no>
(cherry picked from commit 2b549daabc9d2cddda3e22c6ec1f5b27ea1997ad)