### PR TITLE
[nrf fromlist] boards: nrf54l15pdk_nrf54l15_cpuapp: yaml for PDK 0.3.0

### DIFF
--- a/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.yaml
+++ b/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+identifier: nrf54l15pdk_nrf54l15_cpuapp@0.3.0
+name: nRF54l15-PDK-nRF54l15-Application
+type: mcu
+arch: arm
+toolchain:
+  - gnuarmemb
+  - xtools
+  - zephyr
+ram: 256
+flash: 1536
+supported:
+  - counter
+  - gpio
+  - i2c
+  - spi
+  - watchdog
+  - i2s


### PR DESCRIPTION
add twister yaml to support PDK 0.3.0 in tests

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/71375 