### PR TITLE
[nrf fromlist] scripts: west_commands: runners: nrf_common: optional …

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -261,13 +261,13 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
                 self.exec_op('erase', core='NRFDL_DEVICE_CORE_NETWORK')
 
             if self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPUAPP'):
-                if not self.erase:
+                if not self.erase and self.build_conf.getboolean('CONFIG_NRF_REGTOOL_GENERATE_UICR'):
                     self.exec_op('erase', core='NRFDL_DEVICE_CORE_APPLICATION',
                                  chip_erase_mode='ERASE_UICR',
                                  qspi_erase_mode='ERASE_NONE')
                 core = 'NRFDL_DEVICE_CORE_APPLICATION'
             elif self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPURAD'):
-                if not self.erase:
+                if not self.erase and self.build_conf.getboolean('CONFIG_NRF_REGTOOL_GENERATE_UICR'):
                     self.exec_op('erase', core='NRFDL_DEVICE_CORE_NETWORK',
                                  chip_erase_mode='ERASE_UICR',
                                  qspi_erase_mode='ERASE_NONE')


### PR DESCRIPTION
…UICR cleanup

The flasher was unconditionally cleaning the UICR area, even when the application didn't have a new configuration generated. This can happen, when CONFIG_NRF_REGTOOL_GENERATE_UICR=n. In such case, keep the old UICR configuration on the device.

A real scenario where we should set CONFIG_NRF_REGTOOL_GENERATE_UICR=n is when building multiple firmware images that are meant to run one domain. The primary application build generates the UICR configuration and secondary images don't. Before this change, the flashing process of the primary application would write new UICR configuration, but the flashing process of secondary images would erase it.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/73391