### PR TITLE
[nrf fromtree] MAINTAINERS: fix more paths

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -3547,7 +3547,6 @@ STM32 Platforms:
     - GeorgeCGV
   files:
     - boards/st/
-    - drivers/*/*stm32*/
     - drivers/*/*stm32*.c
     - drivers/*/*stm32*.h
     - drivers/*/*/*stm32*
@@ -3674,8 +3673,7 @@ Infineon Platforms:
     - boards/cypress/
     - boards/infineon/
     - drivers/*/*ifx_cat1*
-    - drivers/*/*xmc*/
-    - drivers/*/*xmc*.c
+    - drivers/*/*xmc*
     - drivers/sensor/infineon/
     - dts/arm/infineon/
     - dts/arm/cypress/


### PR DESCRIPTION
Fix few more paths that are failing to parse on system running Python >= 3.11 due to a change in behavior of glob.

Signed-off-by: Fabio Baltieri <fabiobaltieri@google.com>
(cherry picked from commit 0ef608a0ab3e90ba28b9f50862a207a0fc64af66)