### PR TITLE
[v3.4.99-ncs1-branch] net: tcp: FIN with data fixes

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2500,28 +2500,9 @@ next_state:
 		break;
 	case TCP_ESTABLISHED:
 		/* full-close */
-		if (th && FL(&fl, ==, (FIN | ACK), th_seq(th) == conn->ack)) {
-			if (net_tcp_seq_cmp(th_ack(th), conn->seq) > 0) {
-				uint32_t len_acked = th_ack(th) - conn->seq;
+		if (th && FL(&fl, &, FIN, th_seq(th) == conn->ack)) {
+			bool acked = false;
 
-				conn_seq(conn, + len_acked);
-			}
-
-			conn_ack(conn, + 1);
-			tcp_out(conn, FIN | ACK);
-			conn_seq(conn, + 1);
-			next = TCP_LAST_ACK;
-			verdict = NET_OK;
-			tcp_setup_last_ack_timer(conn);
-			break;
-		} else if (th && FL(&fl, ==, FIN, th_seq(th) == conn->ack)) {
-			conn_ack(conn, + 1);
-			tcp_out(conn, ACK);
-			next = TCP_CLOSE_WAIT;
-			verdict = NET_OK;
-			break;
-		} else if (th && FL(&fl, ==, (FIN | ACK | PSH),
-				    th_seq(th) == conn->ack)) {
 			if (len) {
 				verdict = tcp_data_get(conn, pkt, &len);
 				if (verdict == NET_OK) {
@@ -2533,10 +2514,27 @@ next_state:
 			}
 
 			conn_ack(conn, + len + 1);
-			tcp_out(conn, FIN | ACK);
-			conn_seq(conn, + 1);
-			next = TCP_LAST_ACK;
-			tcp_setup_last_ack_timer(conn);
+
+			if (FL(&fl, &, ACK)) {
+				acked = true;
+
+				if (net_tcp_seq_cmp(th_ack(th), conn->seq) > 0) {
+					uint32_t len_acked = th_ack(th) - conn->seq;
+
+					conn_seq(conn, + len_acked);
+				}
+			}
+
+			if (acked) {
+				tcp_out(conn, FIN | ACK);
+				conn_seq(conn, + 1);
+				tcp_setup_last_ack_timer(conn);
+				next = TCP_LAST_ACK;
+			} else {
+				tcp_out(conn, ACK);
+				next = TCP_CLOSE_WAIT;
+			}
+
 			break;
 		}
 

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -28,6 +28,8 @@ LOG_MODULE_REGISTER(net_tcp, CONFIG_NET_TCP_LOG_LEVEL);
 
 #define ACK_TIMEOUT_MS CONFIG_NET_TCP_ACK_TIMEOUT
 #define ACK_TIMEOUT K_MSEC(ACK_TIMEOUT_MS)
+#define LAST_ACK_TIMEOUT_MS tcp_fin_timeout_ms
+#define LAST_ACK_TIMEOUT K_MSEC(LAST_ACK_TIMEOUT_MS)
 #define FIN_TIMEOUT K_MSEC(tcp_fin_timeout_ms)
 #define ACK_DELAY K_MSEC(100)
 #define ZWP_MAX_DELAY_MS 120000
@@ -1448,9 +1450,9 @@ static void tcp_resend_data(struct k_work *work)
 	conn->send_data_retries++;
 	if (ret == 0) {
 		if (conn->in_close && conn->send_data_total == 0) {
-			NET_DBG("TCP connection in active close, "
+			NET_DBG("TCP connection in %s close, "
 				"not disposing yet (waiting %dms)",
-				tcp_fin_timeout_ms);
+				"active", tcp_fin_timeout_ms);
 			k_work_reschedule_for_queue(&tcp_work_q,
 						    &conn->fin_timer,
 						    FIN_TIMEOUT);
@@ -1525,6 +1527,40 @@ static void tcp_fin_timeout(struct k_work *work)
 	NET_DBG("conn: %p %s", conn, tcp_conn_state(conn, NULL));
 
 	(void)tcp_conn_close(conn, -ETIMEDOUT);
+}
+
+static void tcp_last_ack_timeout(struct k_work *work)
+{
+	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
+	struct tcp *conn = CONTAINER_OF(dwork, struct tcp, fin_timer);
+
+	NET_DBG("Did not receive %s in %dms", "last ACK", LAST_ACK_TIMEOUT_MS);
+	NET_DBG("conn: %p %s", conn, tcp_conn_state(conn, NULL));
+
+	(void)tcp_conn_close(conn, -ETIMEDOUT);
+}
+
+static void tcp_setup_last_ack_timer(struct tcp *conn)
+{
+	/* Just in case the last ack is lost, install a timer that will
+	 * close the connection in that case. Use the fin_timer for that
+	 * as the fin handling cannot be done in this passive close state.
+	 * Instead of default tcp_fin_timeout() function, have a separate
+	 * function to catch this last ack case.
+	 */
+	k_work_init_delayable(&conn->fin_timer, tcp_last_ack_timeout);
+
+	NET_DBG("TCP connection in %s close, "
+		"not disposing yet (waiting %dms)",
+		"passive", LAST_ACK_TIMEOUT_MS);
+	k_work_reschedule_for_queue(&tcp_work_q,
+				    &conn->fin_timer,
+				    LAST_ACK_TIMEOUT);
+}
+
+static void tcp_cancel_last_ack_timer(struct tcp *conn)
+{
+	k_work_cancel_delayable(&conn->fin_timer);
 }
 
 static void tcp_send_zwp(struct k_work *work)
@@ -2475,6 +2511,7 @@ next_state:
 			tcp_out(conn, FIN | ACK);
 			next = TCP_LAST_ACK;
 			verdict = NET_OK;
+			tcp_setup_last_ack_timer(conn);
 			break;
 		} else if (th && FL(&fl, ==, FIN, th_seq(th) == conn->ack)) {
 			conn_ack(conn, + 1);
@@ -2497,6 +2534,7 @@ next_state:
 			conn_ack(conn, + len + 1);
 			tcp_out(conn, FIN | ACK);
 			next = TCP_LAST_ACK;
+			tcp_setup_last_ack_timer(conn);
 			break;
 		}
 
@@ -2671,6 +2709,7 @@ next_state:
 	case TCP_CLOSE_WAIT:
 		tcp_out(conn, FIN);
 		next = TCP_LAST_ACK;
+		tcp_setup_last_ack_timer(conn);
 		break;
 	case TCP_LAST_ACK:
 		if (th && FL(&fl, ==, ACK, th_seq(th) == conn->ack)) {
@@ -2678,6 +2717,9 @@ next_state:
 			do_close = true;
 			verdict = NET_OK;
 			close_status = 0;
+
+			/* Remove the last ack timer if we received it in time */
+			tcp_cancel_last_ack_timer(conn);
 		}
 		break;
 	case TCP_CLOSED:
@@ -3003,8 +3045,9 @@ int net_tcp_put(struct net_context *context)
 		} else {
 			int ret;
 
-			NET_DBG("TCP connection in active close, not "
-				"disposing yet (waiting %dms)", tcp_fin_timeout_ms);
+			NET_DBG("TCP connection in %s close, "
+				"not disposing yet (waiting %dms)",
+				"active", tcp_fin_timeout_ms);
 			k_work_reschedule_for_queue(&tcp_work_q,
 						    &conn->fin_timer,
 						    FIN_TIMEOUT);

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2636,6 +2636,10 @@ next_state:
 				tcp_send_timer_cancel(conn);
 				next = TCP_FIN_WAIT_1;
 
+				k_work_reschedule_for_queue(&tcp_work_q,
+							    &conn->fin_timer,
+							    FIN_TIMEOUT);
+
 				tcp_out(conn, FIN | ACK);
 				conn_seq(conn, + 1);
 				verdict = NET_OK;

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2509,6 +2509,7 @@ next_state:
 
 			conn_ack(conn, + 1);
 			tcp_out(conn, FIN | ACK);
+			conn_seq(conn, + 1);
 			next = TCP_LAST_ACK;
 			verdict = NET_OK;
 			tcp_setup_last_ack_timer(conn);
@@ -2533,6 +2534,7 @@ next_state:
 
 			conn_ack(conn, + len + 1);
 			tcp_out(conn, FIN | ACK);
+			conn_seq(conn, + 1);
 			next = TCP_LAST_ACK;
 			tcp_setup_last_ack_timer(conn);
 			break;
@@ -2712,11 +2714,12 @@ next_state:
 		break;
 	case TCP_CLOSE_WAIT:
 		tcp_out(conn, FIN);
+		conn_seq(conn, + 1);
 		next = TCP_LAST_ACK;
 		tcp_setup_last_ack_timer(conn);
 		break;
 	case TCP_LAST_ACK:
-		if (th && FL(&fl, ==, ACK, th_seq(th) == conn->ack)) {
+		if (th && FL(&fl, ==, ACK, th_ack(th) == conn->seq)) {
 			tcp_send_timer_cancel(conn);
 			do_close = true;
 			verdict = NET_OK;

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -129,6 +129,7 @@ static void handle_client_closing_test(sa_family_t af, struct tcphdr *th);
 static void handle_data_fin1_test(sa_family_t af, struct tcphdr *th);
 static void handle_data_during_fin1_test(sa_family_t af, struct tcphdr *th);
 static void handle_server_recv_out_of_order(struct net_pkt *pkt);
+static void handle_client_fin_ack_with_data_test(sa_family_t af, struct tcphdr *th);
 
 static void verify_flags(struct tcphdr *th, uint8_t flags,
 			 const char *fun, int line)
@@ -430,6 +431,11 @@ static int tester_send(const struct device *dev, struct net_pkt *pkt)
 	case 11:
 		handle_data_during_fin1_test(net_pkt_family(pkt), &th);
 		break;
+
+	case 18:
+		handle_client_fin_ack_with_data_test(net_pkt_family(pkt), &th);
+		break;
+
 	default:
 		zassert_true(false, "Undefined test case");
 	}
@@ -1809,6 +1815,193 @@ ZTEST(net_tcp, test_server_out_of_order_data)
 {
 	test_server_recv_out_of_order_data();
 	test_server_timeout_out_of_order_data();
+}
+
+#define TEST_FIN_DATA "test_data"
+
+static enum fin_data_variant {
+	FIN_DATA_FIN,
+	FIN_DATA_FIN_ACK,
+	FIN_DATA_FIN_ACK_PSH,
+} test_fin_data_variant;
+
+static struct k_work_delayable test_fin_data_work;
+
+/* In this test we check that FIN packet containing data is handled correctly
+ * by the TCP stack.
+ */
+static void handle_client_fin_ack_with_data_test(sa_family_t af, struct tcphdr *th)
+{
+	static uint16_t peer_port;
+	struct net_pkt *reply;
+	uint8_t flags = 0;
+
+	switch (t_state) {
+	case T_SYN:
+		test_verify_flags(th, SYN);
+		device_initial_seq = ntohl(th->th_seq);
+		seq = 0U;
+		ack = ntohl(th->th_seq) + 1U;
+		peer_port = th->th_sport;
+		reply = prepare_syn_ack_packet(af, htons(MY_PORT), peer_port);
+		seq++;
+		t_state = T_SYN_ACK;
+		break;
+	case T_SYN_ACK:
+		test_verify_flags(th, ACK);
+		t_state = T_DATA;
+
+		/* FIN packet with DATA needs to be rescheduled for later - if
+		 * we send it here, the net_context_recv() won't have a chance
+		 * to execute, hence no callback will be registered and data
+		 * will be dropped.
+		 */
+		k_work_reschedule(&test_fin_data_work, K_MSEC(1));
+		return;
+	case T_DATA:
+		switch (test_fin_data_variant) {
+		case FIN_DATA_FIN:
+			flags = FIN;
+			t_state = T_FIN;
+			break;
+		case FIN_DATA_FIN_ACK:
+			flags = FIN | ACK;
+			t_state = T_FIN_ACK;
+			break;
+		case FIN_DATA_FIN_ACK_PSH:
+			flags = FIN | ACK | PSH;
+			t_state = T_FIN_ACK;
+			break;
+		}
+
+		reply = tester_prepare_tcp_pkt(af, htons(MY_PORT), peer_port,
+					       flags, TEST_FIN_DATA,
+					       strlen(TEST_FIN_DATA));
+		seq += strlen(TEST_FIN_DATA) + 1;
+
+		break;
+	case T_FIN:
+		test_verify_flags(th, ACK);
+		zassert_equal(get_rel_seq(th), 1, "Unexpected SEQ number in T_FIN, got %d",
+			      get_rel_seq(th));
+		zassert_equal(ntohl(th->th_ack), seq, "Unexpected ACK in T_FIN, got %d",
+			      ntohl(th->th_ack));
+
+		t_state = T_CLOSING;
+		return;
+	case T_FIN_ACK:
+		test_verify_flags(th, FIN | ACK);
+		zassert_equal(get_rel_seq(th), 1, "Unexpected SEQ number in T_FIN_ACK, got %d",
+			      get_rel_seq(th));
+		zassert_equal(ntohl(th->th_ack), seq, "Unexpected ACK in T_FIN_ACK, got %d",
+			      ntohl(th->th_ack));
+
+		ack++;
+		reply = prepare_ack_packet(af, htons(MY_PORT), peer_port);
+		t_state = T_SYN;
+		break;
+
+	case T_CLOSING:
+		test_verify_flags(th, FIN);
+		zassert_equal(get_rel_seq(th), 1, "Unexpected SEQ number in T_CLOSING, got %d",
+			      get_rel_seq(th));
+
+		ack++;
+		reply = prepare_ack_packet(af, htons(MY_PORT), peer_port);
+		t_state = T_SYN;
+		break;
+
+	default:
+		zassert_true(false, "%s unexpected state", __func__);
+		return;
+	}
+
+	zassert_ok(net_recv_data(net_iface, reply), "%s failed", __func__);
+}
+
+
+static void test_fin_data_handler(struct k_work *work)
+{
+	ARG_UNUSED(work);
+
+	handle_client_fin_ack_with_data_test(AF_INET, NULL);
+}
+
+static void test_fin_ack_data_recv_cb(struct net_context *context,
+				      struct net_pkt *pkt,
+				      union net_ip_header *ip_hdr,
+				      union net_proto_header *proto_hdr,
+				      int status,
+				      void *user_data)
+{
+	if (status) {
+		zassert_true(false, "failed to recv the data");
+	}
+
+	if (pkt) {
+		uint8_t buf[sizeof(TEST_FIN_DATA)] = { 0 };
+		int data_len = net_pkt_remaining_data(pkt);
+
+		zassert_equal(data_len, strlen(TEST_FIN_DATA),
+			      "Invalid packet length, %d", data_len);
+		zassert_ok(net_pkt_read(pkt, buf, data_len));
+		zassert_mem_equal(buf, TEST_FIN_DATA, data_len);
+
+		net_pkt_unref(pkt);
+	}
+
+	test_sem_give();
+}
+
+/* Test case scenario IPv4
+ *   expect SYN,
+ *   send SYN ACK,
+ *   expect ACK,
+ *   send FIN/FIN,ACK/FIN,ACK,PSH with Data,
+ *   expect FIN/FIN,ACK/ACK,
+ *   send ACK
+ *   any failures cause test case to fail.
+ */
+ZTEST(net_tcp, test_client_fin_ack_with_data)
+{
+	struct net_context *ctx;
+
+	test_case_no = 18;
+
+	k_work_init_delayable(&test_fin_data_work, test_fin_data_handler);
+
+	for (enum fin_data_variant variant = FIN_DATA_FIN;
+	     variant <= FIN_DATA_FIN_ACK_PSH; variant++) {
+		test_fin_data_variant = variant;
+		t_state = T_SYN;
+		seq = ack = 0;
+
+		zassert_ok(net_context_get(AF_INET, SOCK_STREAM, IPPROTO_TCP, &ctx),
+			   "Failed to get net_context");
+
+		net_context_ref(ctx);
+
+		zassert_ok(net_context_connect(ctx, (struct sockaddr *)&peer_addr_s,
+					       sizeof(struct sockaddr_in), NULL,
+					       K_MSEC(1000), NULL),
+			   "Failed to connect to peer");
+		zassert_ok(net_context_recv(ctx, test_fin_ack_data_recv_cb,
+					    K_NO_WAIT, NULL),
+			   "Failed to recv data from peer");
+
+		/* Take sem twice, one for data packet, second for conn close
+		 * (NULL net_pkt).
+		 */
+		test_sem_take(K_MSEC(100), __LINE__);
+		test_sem_take(K_MSEC(100), __LINE__);
+
+		net_context_put(ctx);
+
+		/* Connection is in TIME_WAIT state, context will be released
+		 * after K_MSEC(CONFIG_NET_TCP_TIME_WAIT_DELAY), so wait for it.
+		 */
+		k_sleep(K_MSEC(CONFIG_NET_TCP_TIME_WAIT_DELAY));
+	}
 }
 
 ZTEST_SUITE(net_tcp, NULL, presetup, NULL, NULL, NULL);


### PR DESCRIPTION
Pull fixes for FIN with data case from the upstream, along with some predependencies to reduce the number of conflicts. 
I've also pulled the new test case, to make sure the fix works well with the older code base.

Fixes SHEL-2687