### PR TITLE
[nrf fromtree] tests: drivers: counter: add nRF54L15 overlay

### DIFF
--- a/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,58 @@
+&timer120 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&timer121 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&timer130 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer131 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer132 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer133 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer134 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer135 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer136 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer137 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&rtc130 {
+	status = "okay";
+	ppi-wrap;
+};
+
+&rtc131 {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpurad.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nrf54h20dk_nrf54h20_cpurad.overlay
@@ -1,0 +1,77 @@
+&timer020 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&timer021 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&timer022 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&timer120 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&timer121 {
+	status = "okay";
+	prescaler = <7>;
+};
+
+&timer130 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer131 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer132 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer133 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer134 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer135 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer136 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&timer137 {
+	status = "okay";
+	prescaler = <4>;
+};
+
+&rtc130 {
+	status = "okay";
+	ppi-wrap;
+};
+
+&rtc131 {
+	status = "okay";
+};
+
+&rtc {
+	status = "okay";
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,34 @@
+&timer00 {
+	prescaler = <6>;
+	status = "okay";
+};
+
+&timer10 {
+	prescaler = <4>;
+	status = "okay";
+};
+
+&timer20 {
+	prescaler = <4>;
+	status = "okay";
+};
+
+&timer21 {
+	prescaler = <4>;
+	status = "okay";
+};
+
+&timer22 {
+	prescaler = <4>;
+	status = "okay";
+};
+
+&timer23 {
+	prescaler = <4>;
+	status = "okay";
+};
+
+&timer24 {
+	prescaler = <4>;
+	status = "okay";
+};


### PR DESCRIPTION
Add nRF54L15 overlay for counter_basic_api test.

Signed-off-by: Magdalena Pastula <magdalena.pastula@nordicsemi.no>
(cherry picked from commit 1e20632b3675e064fe8c53a3e398defa99592c9a)