### PR TITLE
fixup! [nrf noup] tree-wide: support NCS Partition Manager (PM) defin…

### DIFF
--- a/cmake/modules/kernel.cmake
+++ b/cmake/modules/kernel.cmake
@@ -245,5 +245,7 @@ if("${CMAKE_EXTRA_GENERATOR}" STREQUAL "Eclipse CDT4")
 endif()
 
 if(ZEPHYR_NRF_MODULE_DIR)
-  include(${ZEPHYR_NRF_MODULE_DIR}/cmake/partition_manager.cmake)
+  if (NOT SYSBUILD OR (SYSBUILD AND SB_CONFIG_PARTITION_MANAGER))
+    include(${ZEPHYR_NRF_MODULE_DIR}/cmake/partition_manager.cmake)
+  endif()
 endif()


### PR DESCRIPTION
…itions

Allow SB_CONFIG_PARTITION_MANAGER to control inclusion of parition_manager.cmake.