### PR TITLE
[nrf fromlist] boards: nordic: Add PWM support for LEDs on nRF54 DKs

### DIFF
--- a/boards/arm/nrf54h20dk_nrf54h20/nrf54h20dk_nrf54h20-pinctrl.dtsi
+++ b/boards/arm/nrf54h20dk_nrf54h20/nrf54h20dk_nrf54h20-pinctrl.dtsi
@@ -50,4 +50,18 @@
 				<NRF_PSEL(UART_CTS, 2, 5)>;
 		};
 	};
+
+	/omit-if-no-ref/ pwm120_default: pwm120_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 9, 0)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm120_sleep: pwm120_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 9, 0)>;
+			low-power-enable;
+		};
+	};
+
 };

--- a/boards/arm/nrf54h20dk_nrf54h20/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/arm/nrf54h20dk_nrf54h20/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -31,6 +31,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;
@@ -86,6 +87,13 @@
 		led3: led_3 {
 			gpios = <&gpio9 3 GPIO_ACTIVE_HIGH>;
 			label = "Green LED 3";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm120 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 
@@ -192,4 +200,11 @@ ipc0: &cpuapp_cpurad_ipc {
 	pinctrl-1 = <&uart136_sleep>;
 	pinctrl-names = "default", "sleep";
 	hw-flow-control;
+};
+
+&pwm120 {
+	status = "okay";
+	pinctrl-0 = <&pwm120_default>;
+	pinctrl-1 = <&pwm120_sleep>;
+	pinctrl-names = "default", "sleep";
 };

--- a/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp-pinctrl.dtsi
+++ b/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp-pinctrl.dtsi
@@ -64,4 +64,17 @@
 						low-power-enable;
 		};
 	};
+
+	pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 8)>;
+		};
+	};
+
+	pwm20_sleep: pwm20_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 8)>;
+			low-power-enable;
+		};
+	};
 };

--- a/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp.dts
+++ b/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp.dts
@@ -43,6 +43,13 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led0: pwm_led_0 {
+			pwms = <&pwm20 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
+		};
+	};
+
 	buttons {
 		compatible = "gpio-keys";
 		button0: button_0 {
@@ -72,6 +79,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
+		pwm-led0 = &pwm_led0;
 		watchdog0 = &wdt30;
 		sw0 = &button0;
 		sw1 = &button1;
@@ -204,4 +212,11 @@
 
 &adc {
 	status = "okay";
+};
+
+&pwm20 {
+	status = "okay";
+	pinctrl-0 = <&pwm20_default>;
+	pinctrl-1 = <&pwm20_sleep>;
+	pinctrl-names = "default", "sleep";
 };

--- a/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
+++ b/boards/arm/nrf54l15pdk_nrf54l15/nrf54l15pdk_nrf54l15_cpuapp_0_3_0.overlay
@@ -36,3 +36,18 @@
 &button3 {
 	gpios = <&gpio0 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 };
+
+&pinctrl {
+	/omit-if-no-ref/ pwm20_default: pwm20_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
+		};
+	};
+
+	/omit-if-no-ref/ pwm20_sleep: pwm20_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 10)>;
+			low-power-enable;
+		};
+	};
+};


### PR DESCRIPTION
Adds support for first possible LED to be connected with HW PWM.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/72010