### PR TITLE
[nrf fromtree] tests: drivers: clock_control: Add nRF54L15 to platfor…

### DIFF
--- a/tests/drivers/clock_control/clock_control_api/testcase.yaml
+++ b/tests/drivers/clock_control/clock_control_api/testcase.yaml
@@ -7,6 +7,7 @@ tests:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf54l15pdk_nrf54l15_cpuapp
       - nrf9160dk_nrf9160
     integration_platforms:
       - nrf51dk_nrf51422
@@ -18,6 +19,7 @@ tests:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf51dk_nrf51422
     extra_args: CONF_FILE="nrf_lfclk_rc.conf"

--- a/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_clock_calibration/testcase.yaml
@@ -7,5 +7,6 @@ tests:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf51dk_nrf51422

--- a/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
+++ b/tests/drivers/clock_control/nrf_lf_clock_start/testcase.yaml
@@ -13,6 +13,7 @@ tests:
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpunet
+      - nrf54l15pdk_nrf54l15_cpuapp
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_WAIT_FOR_STABILITY=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
@@ -27,6 +28,7 @@ tests:
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpunet
+      - nrf54l15pdk_nrf54l15_cpuapp
     extra_configs:
       - CONFIG_SYSTEM_CLOCK_WAIT_FOR_AVAILABILITY=y
       - CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL=y
@@ -41,6 +43,7 @@ tests:
       - nrf9160dk_nrf9160
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpunet
+      - nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf51dk_nrf51422
     extra_configs:
@@ -54,6 +57,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpunet
+      - nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf51dk_nrf51422
     extra_configs:
@@ -67,6 +71,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpunet
+      - nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf51dk_nrf51422
     extra_configs:
@@ -80,6 +85,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpunet
+      - nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf51dk_nrf51422
     extra_configs:
@@ -93,6 +99,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpunet
+      - nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf51dk_nrf51422
     extra_configs:
@@ -106,6 +113,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpunet
+      - nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf51dk_nrf51422
     extra_configs:
@@ -119,6 +127,7 @@ tests:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
       - nrf5340dk_nrf5340_cpunet
+      - nrf54l15pdk_nrf54l15_cpuapp
     integration_platforms:
       - nrf51dk_nrf51422
     extra_configs:

--- a/tests/drivers/clock_control/onoff/testcase.yaml
+++ b/tests/drivers/clock_control/onoff/testcase.yaml
@@ -7,6 +7,7 @@ tests:
       - nrf51dk_nrf51422
       - nrf52dk_nrf52832
       - nrf52840dk_nrf52840
+      - nrf54l15pdk_nrf54l15_cpuapp
       - nrf9160dk_nrf9160
     integration_platforms:
       - nrf51dk_nrf51422


### PR DESCRIPTION
…m allow

Add nRF54L15 to platform_allow in the sample.yaml:
- clock_control_api,
- nrf_clock_calibration,
- nrf_lf_clock_start,
- onoff.

Signed-off-by: Sebastian Głąb <sebastian.glab@nordicsemi.no>
(cherry picked from commit 5600ae335b104f6ba088693946ee3e60b63161b9)