### PR TITLE
[nrf fromtree] Bluetooth: Audio: Add iso_chan to bt_bap_ep_info

### DIFF
--- a/include/zephyr/bluetooth/audio/bap.h
+++ b/include/zephyr/bluetooth/audio/bap.h
@@ -397,6 +397,9 @@ struct bt_bap_ep_info {
 	/** Capabilities type */
 	enum bt_audio_dir dir;
 
+	/** The isochronous channel associated with the endpoint. */
+	struct bt_iso_chan *iso_chan;
+
 	/** @brief True if the stream associated with the endpoint is able to send data */
 	bool can_send;
 

--- a/subsys/bluetooth/audio/bap_stream.c
+++ b/subsys/bluetooth/audio/bap_stream.c
@@ -107,8 +107,10 @@ int bt_bap_ep_get_info(const struct bt_bap_ep *ep, struct bt_bap_ep_info *info)
 
 	if (ep->iso == NULL) {
 		info->paired_ep = NULL;
+		info->iso_chan = NULL;
 	} else {
 		info->paired_ep = bt_bap_iso_get_paired_ep(ep);
+		info->iso_chan = &ep->iso->chan;
 	}
 
 	info->can_send = false;


### PR DESCRIPTION
By exposing the underlying iso channel, the application can retrieve properties of the iso channel.

This can be useful in case the application wants to use the connection handle for vendor specific HCI commands or to retrieve the particular parameters used for the given channel.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>
(cherry picked from commit 75973852bfb0328957b2bf86cfbe67e1139ee2c0)