### PR TITLE
[nrf noup] boards: nordic: thingy53: Remove old SECURE_BOOT selection

### DIFF
--- a/boards/nordic/thingy53/Kconfig.sysbuild
+++ b/boards/nordic/thingy53/Kconfig.sysbuild
@@ -11,17 +11,14 @@ choice MCUBOOT_MODE
 	default MCUBOOT_MODE_OVERWRITE_ONLY
 endchoice
 
-config SECURE_BOOT
-	default y
-
 config SECURE_BOOT_NETCORE
-	default y if SECURE_BOOT
+	default y
 
 config NETCORE_APP_UPDATE
-	default y if SECURE_BOOT
+	default y if SECURE_BOOT_NETCORE
 
 config NRF_DEFAULT_EMPTY
-	default y
+	default y if SECURE_BOOT_NETCORE
 
 endif # BOARD_THINGY53_NRF5340_CPUAPP || BOARD_THINGY53_NRF5340_CPUAPP_NS
 


### PR DESCRIPTION
Removes selecting SECURE_BOOT as this is now an automatic selection