### PR TITLE
[nrf fromlist] boards: nrf54h20dk: Enable shell input

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -25,6 +25,7 @@
 		zephyr,shell-uart = &uart136;
 		zephyr,bt-hci-ipc = &ipc0;
 		zephyr,entropy = &prng;
+		zephyr,shell-uart = &uart136;
 	};
 
 	aliases {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -26,6 +26,7 @@
 		zephyr,shell-uart = &uart135;
 		zephyr,bt-hci-ipc = &ipc0;
 		zephyr,entropy = &prng;
+		zephyr,shell-uart = &uart135;
 	};
 
 	prng: prng {


### PR DESCRIPTION
This enables typing commands in shell over UART.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/71498 (Backport to HWMv1)