### PR TITLE
[nrf noup] samples/**/smp_svr: fix SB_CONFIG_PARTITION_MANAGER injection

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -122,7 +122,6 @@ tests:
       - DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay"
       - mcuboot_CONF_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.conf"
       - mcuboot_EXTRA_DTC_OVERLAY_FILE="boards/nrf54l15pdk_nrf54l15_cpuapp_ext_flash.overlay"
-    extra_configs:
       - SB_CONFIG_PARTITION_MANAGER=n
     platform_allow:
       - nrf54l15pdk/nrf54l15/cpuapp


### PR DESCRIPTION
In sample.yaml:
`SB_CONFIG_PARTITION_MANAGER=n` moved to extar_args as extra_config can't handle property with `SB_` prefix.]

REf.: https://github.com/nrfconnect/sdk-zephyr/pull/1636#pullrequestreview-2068729246