### PR TITLE
[nrf fromtree] samples: sensor: qdec: Allow coverage calculation

### DIFF
--- a/samples/sensor/qdec/src/main.c
+++ b/samples/sensor/qdec/src/main.c
@@ -85,7 +85,11 @@ int main(void)
 
 	qenc_emulate_init();
 
+#ifndef CONFIG_COVERAGE
 	while (true) {
+#else
+	for (int i = 0; i < 3; i++) {
+#endif
 		rc = sensor_sample_fetch(dev);
 		if (rc != 0) {
 			printk("Failed to fetch sample (%d)\n", rc);


### PR DESCRIPTION
Sample must end to dump coverage data.

Signed-off-by: Piotr Kosycarz <piotr.kosycarz@nordicsemi.no>
(cherry picked from commit 8d4743d14474fc5b65cbb8016aeee7ab3fe3090c)