### PR TITLE
Nrf54l15 ext flash smp svr

### DIFF
--- a/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp-pinctrl.dtsi
+++ b/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp-pinctrl.dtsi
@@ -47,4 +47,21 @@
 			low-power-enable;
 		};
 	};
+
+	spi0_default: spi0_default {
+		group1 {
+				psels = <NRF_PSEL(SPIM_SCK, 2, 1)>,
+						<NRF_PSEL(SPIM_MOSI, 2, 2)>,
+						<NRF_PSEL(SPIM_MISO, 2, 4)>;
+		};
+	};
+
+	spi0_sleep: spi0_sleep {
+		group1 {
+				psels = <NRF_PSEL(SPIM_SCK, 2, 1)>,
+						<NRF_PSEL(SPIM_MOSI, 2, 2)>,
+						<NRF_PSEL(SPIM_MISO, 2, 4)>;
+						low-power-enable;
+		};
+	};
 };

--- a/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp.dts
+++ b/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp.dts
@@ -77,6 +77,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		spi-flash0 = &mx25r64;
 	};
 };
 
@@ -173,4 +174,30 @@
 
 &clock {
 	status = "okay";
+};
+
+&spi00 {
+	status = "okay";
+	cs-gpios = <&gpio2 5 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&spi0_default>;
+	pinctrl-1 = <&spi0_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	mx25r64: mx25r6435f@0 {
+		compatible = "jedec,spi-nor";
+		reg = <0>;
+		status = "disabled";
+		spi-max-frequency = <8000000>;
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 48 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
 };

--- a/samples/subsys/mgmt/mcumgr/smp_svr/boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay
@@ -1,0 +1,9 @@
+/ {
+	chosen {
+		nordic,pm-ext-flash = &mx25r64;
+	};
+};
+
+&mx25r64 {
+	status = "okay";
+};

--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -94,3 +94,15 @@ tests:
       - mg100
     integration_platforms:
       - nrf52840dk_nrf52840
+  sample.mcumgr.smp_svr.bt.nrf54l15pdk.ext_flash:
+    extra_args:
+      - OVERLAY_CONFIG="overlay-bt.conf"
+      - DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay"
+      - mcuboot_CONF_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.conf"
+      - mcuboot_EXTRA_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay"
+    extra_configs:
+      - CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
+    platform_allow:
+      - nrf54l15pdk_nrf54l15_cpuapp
+    integration_platforms:
+      - nrf54l15pdk_nrf54l15_cpuapp

--- a/soc/common/nordic_nrf/Kconfig.peripherals
+++ b/soc/common/nordic_nrf/Kconfig.peripherals
@@ -74,6 +74,9 @@ config HAS_HW_NRF_GPIO0
 config HAS_HW_NRF_GPIO1
 	def_bool $(dt_nodelabel_enabled_with_compat,gpio1,$(DT_COMPAT_NORDIC_NRF_GPIO))
 
+config HAS_HW_NRF_GPIO2
+	def_bool $(dt_nodelabel_enabled_with_compat,gpio2,$(DT_COMPAT_NORDIC_NRF_GPIO))
+
 config HAS_HW_NRF_GPIOTE0
 	def_bool $(dt_nodelabel_enabled_with_compat,gpiote0,$(DT_COMPAT_NORDIC_NRF_GPIOTE))
 


### PR DESCRIPTION
Configuration for MCUboot and smp_svr which
allows to use nRF54L15pdk external flash as location for the secondary partition.

For testing, see usage in [the manifest PR](https://github.com/nrfconnect/sdk-nrf/pull/14838) description.