### PR TITLE
[nrf fromtree] drivers: pinctrl_nrf: Configure QSPI IO3 pin as output…

### DIFF
--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -355,7 +355,8 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			break;
 		case NRF_FUN_QSPI_IO3:
 			NRF_PSEL_QSPI(reg, IO3) = psel;
-			dir = NRF_GPIO_PIN_DIR_INPUT;
+			write = 1U;
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
 			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 #endif /* defined(NRF_PSEL_QSPI) */


### PR DESCRIPTION
… set high

... so that the pin is kept in a defined state when the IO3 line is not controlled by the QSPI peripheral (when the peripheral is disabled or disconnected from the pin).

The IO3 pin in Quad SPI flash chips usually has dual functionality - it is an I/O line when the chip is configured to work in Quad (4 I/O) mode and it is a HOLD# or RESET# line when the chip is configured to work in non-Quad (2 I/O) mode. In the latter case, it is important that the line is kept in the inactive (high) state, otherwise communication with the chip may be disrupted (and this actually happens when e.g. the spi_flash sample is used on a brand new nRF5340 or nRF52840 DK - the nrf_qspi_nor driver fails to initialize and the sample just ends up with the "mx25r6435f@0: device not ready" message).

This commit addresses the problem in the same way that it was done for the CSN line in commit 6d8172f4e997254a338b8b8eee92e1c1fb36229d.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/71373