### PR TITLE
[noup] test-spec: update boards paths for HWv2

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -24,13 +24,13 @@
   - "subsys/net/**/*"
 
 "CI-iot-samples-test":
-  - "boards/arm/nrf9160dk_nrf9160/**/*"
+  - "boards/nordic/nrf9160dk/**/*"
   - "dts/arm/nordic/nrf9160*"
   - "include/net/**/*"
   - "subsys/net/lib/**/*"
 
 "CI-iot-libraries-test":
-  - "boards/arm/nrf9160dk_nrf9160/**/*"
+  - "boards/nordic/nrf9160dk/**/*"
   - "dts/arm/nordic/nrf9160*"
   - "include/net/socket_ncs.h"
   - "subsys/testsuite/ztest/**/*"
@@ -46,8 +46,8 @@
   - "samples/subsys/mgmt/mcumgr/smp_svr/**/*"
 
 "CI-tfm-test":
-  - "boards/arm/nrf5340dk_nrf5340/**/*"
-  - "boards/arm/nrf9160dk_nrf9160/**/*"
+  - "boards/nordic/nrf5340dk/**/*"
+  - "boards/nordic/nrf9160dk/**/*"
   - "drivers/entropy/*"
   - "dts/arm/nordic/nrf5340*"
   - "dts/arm/nordic/nrf9160*"
@@ -98,7 +98,7 @@
   - "include/dfu/**/*"
 
 "CI-thingy91-test":
-  - "boards/arm/nrf9160dk_nrf9160/**/*"
+  - "boards/nordic/nrf9160dk/**/*"
   - "arch/x86/core/**/*"
   - "arch/x86/include/**/*"
   - "drivers/console/**/*"
@@ -137,9 +137,9 @@
       - "!tests/bluetooth/**/*"
 
 "CI-crypto-test":
-  - "boards/arm/nrf52840dk_nrf52840/**/*"
-  - "boards/arm/nrf5340dk_nrf5340/**/*"
-  - "boards/arm/nrf9160dk_nrf9160/**/*"
+  - "boards/nordic/nrf52840dk/**/*"
+  - "boards/nordic/nrf5340dk/**/*"
+  - "boards/nordic/nrf9160dk/**/*"
   - "drivers/entropy/*"
   - "drivers/serial/**/*"
   - "dts/arm/nordic/nrf52840*"
@@ -261,7 +261,7 @@
       - "!subsys/bluetooth/audio/**/*"
 
 "CI-audio-test":
-  - "boards/arm/nrf5340_audio_dk_nrf5340/**/*"
+  - "boards/nordic/nrf5340_audio_dk/**/*"
   - "drivers/flash/**/*"
   - "drivers/spi/**/*"
   - "drivers/gpio/**/*"


### PR DESCRIPTION
nrf-squash! [nrf noup] test-spec: include nrf54 boards in low-level test trigger
nrf-squash! [nrf noup] test-spec: introduce specific ble-sample label
nrf-squash! [nrf noup] ci: add .github/test-spec.yml

/boards/arm -> /boards/nordic

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>