### PR TITLE
[nrf fromlist] net: mgmt: Protect processing of iface data

### DIFF
--- a/subsys/net/l2/wifi/wifi_nm.c
+++ b/subsys/net/l2/wifi/wifi_nm.c
@@ -10,6 +10,9 @@ LOG_MODULE_REGISTER(wifi_nm, CONFIG_WIFI_NM_LOG_LEVEL);
 #include <zephyr/kernel.h>
 #include <zephyr/net/wifi_nm.h>
 
+/* Used to protect nm data */
+static K_MUTEX_DEFINE(wifi_nm_lock);
+
 struct wifi_nm_instance *wifi_nm_get_instance(const char *name)
 {
 	STRUCT_SECTION_FOREACH(wifi_nm_instance, nm) {
@@ -27,13 +30,16 @@ struct wifi_nm_instance *wifi_nm_get_instance_iface(struct net_if *iface)
 		return false;
 	}
 
+	k_mutex_lock(&wifi_nm_lock, K_FOREVER);
 	STRUCT_SECTION_FOREACH(wifi_nm_instance, nm) {
 		for (int i = 0; i < CONFIG_WIFI_NM_MAX_MANAGED_INTERFACES; i++) {
 			if (nm->mgd_ifaces[i] == iface) {
+				k_mutex_unlock(&wifi_nm_lock);
 				return nm;
 			}
 		}
 	}
+	k_mutex_unlock(&wifi_nm_lock);
 
 	return NULL;
 }
@@ -48,12 +54,15 @@ int wifi_nm_register_mgd_iface(struct wifi_nm_instance *nm, struct net_if *iface
 		return -ENOTSUP;
 	}
 
+	k_mutex_lock(&wifi_nm_lock, K_FOREVER);
 	for (int i = 0; i < CONFIG_WIFI_NM_MAX_MANAGED_INTERFACES; i++) {
 		if (!nm->mgd_ifaces[i]) {
 			nm->mgd_ifaces[i] = iface;
+			k_mutex_unlock(&wifi_nm_lock);
 			return 0;
 		}
 	}
+	k_mutex_unlock(&wifi_nm_lock);
 
 	return -ENOMEM;
 }
@@ -64,12 +73,15 @@ int wifi_nm_unregister_mgd_iface(struct wifi_nm_instance *nm, struct net_if *ifa
 		return -EINVAL;
 	}
 
+	k_mutex_lock(&wifi_nm_lock, K_FOREVER);
 	for (int i = 0; i < CONFIG_WIFI_NM_MAX_MANAGED_INTERFACES; i++) {
 		if (nm->mgd_ifaces[i] == iface) {
 			nm->mgd_ifaces[i] = NULL;
+			k_mutex_unlock(&wifi_nm_lock);
 			return 0;
 		}
 	}
+	k_mutex_unlock(&wifi_nm_lock);
 
 	return -ENOENT;
 }

--- a/subsys/net/l2/wifi/wifi_nm.c
+++ b/subsys/net/l2/wifi/wifi_nm.c
@@ -27,7 +27,7 @@ struct wifi_nm_instance *wifi_nm_get_instance(const char *name)
 struct wifi_nm_instance *wifi_nm_get_instance_iface(struct net_if *iface)
 {
 	if (!iface || !net_if_is_wifi(iface)) {
-		return false;
+		return NULL;
 	}
 
 	k_mutex_lock(&wifi_nm_lock, K_FOREVER);


### PR DESCRIPTION
Use lock while accessing iface data.
One of the use case is while setting regulatory, it access iface info, while from some other place also it can be accessed. Protected the data processing.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/71737