### PR TITLE
[nrf fromtree] boards: arm: mark counter as supported for nRF54L15

### DIFF
--- a/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp.yaml
+++ b/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp.yaml
@@ -12,6 +12,7 @@ toolchain:
 ram: 256
 flash: 1536
 supported:
+  - counter
   - gpio
   - i2c
   - pwm


### PR DESCRIPTION
Mark counter as supported for nRF54L15 to allow running counter_basic_api by twister.

Signed-off-by: Magdalena Pastula <magdalena.pastula@nordicsemi.no>
(cherry picked from commit 76f990730f629b011b7c1c34d706fa87bd0585d3)