### PR TITLE
[nrf fromlist] kernel: banner: Make function weak

### DIFF
--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -24,7 +24,7 @@
 #endif /* BUILD_VERSION */
 #endif /* !BANNER_VERSION */
 
-void boot_banner(void)
+__weak void boot_banner(void)
 {
 #if defined(CONFIG_BOOT_DELAY) && (CONFIG_BOOT_DELAY > 0)
 	printk("***** delaying boot " DELAY_STR "ms (per build configuration) *****\n");


### PR DESCRIPTION
Makes the boot banner function weak, this resolves an issue when building with llext enabled which uses different build options than a normal zephyr build

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/72400