### PR TITLE
[nrf fromlist] drivers: ieee802154: nrf5: sleep if idle when RxOnWhen…

### DIFF
--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -1009,6 +1009,10 @@ static int nrf5_configure(const struct device *dev,
 	case IEEE802154_CONFIG_RX_ON_WHEN_IDLE:
 		nrf_802154_rx_on_when_idle_set(config->rx_on_when_idle);
 		nrf5_data.rx_on_when_idle = config->rx_on_when_idle;
+
+		if (config->rx_on_when_idle == false) {
+			(void)nrf_802154_sleep_if_idle();
+		}
 		break;
 
 	default:


### PR DESCRIPTION
…Idle=0

When RxOnWhenIdle is set to False, turn the radio off
if no operation is ongoing in order to save power.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/73471