### PR TITLE
[nrf noup] samples: psa_crypto: Remove support for Nordic boards

### DIFF
--- a/samples/tfm_integration/psa_crypto/sample.yaml
+++ b/samples/tfm_integration/psa_crypto/sample.yaml
@@ -12,7 +12,6 @@ tests:
       - csr
       - mcuboot
     platform_allow: mps2_an521_ns v2m_musca_s1_ns
-      nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
       stm32l562e_dk_ns bl5340_dvk_cpuapp_ns
     harness: console
     harness_config:


### PR DESCRIPTION
We have our own psa crypto samples to show how to used PSA crypto with NCS.

This sample still uses CONFIG_MBEDTLS_BUILTIN which is not supported anymore, therefore removing the support for it in NCS.

Ref: NCSDK-17944