### PR TITLE
[nrf fromtree] drivers: flash: rram: Select NRFX_RRAMC

### DIFF
--- a/drivers/flash/Kconfig.nrf_rram
+++ b/drivers/flash/Kconfig.nrf_rram
@@ -8,6 +8,7 @@ menuconfig SOC_FLASH_NRF_RRAM
 	bool "Nordic Semiconductor flash driver for nRF RRAM"
 	default y
 	depends on DT_HAS_NORDIC_RRAM_CONTROLLER_ENABLED
+	select NRFX_RRAMC
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_NRF_FORCE_ALT


### PR DESCRIPTION
Select NRFX_RRAMC for RRAM driver.

(cherry picked from commit d954060626ee4b5f7dcaaa1e684a4c6a8337768d)
Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>