### PR TITLE
[nrf fromlist] boards: nrf54h20dk: Add default DFU partition

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -170,11 +170,11 @@
 		#size-cells = <1>;
 
 		cpuapp_slot0_partition: partition@a6000 {
-			reg = <0xa6000 DT_SIZE_K(512)>;
+			reg = <0xa6000 DT_SIZE_K(296)>;
 		};
 
-		cpuppr_code_partition: partition@126000 {
-			reg = <0x126000 DT_SIZE_K(64)>;
+		cpuppr_code_partition: partition@f0000 {
+			reg = <0xf0000 DT_SIZE_K(64)>;
 		};
 	};
 
@@ -187,8 +187,12 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		storage_partition: partition@136000 {
-			reg = <0x136000 DT_SIZE_K(24)>;
+		dfu_partition: partition@100000 {
+			reg = < 0x100000 DT_SIZE_K(892) >;
+		};
+
+		storage_partition: partition@1df000 {
+			reg = < 0x1df000 DT_SIZE_K(24) >;
 		};
 	};
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.yaml
@@ -10,7 +10,7 @@ toolchain:
   - xtools
   - zephyr
 ram: 256
-flash: 512
+flash: 296
 supported:
   - can
   - counter


### PR DESCRIPTION
Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/73408

Define the default DFU partition.

Ref: NCSDK-NONE