### PR TITLE
[nrf fromtree] net: arp: Add support for gratuitous ARP transmission

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -971,6 +971,24 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 }
 #endif
 
+/**
+ * @brief Check if the given interface is a VLAN interface.
+ *
+ * @param iface Network interface
+ *
+ * @return True if this network interface is VLAN one, false if not.
+ */
+#if defined(CONFIG_NET_VLAN)
+bool net_eth_is_vlan_interface(struct net_if *iface);
+#else
+static inline bool net_eth_is_vlan_interface(struct net_if *iface)
+{
+	ARG_UNUSED(iface);
+
+	return false;
+}
+#endif
+
 #if !defined(CONFIG_ETH_DRIVER_RAW_MODE)
 
 #define Z_ETH_NET_DEVICE_INIT_INSTANCE(node_id, dev_id, name, instance,	\

--- a/subsys/net/l2/ethernet/Kconfig
+++ b/subsys/net/l2/ethernet/Kconfig
@@ -73,6 +73,19 @@ config NET_ARP_GRATUITOUS
 	  ff:ff:ff:ff:ff:ff. Ordinarily, no reply packet will occur.
 	  A gratuitous ARP reply is a reply to which no request has been made.
 
+config NET_ARP_GRATUITOUS_TRANSMISSION
+	bool "Transmit gratuitous ARP requests"
+	depends on NET_ARP_GRATUITOUS
+	depends on NET_MGMT_EVENT
+	depends on NET_MGMT_EVENT_INFO
+	help
+	  Transmit gratuitous ARP requests, as defined in RFC 5227.
+
+config NET_ARP_GRATUITOUS_INTERVAL
+	int "Time interval (in seconds) between sending gratuitous ARP requests"
+	depends on NET_ARP_GRATUITOUS_TRANSMISSION
+	default 60
+
 if NET_ARP
 module = NET_ARP
 module-dep = NET_LOG

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -336,6 +336,22 @@ uint16_t net_eth_get_vlan_tag(struct net_if *iface)
 	return tag;
 }
 
+bool net_eth_is_vlan_interface(struct net_if *iface)
+{
+	enum virtual_interface_caps caps;
+
+	if (net_if_l2(iface) != &NET_L2_GET_NAME(VIRTUAL)) {
+		return false;
+	}
+
+	caps = net_virtual_get_iface_capabilities(iface);
+	if (!(caps & VIRTUAL_INTERFACE_VLAN)) {
+		return false;
+	}
+
+	return true;
+}
+
 bool net_eth_get_vlan_status(struct net_if *iface)
 {
 	bool status = false;

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -317,18 +317,17 @@ bool net_eth_is_vlan_enabled(struct ethernet_context *ctx,
 uint16_t net_eth_get_vlan_tag(struct net_if *iface)
 {
 	uint16_t tag = NET_VLAN_TAG_UNSPEC;
-	struct vlan_context *ctx;
 
 	k_mutex_lock(&lock, K_FOREVER);
 
-	ctx = get_vlan_ctx(iface, tag, true);
-	if (ctx != NULL) {
-		/* The Ethernet interface does not have a tag so if user
-		 * tried to use the main interface, then do not return
-		 * the tag.
-		 */
-		if (ctx->attached_to != iface) {
-			tag = ctx->tag;
+	ARRAY_FOR_EACH(vlan_ctx, i) {
+		if (vlan_ctx[i] == NULL || !vlan_ctx[i]->is_used) {
+			continue;
+		}
+
+		if (vlan_ctx[i]->iface == iface) {
+			tag = vlan_ctx[i]->tag;
+			break;
 		}
 	}
 

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -581,6 +581,11 @@ static void test_vlan_enable(void)
 		ARRAY_FOR_EACH_PTR(vlan_interfaces, vlan_iface) {
 			uint16_t tag;
 
+			ret = net_eth_is_vlan_interface(*vlan_iface);
+			zassert_equal(ret, true,
+				      "Not identified as VLAN interface %d",
+				      net_if_get_by_iface(*vlan_iface));
+
 			if (*vlan_iface == iface) {
 				tag = net_eth_get_vlan_tag(*vlan_iface);
 

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -574,6 +574,23 @@ static void test_vlan_enable(void)
 	ret = net_eth_vlan_enable(iface, VLAN_TAG_1);
 	zassert_equal(ret, -EALREADY, "VLAN tag %d enabled for iface 1 (%d)",
 		      VLAN_TAG_1, ret);
+
+	for (int i = VLAN_TAG_1; i <= VLAN_TAG_5; i += 100) {
+		iface = net_eth_get_vlan_iface(NULL, i);
+
+		ARRAY_FOR_EACH_PTR(vlan_interfaces, vlan_iface) {
+			uint16_t tag;
+
+			if (*vlan_iface == iface) {
+				tag = net_eth_get_vlan_tag(*vlan_iface);
+
+				zassert_equal(tag, i,
+					      "Could not get the VLAN interface (%d)",
+					      net_if_get_by_iface(*vlan_iface));
+				break;
+			}
+		}
+	}
 }
 
 static void test_vlan_disable(void)
@@ -628,13 +645,13 @@ static void test_vlan_enable_all(void)
 	int ret;
 
 	ret = net_eth_vlan_enable(eth_interfaces[0], VLAN_TAG_1);
-	zassert_equal(ret, 0, "Cannot enable %d", VLAN_TAG_1);
+	zassert_true(ret == 0 || ret == -EALREADY, "Cannot enable %d", VLAN_TAG_1);
 	ret = net_eth_vlan_enable(eth_interfaces[0], VLAN_TAG_2);
-	zassert_equal(ret, 0, "Cannot enable %d", VLAN_TAG_2);
+	zassert_true(ret == 0 || ret == -EALREADY, "Cannot enable %d", VLAN_TAG_2);
 	ret = net_eth_vlan_enable(eth_interfaces[0], VLAN_TAG_3);
-	zassert_equal(ret, 0, "Cannot enable %d", VLAN_TAG_3);
+	zassert_true(ret == 0 || ret == -EALREADY, "Cannot enable %d", VLAN_TAG_3);
 	ret = net_eth_vlan_enable(eth_interfaces[0], VLAN_TAG_4);
-	zassert_equal(ret, 0, "Cannot enable %d", VLAN_TAG_4);
+	zassert_true(ret == 0 || ret == -EALREADY, "Cannot enable %d", VLAN_TAG_4);
 
 	eth_ctx = net_if_l2_data(eth_interfaces[0]);
 


### PR DESCRIPTION
Add support for gratuitous ARP transmission by Zephyr network stack. This allows to prematurely fill the peer ARP table, so there's no need to send an explicit request when peer needs to send an actual packet.

The gratuitous ARP is send when the network interface is brought up (joins the network) or a new IP address is added. The gratuitous ARP request is also sent periodically, with a configurable interval time. The gratuitous ARP should also be sent whenever MAC address of the interface is changed, but as Zephyr only allows to do this when interface is down, this is already covered by the first case (interface brought up).