### PR TITLE
[nrf fromtree] samples: sensor: qdec: Run sample on nrf54h20

### DIFF
--- a/samples/sensor/qdec/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/sensor/qdec/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &qdec130;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+		phase_a: phase_a {
+			gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+		};
+		phase_b: phase_b {
+			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	qdec_pinctrl: qdec_pinctrl {
+		group1 {
+			psels = <NRF_PSEL(QDEC_A, 1, 0)>,
+				<NRF_PSEL(QDEC_B, 1, 2)>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&qdec130 {
+	status = "okay";
+	pinctrl-0 = <&qdec_pinctrl>;
+	pinctrl-names = "default";
+	steps = <120>;
+	led-pre = <500>;
+};

--- a/samples/sensor/qdec/sample.yaml
+++ b/samples/sensor/qdec/sample.yaml
@@ -22,10 +22,12 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     harness_config:
       fixture: gpio_loopback
       type: multi_line


### PR DESCRIPTION
Add overlay file that enables sample on nrf54h20 Application core.

(cherry picked from commit f84e082f73511789eab69577521a16040b8e1fce)