### PR TITLE
[nrf noup] tests: Allow UARTE new tests to run with HW model v…

### DIFF
--- a/tests/drivers/uart/uart_elementary/testcase.yaml
+++ b/tests/drivers/uart/uart_elementary/testcase.yaml
@@ -8,20 +8,20 @@ tests:
   drivers.uart.uart_elementary:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
     platform_allow:
-      - nrf54h20dk/nrf54h20/cpuapp
-      - nrf54l15pdk/nrf54l15/cpuapp
-      - nrf5340dk/nrf5340/cpuapp
+      - nrf54h20dk_nrf54h20_cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
+      - nrf5340dk_nrf5340_cpuapp
   drivers.uart.uart_elementary_dual_nrf54h:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
     platform_allow:
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk_nrf54h20_cpuapp
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_dual_uart.overlay"
     extra_configs:
       - CONFIG_DUAL_UART_TEST=y
   drivers.uart.uart_elementary_dual_setup_mismatch_nrf54h:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
     platform_allow:
-      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk_nrf54h20_cpuapp
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_dual_uart.overlay"
     extra_configs:
       - CONFIG_DUAL_UART_TEST=y
@@ -29,7 +29,7 @@ tests:
   drivers.uart.uart_elementary_dual_nrf54l:
     filter: CONFIG_SERIAL_SUPPORT_INTERRUPT
     platform_allow:
-      - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54l15pdk_nrf54l15_cpuapp
     extra_args: DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_dual_uart.overlay"
     extra_configs:
       - CONFIG_DUAL_UART_TEST=y


### PR DESCRIPTION
…1 board names

NRFX-5524: Verify coverage for UARTE - extend testing