### PR TITLE
posix: env: Fix 2 build warnings

### DIFF
--- a/lib/posix/options/env.c
+++ b/lib/posix/options/env.c
@@ -106,7 +106,7 @@ int getenv_r(const char *name, char *buf, size_t len)
 			ret = -ERANGE;
 			K_SPINLOCK_BREAK;
 		}
-		strncpy(buf, val, vsize);
+		strcpy(buf, val);
 		LOG_DBG("Found entry %s", environ[ret]);
 	}
 
@@ -188,7 +188,7 @@ int setenv(const char *name, const char *val, int overwrite)
 			environ[ret] = env;
 		}
 
-		strncpy(environ[ret], name, nsize);
+		strcpy(environ[ret], name);
 		environ[ret][nsize] = '=';
 		strncpy(environ[ret] + nsize + 1, val, vsize + 1);
 		LOG_DBG("Added entry %s", environ[ret]);


### PR DESCRIPTION
Fix 2 build warnings in posix/options/env:
The maximum length given to strncpy() matches the input string length, which makes the call equivalent to strcpy(). As the destination buffer size has been ensured sufficient (in the first case by chechking just before,
in the second case by allocating it big enough),
let's just use strcpy() instead.

lib/posix/options/env.c: In function 'getenv_r':
lib/posix/options/env.c:109:17: error: 'strncpy' specified bound depends on the length of the source argument
[-Werror=stringop-truncation]
  109 |                 strncpy(buf, val, vsize);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~
lib/posix/options/env.c:104:25: note: length computed here
  104 |                 vsize = strlen(val) + 1;
      |                         ^~~~~~~~~~~
lib/posix/options/env.c: In function 'setenv':
lib/posix/options/env.c:191:17: error: 'strncpy' output truncated
before terminating nul copying as many bytes from a string as its
length [-Werror=stringop-truncation]
  191 |                 strncpy(environ[ret], name, nsize);
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/posix/options/env.c:128:51: note: length computed here
  128 |         const size_t nsize = (name == NULL) ? 0 : strlen(name);
      |                                                   ^~~~~~~~~~~~

Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
(cherry picked from commit 7c8d53898228d8583861f4ef8411d984d0adc949)