### PR TITLE
[nrf fromlist] soc: nordic: RRAMC regions

### DIFF
--- a/drivers/flash/Kconfig.nrf_rram
+++ b/drivers/flash/Kconfig.nrf_rram
@@ -66,4 +66,17 @@ config SOC_FLASH_NRF_TIMEOUT_MULTIPLIER
 	  the multiplication would allow erasing all nRF flash pages in
 	  blocking mode.
 
+config NRF_RRAM_REGION_ADDRESS_RESOLUTION
+	hex
+	default 0x400
+	help
+	  RRAMC's region protection address resolution.
+	  Applies to region with configurable start address.
+
+config NRF_RRAM_REGION_SIZE_UNIT
+	hex
+	default 0x400
+	help
+	  Base unit for the size of RRAMC's region protection.
+
 endif # SOC_FLASH_NRF_RRAM


### PR DESCRIPTION
Adding definition of regions granularity to Kconfig.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/72509