### PR TITLE
[nrf noup] scripts: twister: Disable random run_id when ccache is used 

### DIFF
--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -103,6 +103,9 @@ class TestInstance:
                 fp.write(run_id)
         return run_id
 
+    def set_clean_run_id(self):
+        self.run_id = '0' * len(hashlib.md5(self.name.encode()).hexdigest())
+
     def add_missing_case_status(self, status, reason=None):
         for case in self.testcases:
             if case.status == 'started':

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -720,6 +720,10 @@ class TestPlan:
                 else:
                     tfilter = 'buildable'
 
+                if "1" == os.getenv("USE_CCACHE", "0"):
+                    # if ccache is used, there should not be random elements in build command
+                    instance.set_clean_run_id()
+
                 instance.run = instance.check_runnable(
                     self.options.enable_slow,
                     tfilter,


### PR DESCRIPTION
With random value in build command ccache is not working optimally.