### PR TITLE
[nrf noup] Bluetooth: Mesh: Disable processing of ext ADV packets

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -152,6 +152,17 @@ config BT_MESH_ADV_EXT_FRIEND_SEPARATE
 	  messages as close to the start of the ReceiveWindow as possible,
 	  thus reducing the scanning time on the Low Power node.
 
+config BT_MESH_ADV_EXT_ACCEPT_EXT_ADV_PACKETS
+	bool "Reject or accept extended advertising packets"
+	depends on BT_LL_SOFTDEVICE
+	help
+	  Configure the scanner and initiator to either reject or accept extended
+	  advertising packets by the SoftDevice Controller. This is set to false
+	  by default, to prevent loss of scan time when receiving a pointer packet
+	  while scanning for Bluetooth Mesh packets. Set to true if extended
+	  advertising packets are to be received by the SoftDevice Controller for
+	  purposes other than Bluetooth Mesh.
+
 endif # BT_MESH_ADV_EXT
 
 endchoice

--- a/subsys/bluetooth/mesh/adv_ext.c
+++ b/subsys/bluetooth/mesh/adv_ext.c
@@ -448,6 +448,18 @@ void bt_mesh_adv_init(void)
 	for (int i = 0; i < ARRAY_SIZE(advs); i++) {
 		(void)memcpy(&advs[i].adv_param, &adv_param, sizeof(adv_param));
 	}
+
+#if defined(CONFIG_BT_LL_SOFTDEVICE)
+	const sdc_hci_cmd_vs_scan_accept_ext_adv_packets_set_t cmd_params = {
+		.accept_ext_adv_packets = IS_ENABLED(CONFIG_BT_MESH_ADV_EXT_ACCEPT_EXT_ADV_PACKETS),
+	};
+
+	int err = sdc_hci_cmd_vs_scan_accept_ext_adv_packets_set(&cmd_params);
+
+	if (err) {
+		LOG_ERR("Failed to set accept_ext_adv_packets: %d", err);
+	}
+#endif
 }
 
 static struct bt_mesh_ext_adv *adv_instance_find(struct bt_le_ext_adv *instance)


### PR DESCRIPTION
Disable processing of extended ADV packets by mesh scanner. This is done to prevent loss of scan time due to reception of pointer packets while scanning for mesh packets.