### PR TITLE
[nrf fromlist] boards: nordic: Add ADC to supported in nRF54L15 PDK

### DIFF
--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp.yaml
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuapp.yaml
@@ -12,6 +12,7 @@ toolchain:
 ram: 256
 flash: 1536
 supported:
+  - adc
   - counter
   - gpio
   - i2c


### PR DESCRIPTION
It will enable testing adc with twister which is relying on board yaml data in determining test scope.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/68692.

This change was missed in previous [nrf fromlist] for this upstream PR.