### PR TITLE
[nrf fromlist] dt-bindings: pinctrl: nrf: allow for more ports

### DIFF
--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -10,13 +10,12 @@
  * The whole nRF pin configuration information is encoded in a 32-bit bitfield
  * organized as follows:
  *
- * - 31..16: Pin function.
- * - 15:     Reserved.
- * - 14:     Pin inversion mode.
- * - 13:     Pin low power mode.
- * - 12..9:  Pin output drive configuration.
- * - 8..7:   Pin pull configuration.
- * - 6..0:   Pin number (combination of port and pin).
+ * - 31..17: Pin function.
+ * - 16:     Pin inversion mode.
+ * - 15:     Pin low power mode.
+ * - 14..11: Pin output drive configuration.
+ * - 10..9:  Pin pull configuration.
+ * - 8..0:   Pin number (combination of port and pin).
  */
 
 /**
@@ -25,29 +24,29 @@
  */
 
 /** Position of the function field. */
-#define NRF_FUN_POS 16U
+#define NRF_FUN_POS 17U
 /** Mask for the function field. */
-#define NRF_FUN_MSK 0xFFFFU
+#define NRF_FUN_MSK 0x7FFFU
 /** Position of the invert field. */
-#define NRF_INVERT_POS 14U
+#define NRF_INVERT_POS 16U
 /** Mask for the invert field. */
 #define NRF_INVERT_MSK 0x1U
 /** Position of the low power field. */
-#define NRF_LP_POS 13U
+#define NRF_LP_POS 15U
 /** Mask for the low power field. */
 #define NRF_LP_MSK 0x1U
 /** Position of the drive configuration field. */
-#define NRF_DRIVE_POS 9U
+#define NRF_DRIVE_POS 11U
 /** Mask for the drive configuration field. */
 #define NRF_DRIVE_MSK 0xFU
 /** Position of the pull configuration field. */
-#define NRF_PULL_POS 7U
+#define NRF_PULL_POS 9U
 /** Mask for the pull configuration field. */
 #define NRF_PULL_MSK 0x3U
 /** Position of the pin field. */
 #define NRF_PIN_POS 0U
 /** Mask for the pin field. */
-#define NRF_PIN_MSK 0x7FU
+#define NRF_PIN_MSK 0x1FFU
 
 /** @} */
 
@@ -218,7 +217,7 @@
  * @brief Utility macro to build nRF psels property entry.
  *
  * @param fun Pin function configuration (see NRF_FUNC_{name} macros).
- * @param port Port (0 or 1).
+ * @param port Port (0 or 15).
  * @param pin Pin (0..31).
  */
 #define NRF_PSEL(fun, port, pin)						       \


### PR DESCRIPTION
New nRF54H20 SoC series expose more ports, e.g. P9, so reserve more bits for the Port+Pin field.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/73097

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>
(cherry picked from commit 8ffa1fa4a89734ec78017ff5e05c335480f1daa8)