### PR TITLE
[nrf fromlist] samples: Bluetooth: use correct periodic advertising intervals

### DIFF
--- a/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
@@ -42,8 +42,8 @@ static struct bt_le_ext_adv_start_param ext_adv_start_param = {
 };
 
 static struct bt_le_per_adv_param per_adv_param = {
-	.interval_min = BT_GAP_ADV_SLOW_INT_MIN,
-	.interval_max = BT_GAP_ADV_SLOW_INT_MAX,
+	.interval_min = BT_GAP_PER_ADV_SLOW_INT_MIN,
+	.interval_max = BT_GAP_PER_ADV_SLOW_INT_MAX,
 	.options = BT_LE_ADV_OPT_USE_TX_POWER,
 };
 


### PR DESCRIPTION
BT_GAP_ADV_SLOW_INT_MIN and BT_GAP_ADV_SLOW_INT_MAX represent 1s and 1.2s, respectively, in the extended advertising context, where the bit interval is 0.625 ms. Using them for periodic advertising will result in a range of [2s, 2.4s], as the bit interval for periodic advertising is 1.25ms.

Instead, BT_GAP_PER_ADV_SLOW_INT_MIN and BT_GAP_PER_ADV_SLOW_INT_MAX should be used in this sample, and the range will become [1s, 1.2s].

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/73418