### PR TITLE
[nrf noup] test-spec: include nrf54 boards in low-level test trigger

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -293,6 +293,8 @@
 
 "CI-test-low-level":
   - "dts/**/*"
+  - "boards/arm/nrf54*/**/*"
+  - "boards/riscv/nrf54*/**/*"
   - "include/zephyr/**/*"
   - "tests/arch/**/*"
   - "arch/**/*"


### PR DESCRIPTION
All changes in nrf54 boards will trigger low-level testing.