### PR TITLE
net: lib: coap_client: Improve cancel function

### DIFF
--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -138,6 +138,17 @@ int coap_client_req(struct coap_client *client, int sock, const struct sockaddr 
 		    struct coap_client_request *req, struct coap_transmission_parameters *params);
 
 /**
+ * @brief Cancel all current requests.
+ *
+ * This is intended for canceling long-running requests (e.g. GETs with the OBSERVE option set)
+ * which has gone stale for some reason.
+ *
+ * @param client Client instance.
+ */
+void coap_client_cancel_requests(struct coap_client *client);
+
+
+/**
  * @}
  */
 

--- a/include/zephyr/net/coap_client.h
+++ b/include/zephyr/net/coap_client.h
@@ -84,6 +84,7 @@ struct coap_client_internal_request {
 	uint32_t last_id;
 	uint8_t request_tkl;
 	bool request_ongoing;
+	atomic_t in_callback;
 	struct coap_block_context recv_blk_ctx;
 	struct coap_block_context send_blk_ctx;
 	struct coap_pending pending;
@@ -140,13 +141,13 @@ int coap_client_req(struct coap_client *client, int sock, const struct sockaddr 
 /**
  * @brief Cancel all current requests.
  *
- * This is intended for canceling long-running requests (e.g. GETs with the OBSERVE option set)
- * which has gone stale for some reason.
+ * This is intended for canceling long-running requests (e.g. GETs with the OBSERVE option set,
+ * or a block transfer) which have gone stale for some reason. It is also intended for responding
+ * to network connectivity issues.
  *
  * @param client Client instance.
  */
 void coap_client_cancel_requests(struct coap_client *client);
-
 
 /**
  * @}

--- a/subsys/net/lib/coap/coap_client.c
+++ b/subsys/net/lib/coap/coap_client.c
@@ -811,8 +811,17 @@ static int handle_response(struct coap_client *client, const struct coap_packet 
 	}
 fail:
 	client->response_ready = false;
-	internal_req->request_ongoing = false;
+	if (ret != 0 || !coap_request_is_observe(&internal_req->request)) {
+		internal_req->request_ongoing = false;
+	}
 	return ret;
+}
+
+void coap_client_cancel_requests(struct coap_client *client)
+{
+	for (int i = 0; i < ARRAY_SIZE(client->requests); i++) {
+		client->requests[i].request_ongoing = false;
+	}
 }
 
 void coap_client_recv(void *coap_cl, void *a, void *b)


### PR DESCRIPTION
Improve coap_client_cancel_requests(). Ensure it can be called from a callback. Clear pending reqs. Report error to waiting callbacks. Clear active flag.
    
This is useful when the network becomes unavailable or prior to disconnecting in order to save power.
    
(cherry picked from commit f04f8b242285dcd56b9e458de8ea233a14237b9b)
