### PR TITLE
nRF54H20 EXMIF

### DIFF
--- a/boards/arm/nrf54h20dk_nrf54h20/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/arm/nrf54h20dk_nrf54h20/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -193,3 +193,44 @@ ipc0: &cpuapp_cpurad_ipc {
 	pinctrl-names = "default", "sleep";
 	hw-flow-control;
 };
+
+&pinctrl {
+	exmif_default: exmif_default {
+		group1 {
+			psels = <NRF_PSEL(EXMIF_CK, 6, 0)>,
+				<NRF_PSEL(EXMIF_DQ0, 6, 7)>,
+				<NRF_PSEL(EXMIF_DQ1, 6, 5)>;
+			nordic,drive-mode = <NRF_DRIVE_H0H1>;
+		};
+	};
+};
+
+&gpio6 {
+	status = "okay";
+};
+
+&exmif {
+	status = "okay";
+	cs-gpios = <&gpio6 3 GPIO_ACTIVE_LOW>;
+	pinctrl-0 = <&exmif_default>;
+	pinctrl-names = "default";
+
+	mx25uw63: mx25uw6345g@0 {
+		compatible = "jedec,spi-nor";
+		status = "okay";
+		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(48)>;
+		jedec-id = [c2 84 37];
+		sfdp-bfp = [
+			e5 20 8a ff  ff ff ff 03  00 ff 00 ff  00 ff 00 ff
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 10 d8
+			00 ff 00 ff  87 79 01 00  84 12 00 c4  cc 04 67 46
+			30 b0 30 b0  f4 bd d5 5c  00 00 00 ff  10 10 00 20
+			00 00 00 00  00 00 7c 23  48 00 00 00  00 00 88 88
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <30000>;
+	};
+};

--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -500,6 +500,7 @@ static int spi_dw_release(const struct device *dev,
 
 void spi_dw_isr(const struct device *dev)
 {
+	const struct spi_dw_config *info = dev->config;
 	uint32_t int_status;
 	int error;
 

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -201,6 +201,12 @@ static int reg_test_bit(uint8_t bit, mm_reg_t addr, uint32_t off)
 #define DW_SPI_CTRLR0_SRL		BIT(DW_SPI_CTRLR0_SRL_BIT)
 #define DW_SPI_CTRLR0_SLV_OE		BIT(DW_SPI_CTRLR0_SLV_OE_BIT)
 
+#define DW_SPI_CTRLR0_TMOD_TX_RX	(0)
+#define DW_SPI_CTRLR0_TMOD_TX		(1 << DW_SPI_CTRLR0_TMOD_SHIFT)
+#define DW_SPI_CTRLR0_TMOD_RX		(2 << DW_SPI_CTRLR0_TMOD_SHIFT)
+#define DW_SPI_CTRLR0_TMOD_EEPROM	(3 << DW_SPI_CTRLR0_TMOD_SHIFT)
+#define DW_SPI_CTRLR0_TMOD_RESET	(3 << DW_SPI_CTRLR0_TMOD_SHIFT)
+
 #define DW_SPI_CTRLR0_DFS_16(__bpw)	((__bpw) - 1)
 #define DW_SPI_CTRLR0_DFS_32(__bpw)	(((__bpw) - 1) << 16)
 

--- a/drivers/spi/spi_dw.h
+++ b/drivers/spi/spi_dw.h
@@ -21,6 +21,7 @@ extern "C" {
 #endif
 
 typedef void (*spi_dw_config_t)(void);
+typedef void (*spi_dw_irq_ack_t)(void);
 typedef uint32_t (*spi_dw_read_t)(uint8_t size, mm_reg_t addr, uint32_t off);
 typedef void (*spi_dw_write_t)(uint8_t size, uint32_t data, mm_reg_t addr, uint32_t off);
 typedef void (*spi_dw_set_bit_t)(uint8_t bit, mm_reg_t addr, uint32_t off);
@@ -43,6 +44,7 @@ struct spi_dw_config {
 	spi_dw_set_bit_t set_bit_func;
 	spi_dw_clear_bit_t clear_bit_func;
 	spi_dw_test_bit_t test_bit_func;
+	spi_dw_irq_ack_t irq_ack_func;
 };
 
 struct spi_dw_data {
@@ -179,24 +181,25 @@ static int reg_test_bit(uint8_t bit, mm_reg_t addr, uint32_t off)
 /* Common registers settings, bits etc... */
 
 /* CTRLR0 settings */
+#if !IS_ENABLED(CONFIG_SPI_DW_HSSI)
 #define DW_SPI_CTRLR0_SCPH_BIT		(6)
 #define DW_SPI_CTRLR0_SCPOL_BIT		(7)
+#define DW_SPI_CTRLR0_TMOD_SHIFT	(8)
+#define DW_SPI_CTRLR0_SLV_OE_BIT	(10)
 #define DW_SPI_CTRLR0_SRL_BIT		(11)
+#else
+/* Bit fields in CTRLR0 (DWC SSI with AHB interface) */
+#define DW_SPI_CTRLR0_SCPH_BIT		8
+#define DW_SPI_CTRLR0_SCPOL_BIT		9
+#define DW_SPI_CTRLR0_TMOD_SHIFT	10
+#define DW_SPI_CTRLR0_SLV_OE_BIT	12
+#define DW_SPI_CTRLR0_SRL_BIT		13
+#endif
 
 #define DW_SPI_CTRLR0_SCPH		BIT(DW_SPI_CTRLR0_SCPH_BIT)
 #define DW_SPI_CTRLR0_SCPOL		BIT(DW_SPI_CTRLR0_SCPOL_BIT)
 #define DW_SPI_CTRLR0_SRL		BIT(DW_SPI_CTRLR0_SRL_BIT)
-
-#define DW_SPI_CTRLR0_SLV_OE_BIT	(10)
 #define DW_SPI_CTRLR0_SLV_OE		BIT(DW_SPI_CTRLR0_SLV_OE_BIT)
-
-#define DW_SPI_CTRLR0_TMOD_SHIFT	(8)
-
-#define DW_SPI_CTRLR0_TMOD_TX_RX	(0)
-#define DW_SPI_CTRLR0_TMOD_TX		(1 << DW_SPI_CTRLR0_TMOD_SHIFT)
-#define DW_SPI_CTRLR0_TMOD_RX		(2 << DW_SPI_CTRLR0_TMOD_SHIFT)
-#define DW_SPI_CTRLR0_TMOD_EEPROM	(3 << DW_SPI_CTRLR0_TMOD_SHIFT)
-#define DW_SPI_CTRLR0_TMOD_RESET	(3 << DW_SPI_CTRLR0_TMOD_SHIFT)
 
 #define DW_SPI_CTRLR0_DFS_16(__bpw)	((__bpw) - 1)
 #define DW_SPI_CTRLR0_DFS_32(__bpw)	(((__bpw) - 1) << 16)

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -943,6 +943,18 @@
 				status = "disabled";
 				interrupts = <470 NRF_DEFAULT_IRQ_PRIORITY>;
 			};
+
+			exmif: spi@95000 {
+				compatible = "nordic,nrf-exmif", "snps,designware-spi";
+				#address-cells = <1>;
+				#size-cells = <0>;
+				reg = <0x95000 0x500 0x95500 0xb00>;
+				reg-names = "wrapper", "core";
+				interrupts = <149 NRF_DEFAULT_IRQ_PRIORITY>;
+				clock-frequency = <DT_FREQ_M(400)>;
+				fifo-depth = <32>;
+				status = "disabled";
+			};
 		};
 	};
 

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -126,6 +126,24 @@
 #define NRF_FUN_QSPI_IO2 33U
 /** QSPI IO3 */
 #define NRF_FUN_QSPI_IO3 34U
+/** EXMIF CK */
+#define NRF_FUN_EXMIF_CK 35U
+/** EXMIF DQ0 */
+#define NRF_FUN_EXMIF_DQ0 36U
+/** EXMIF DQ1 */
+#define NRF_FUN_EXMIF_DQ1 37U
+/** EXMIF DQ2 */
+#define NRF_FUN_EXMIF_DQ2 38U
+/** EXMIF DQ3 */
+#define NRF_FUN_EXMIF_DQ3 39U
+/** EXMIF DQ4 */
+#define NRF_FUN_EXMIF_DQ4 40U
+/** EXMIF DQ5 */
+#define NRF_FUN_EXMIF_DQ5 41U
+/** EXMIF DQ6 */
+#define NRF_FUN_EXMIF_DQ6 42U
+/** EXMIF DQ7 */
+#define NRF_FUN_EXMIF_DQ7 43U
 
 /** @} */
 


### PR DESCRIPTION
Added device tree description for the EXMIF peripheral.
Added device tree description for the mx25uw6345g SPI NOR device.
Added changes to `spi_dw.c` making it work with the EXMIF peripheral.

Currently untested.

Built with `zephyr/samples/drivers/jesd216` sample:
```
west build -b nrf54h20dk_nrf54h20_cpuapp -p --sysbuild
```
 