### PR TITLE
[nrf noup] arch: arm: cortex_m: add hook before resume from RAM

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -588,6 +588,11 @@ config INIT_ARCH_HW_AT_BOOT
 
 endmenu
 
+config PRE_S2RAM_INIT_HOOK
+	bool "Run setup function before RAM is accessed"
+	help
+	  Execute a setup function before RAM is accessed.
+
 #
 # Architecture Capabilities
 #

--- a/arch/arm/core/cortex_m/reset.S
+++ b/arch/arm/core/cortex_m/reset.S
@@ -89,6 +89,10 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
 
 #endif /* CONFIG_INIT_ARCH_HW_AT_BOOT */
 
+#if defined(CONFIG_PRE_S2RAM_INIT_HOOK)
+    bl pre_s2ram_init_hook
+#endif
+
 #if defined(CONFIG_PM_S2RAM)
     bl arch_pm_s2ram_resume
 #endif /* CONFIG_PM_S2RAM */


### PR DESCRIPTION
Support targets that need special setup before accessing RAM.

I'm not sure how something like this should be integrated with the overall code base, but I suppose t it should be reframed to be a little more general.