### PR TITLE
[nrf fromlist] bluetooth: tester: Adjust Broadcaster ext adv pars

### DIFF
--- a/tests/bluetooth/tester/src/btp_bap_broadcast.c
+++ b/tests/bluetooth/tester/src/btp_bap_broadcast.c
@@ -360,7 +360,7 @@ uint8_t btp_bap_broadcast_source_setup(const void *cmd, uint16_t cmd_len,
 
 	err = tester_gap_padv_configure(BT_LE_PER_ADV_PARAM(BT_GAP_PER_ADV_FAST_INT_MIN_2,
 							    BT_GAP_PER_ADV_FAST_INT_MAX_2,
-							    BT_LE_PER_ADV_OPT_USE_TX_POWER));
+							    BT_LE_PER_ADV_OPT_NONE));
 	if (err != 0) {
 		LOG_DBG("Failed to configure periodic advertising: %d", err);
 

--- a/tests/bluetooth/tester/src/btp_cap.c
+++ b/tests/bluetooth/tester/src/btp_cap.c
@@ -569,7 +569,7 @@ static int cap_broadcast_source_adv_setup(struct btp_bap_broadcast_local_source 
 
 	err = tester_gap_padv_configure(BT_LE_PER_ADV_PARAM(BT_GAP_PER_ADV_FAST_INT_MIN_2,
 							    BT_GAP_PER_ADV_FAST_INT_MAX_2,
-							    BT_LE_PER_ADV_OPT_USE_TX_POWER));
+							    BT_LE_PER_ADV_OPT_NONE));
 	if (err != 0) {
 		LOG_DBG("Failed to configure periodic advertising: %d", err);
 


### PR DESCRIPTION
The Broadcaster setup has been hardcoded to include the BT_LE_PER_ADV_OPT_USE_TX_POWER parameter. This may cause incompabilities should the controller not support it, and since the feature may not be required for most broadcast tests it should not be forced.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/73361