### PR TITLE
[nrf fromtre] mcumgr/img_mgmt: CONFIG_MCUBOOT_BOOTLOADER_NO_DOWNGRADE fixes

### DIFF
--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -469,9 +469,9 @@ os_mgmt_bootloader_info(struct smp_streamer *ctxt)
 
 		ok = zcbor_tstr_put_lit(zse, "mode") &&
 		     zcbor_int32_put(zse, BOOTLOADER_MODE);
-#if IS_ENABLED(CONFIG_MCUBOOT_BOOTLOADER_NO_DOWNGRADE)
-		ok = zcbor_tstr_put_lit(zse, "no-downgrade") &&
-		     zcbor_bool_encode(zse, true);
+#ifdef CONFIG_MCUBOOT_BOOTLOADER_NO_DOWNGRADE
+		ok = ok && zcbor_tstr_put_lit(zse, "no-downgrade") &&
+		     zcbor_bool_encode(zse, &(bool){true});
 #endif
 	} else {
 		return OS_MGMT_ERR_QUERY_YIELDS_NO_ANSWER;

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/src/os_mgmt.c
@@ -469,7 +469,7 @@ os_mgmt_bootloader_info(struct smp_streamer *ctxt)
 
 		ok = zcbor_tstr_put_lit(zse, "mode") &&
 		     zcbor_int32_put(zse, BOOTLOADER_MODE);
-#if IS_ENABLED(MCUBOOT_BOOTLOADER_NO_DOWNGRADE)
+#if IS_ENABLED(CONFIG_MCUBOOT_BOOTLOADER_NO_DOWNGRADE)
 		ok = zcbor_tstr_put_lit(zse, "no-downgrade") &&
 		     zcbor_bool_encode(zse, true);
 #endif


### PR DESCRIPTION
There are two fixes now.
Previously there has been one, but it required conflict resolution at cherry-pick as there has been previous change missing;
this time both changes are brought.