### PR TITLE
[nrf fromtree] tests: drivers: spi: spi_error_cases: Enable test exec…

### DIFF
--- a/tests/drivers/spi/spi_error_cases/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf52840dk_nrf52840.overlay
@@ -9,7 +9,7 @@
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 1)>,
 				<NRF_PSEL(SPIM_MISO, 1, 3)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 5)>;
+				<NRF_PSEL(SPIM_MOSI, 1, 7)>;
 		};
 	};
 
@@ -17,7 +17,7 @@
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 1, 1)>,
 				<NRF_PSEL(SPIM_MISO, 1, 3)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 5)>;
+				<NRF_PSEL(SPIM_MOSI, 1, 7)>;
 			low-power-enable;
 		};
 	};
@@ -26,8 +26,8 @@
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 2)>,
 				<NRF_PSEL(SPIS_MISO, 1, 4)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 6)>,
-				<NRF_PSEL(SPIS_CSN, 1, 8)>;
+				<NRF_PSEL(SPIS_MOSI, 1, 8)>,
+				<NRF_PSEL(SPIS_CSN, 1, 10)>;
 		};
 	};
 
@@ -35,25 +35,25 @@
 		group1 {
 			psels = <NRF_PSEL(SPIS_SCK, 1, 2)>,
 				<NRF_PSEL(SPIS_MISO, 1, 4)>,
-				<NRF_PSEL(SPIS_MOSI, 1, 6)>,
-				<NRF_PSEL(SPIS_CSN, 1, 8)>;
+				<NRF_PSEL(SPIS_MOSI, 1, 8)>,
+				<NRF_PSEL(SPIS_CSN, 1, 10)>;
 			low-power-enable;
 		};
 	};
 
 };
 
-dut_spi: &spi3 {
+&spi3 {
 	status = "okay";
 	pinctrl-0 = <&spi3_default_alt>;
 	pinctrl-1 = <&spi3_sleep_alt>;
 	pinctrl-names = "default", "sleep";
 	overrun-character = <0x00>;
-	cs-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
+	cs-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
-		spi-max-frequency = <200000>;
+		spi-max-frequency = <4000000>;
 	};
 };
 
@@ -64,9 +64,4 @@ dut_spis: &spi1 {
 	pinctrl-0 = <&spi1_default_alt>;
 	pinctrl-1 = <&spi1_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	dut_spis_dt: test-spis-dev@0 {
-		compatible = "vnd,spi-device";
-		reg = <0>;
-		spi-max-frequency = <200000>;
-	};
 };

--- a/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	spi130_default_alt: spi130_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
+				<NRF_PSEL(SPIM_MISO, 0, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+		};
+	};
+
+	spi130_sleep_alt: spi130_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 0)>,
+				<NRF_PSEL(SPIM_MISO, 0, 6)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 8)>;
+			low-power-enable;
+		};
+	};
+
+	spis131_default_alt: spis131_default_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
+				<NRF_PSEL(SPIS_MISO, 0, 7)>,
+				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
+				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+		};
+	};
+
+	spis131_sleep_alt: spis131_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(SPIS_SCK, 0, 1)>,
+				<NRF_PSEL(SPIS_MISO, 0, 7)>,
+				<NRF_PSEL(SPIS_MOSI, 0, 9)>,
+				<NRF_PSEL(SPIS_CSN, 0, 11)>;
+			low-power-enable;
+		};
+	};
+
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&spi130 {
+	compatible = "nordic,nrf-spim";
+	status = "okay";
+	pinctrl-0 = <&spi130_default_alt>;
+	pinctrl-1 = <&spi130_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	overrun-character = <0x00>;
+	cs-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+	dut_spi_dt: test-spi-dev@0 {
+		compatible = "vnd,spi-device";
+		reg = <0>;
+		spi-max-frequency = <500000>;
+	};
+	memory-regions = <&cpuapp_dma_region>;
+};
+
+dut_spis: &spi131 {
+	compatible = "nordic,nrf-spis";
+	status = "okay";
+	def-char = <0x00>;
+	pinctrl-0 = <&spis131_default_alt>;
+	pinctrl-1 = <&spis131_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&cpuapp_dma_region>;
+	/delete-property/rx-delay-supported;
+	/delete-property/rx-delay;
+};

--- a/tests/drivers/spi/spi_error_cases/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_error_cases/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -47,7 +47,7 @@
 	status = "okay";
 };
 
-dut_spi: &spi22 {
+&spi22 {
 	status = "okay";
 	pinctrl-0 = <&spi22_default_alt>;
 	pinctrl-1 = <&spi22_sleep_alt>;
@@ -57,7 +57,7 @@ dut_spi: &spi22 {
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
-		spi-max-frequency = <200000>;
+		spi-max-frequency = <4000000>;
 	};
 };
 
@@ -68,11 +68,6 @@ dut_spis: &spi21 {
 	pinctrl-0 = <&spi21_default_alt>;
 	pinctrl-1 = <&spi21_sleep_alt>;
 	pinctrl-names = "default", "sleep";
-	dut_spis_dt: test-spis-dev@0 {
-		compatible = "vnd,spi-device";
-		reg = <0>;
-		spi-max-frequency = <200000>;
-	};
 	/delete-property/rx-delay-supported;
 	/delete-property/rx-delay;
 };

--- a/tests/drivers/spi/spi_error_cases/src/main.c
+++ b/tests/drivers/spi/spi_error_cases/src/main.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/ztest.h>
 
 #define SPI_MODE (SPI_MODE_CPOL | SPI_WORD_SET(8) | SPI_LINES_SINGLE)
@@ -15,7 +16,10 @@
 #define SPIS_OP	 (SPI_OP_MODE_SLAVE | SPI_MODE)
 
 static struct spi_dt_spec spim = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spi_dt), SPIM_OP, 0);
-static struct spi_dt_spec spis = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spis_dt), SPIS_OP, 0);
+static const struct device *spis_dev = DEVICE_DT_GET(DT_NODELABEL(dut_spis));
+static const struct spi_config spis_config = {
+	.operation = SPIS_OP
+};
 
 #define MEMORY_SECTION(node)                                                                       \
 	COND_CODE_1(DT_NODE_HAS_PROP(node, memory_regions),                                        \
@@ -23,7 +27,7 @@ static struct spi_dt_spec spis = SPI_DT_SPEC_GET(DT_NODELABEL(dut_spis_dt), SPIS
 			    LINKER_DT_NODE_REGION_NAME(DT_PHANDLE(node, memory_regions)))))),      \
 		    ())
 
-static uint8_t spim_buffer[32] MEMORY_SECTION(DT_NODELABEL(dut_spi));
+static uint8_t spim_buffer[32] MEMORY_SECTION(DT_BUS(DT_NODELABEL(dut_spi_dt)));
 static uint8_t spis_buffer[32] MEMORY_SECTION(DT_NODELABEL(dut_spis));
 
 struct test_data {
@@ -64,14 +68,14 @@ ZTEST(spi_error_cases, test_SPI_HALF_DUPLEX_not_supported)
 	int rv;
 	int slave_rv;
 	struct spi_dt_spec spim_invalid = spim;
-	struct spi_dt_spec spis_invalid = spis;
+	struct spi_config spis_config_invalid = spis_config;
 
 	spim_invalid.config.operation |= SPI_HALF_DUPLEX;
-	spis_invalid.config.operation |= SPI_HALF_DUPLEX;
+	spis_config_invalid.operation |= SPI_HALF_DUPLEX;
 
 	rv = spi_transceive_dt(&spim_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(rv, -ENOTSUP, "Got %d instead", rv);
-	slave_rv = spi_transceive_dt(&spis_invalid, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -ENOTSUP, "Got %d instead", slave_rv);
 }
 
@@ -80,16 +84,16 @@ ZTEST(spi_error_cases, test_SPI_OP_MODE_invalid)
 	int rv;
 	int slave_rv;
 	struct spi_dt_spec spim_invalid = spim;
-	struct spi_dt_spec spis_invalid = spis;
+	struct spi_config spis_config_invalid = spis_config;
 
 	spim_invalid.config.operation |= SPI_OP_MODE_SLAVE;
-	spis_invalid.config.operation &= !SPI_OP_MODE_SLAVE;
+	spis_config_invalid.operation &= !SPI_OP_MODE_SLAVE;
 
 	/* Check that Operation Mode Slave on spim is not supported */
 	rv = spi_transceive_dt(&spim_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(rv, -EINVAL, "Got %d instead", rv);
 	/* Check that Operation Mode Master on spis is not supported */
-	slave_rv = spi_transceive_dt(&spis_invalid, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -EINVAL, "Got %d instead", slave_rv);
 }
 
@@ -98,14 +102,14 @@ ZTEST(spi_error_cases, test_SPI_MODE_LOOP_not_supported)
 	int rv;
 	int slave_rv;
 	struct spi_dt_spec spim_invalid = spim;
-	struct spi_dt_spec spis_invalid = spis;
+	struct spi_config spis_config_invalid = spis_config;
 
 	spim_invalid.config.operation |= SPI_MODE_LOOP;
-	spis_invalid.config.operation |= SPI_MODE_LOOP;
+	spis_config_invalid.operation |= SPI_MODE_LOOP;
 
 	rv = spi_transceive_dt(&spim_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(rv, -EINVAL, "Got %d instead", rv);
-	slave_rv = spi_transceive_dt(&spis_invalid, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -EINVAL, "Got %d instead", slave_rv);
 }
 
@@ -114,34 +118,34 @@ ZTEST(spi_error_cases, test_only_SPI_LINES_SINGLE_supported)
 	int rv;
 	int slave_rv;
 	struct spi_dt_spec spim_invalid = spim;
-	struct spi_dt_spec spis_invalid = spis;
+	struct spi_config spis_config_invalid = spis_config;
 
 	spim_invalid.config.operation |= SPI_LINES_DUAL;
-	spis_invalid.config.operation |= SPI_LINES_DUAL;
+	spis_config_invalid.operation |= SPI_LINES_DUAL;
 
 	rv = spi_transceive_dt(&spim_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(rv, -EINVAL, "Got %d instead", rv);
-	slave_rv = spi_transceive_dt(&spis_invalid, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -EINVAL, "Got %d instead", slave_rv);
 
 	spim_invalid = spim;
-	spis_invalid = spis;
+	spis_config_invalid = spis_config;
 	spim_invalid.config.operation |= SPI_LINES_QUAD;
-	spis_invalid.config.operation |= SPI_LINES_QUAD;
+	spis_config_invalid.operation |= SPI_LINES_QUAD;
 
 	rv = spi_transceive_dt(&spim_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(rv, -EINVAL, "Got %d instead", rv);
-	slave_rv = spi_transceive_dt(&spis_invalid, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -EINVAL, "Got %d instead", slave_rv);
 
 	spim_invalid = spim;
-	spis_invalid = spis;
+	spis_config_invalid = spis_config;
 	spim_invalid.config.operation |= SPI_LINES_OCTAL;
-	spis_invalid.config.operation |= SPI_LINES_OCTAL;
+	spis_config_invalid.operation |= SPI_LINES_OCTAL;
 
 	rv = spi_transceive_dt(&spim_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(rv, -EINVAL, "Got %d instead", rv);
-	slave_rv = spi_transceive_dt(&spis_invalid, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -EINVAL, "Got %d instead", slave_rv);
 }
 
@@ -150,14 +154,14 @@ ZTEST(spi_error_cases, test_only_8BIT_supported)
 	int rv;
 	int slave_rv;
 	struct spi_dt_spec spim_invalid = spim;
-	struct spi_dt_spec spis_invalid = spis;
+	struct spi_config spis_config_invalid = spis_config;
 
 	spim_invalid.config.operation |= SPI_WORD_SET(16);
-	spis_invalid.config.operation |= SPI_WORD_SET(16);
+	spis_config_invalid.operation |= SPI_WORD_SET(16);
 
 	rv = spi_transceive_dt(&spim_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(rv, -EINVAL, "Got %d instead", rv);
-	slave_rv = spi_transceive_dt(&spis_invalid, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -EINVAL, "Got %d instead", slave_rv);
 }
 
@@ -175,12 +179,12 @@ ZTEST(spi_error_cases, test_unsupported_frequency)
 ZTEST(spi_error_cases, test_CS_unsupported_on_slave)
 {
 	int slave_rv;
-	struct spi_dt_spec spis_invalid = spis;
-	struct gpio_dt_spec test_gpio = { DEVICE_DT_GET(DT_NODELABEL(gpio1)), 10, GPIO_ACTIVE_LOW };
+	struct spi_config spis_config_invalid = spis_config;
+	struct gpio_dt_spec test_gpio = { DEVICE_DT_GET(DT_NODELABEL(gpio0)), 10, GPIO_ACTIVE_LOW };
 
-	spis_invalid.config.cs.gpio = test_gpio;
+	spis_config_invalid.cs.gpio = test_gpio;
 
-	slave_rv = spi_transceive_dt(&spis_invalid, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config_invalid, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -EINVAL, "Got %d instead", slave_rv);
 }
 
@@ -189,7 +193,7 @@ ZTEST(spi_error_cases, test_spis_scattered_tx_buf_not_supported)
 	int slave_rv;
 
 	tdata.sets[2].count = 2;
-	slave_rv = spi_transceive_dt(&spis, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -ENOTSUP, "Got %d instead", slave_rv);
 }
 
@@ -198,7 +202,7 @@ ZTEST(spi_error_cases, test_spis_scattered_rx_buf_not_supported)
 	int slave_rv;
 
 	tdata.sets[3].count = 2;
-	slave_rv = spi_transceive_dt(&spis, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -ENOTSUP, "Got %d instead", slave_rv);
 }
 
@@ -207,7 +211,7 @@ ZTEST(spi_error_cases, test_spis_tx_buf_too_big)
 	int slave_rv;
 
 	tdata.bufs[2].len = (size_t)65536;
-	slave_rv = spi_transceive_dt(&spis, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -EINVAL, "Got %d instead", slave_rv);
 }
 
@@ -216,7 +220,7 @@ ZTEST(spi_error_cases, test_spis_rx_buf_too_big)
 	int slave_rv;
 
 	tdata.bufs[3].len = (size_t)65536;
-	slave_rv = spi_transceive_dt(&spis, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -EINVAL, "Got %d instead", slave_rv);
 }
 
@@ -225,7 +229,7 @@ ZTEST(spi_error_cases, test_spis_tx_buf_not_in_ram)
 	int slave_rv;
 
 	tdata.bufs[2].buf = (void *)0x12345678;
-	slave_rv = spi_transceive_dt(&spis, tdata.stx_set, tdata.srx_set);
+	slave_rv = spi_transceive(spis_dev, &spis_config, tdata.stx_set, tdata.srx_set);
 	zassert_equal(slave_rv, -ENOTSUP, "Got %d instead", slave_rv);
 }
 

--- a/tests/drivers/spi/spi_error_cases/testcase.yaml
+++ b/tests/drivers/spi/spi_error_cases/testcase.yaml
@@ -8,5 +8,6 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840


### PR DESCRIPTION
…ution on nrf54h20

Add overlay file for nrf54h20.
Align code and DTS between spi_error_cases and spi_controller_peripheral.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/72353
Cherry picked from commit https://github.com/zephyrproject-rtos/zephyr/commit/74378f3d523da9161145dd26cc87a644f1cb0538