### PR TITLE
[nrf fromlist] net: sockets_service: Fix thread failure

### DIFF
--- a/subsys/net/lib/sockets/sockets_service.c
+++ b/subsys/net/lib/sockets/sockets_service.c
@@ -13,7 +13,13 @@ LOG_MODULE_REGISTER(net_sock_svc, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #include <zephyr/posix/sys/eventfd.h>
 
 static int init_socket_service(void);
-static bool init_done;
+enum SOCKET_SERVICE_THREAD_STATUS {
+	SOCKET_SERVICE_THREAD_UNINITIALIZED = 0,
+	SOCKET_SERVICE_THREAD_FAILED,
+	SOCKET_SERVICE_THREAD_STOPPED,
+	SOCKET_SERVICE_THREAD_RUNNING,
+};
+static enum SOCKET_SERVICE_THREAD_STATUS thread_status;
 
 static K_MUTEX_DEFINE(lock);
 static K_CONDVAR_DEFINE(wait_start);
@@ -52,8 +58,11 @@ int z_impl_net_socket_service_register(const struct net_socket_service_desc *svc
 
 	k_mutex_lock(&lock, K_FOREVER);
 
-	if (!init_done) {
+	if (thread_status == SOCKET_SERVICE_THREAD_UNINITIALIZED) {
 		(void)k_condvar_wait(&wait_start, &lock, K_FOREVER);
+	} else if (thread_status != SOCKET_SERVICE_THREAD_RUNNING) {
+		ret = -EIO;
+		goto out;
 	}
 
 	if (STRUCT_SECTION_START(net_socket_service_desc) > svc ||
@@ -220,7 +229,7 @@ static void socket_service_thread(void)
 		goto out;
 	}
 
-	init_done = true;
+	thread_status = SOCKET_SERVICE_THREAD_RUNNING;
 	k_condvar_broadcast(&wait_start);
 
 	ctx.events[0].fd = fd;
@@ -289,11 +298,12 @@ restart:
 
 out:
 	NET_DBG("Socket service thread stopped");
-	init_done = false;
+	thread_status = SOCKET_SERVICE_THREAD_STOPPED;
 
 	return;
 
 fail:
+	thread_status = SOCKET_SERVICE_THREAD_FAILED;
 	k_condvar_broadcast(&wait_start);
 }
 


### PR DESCRIPTION
In case of thread failure, fix the registrations by properly managing the synchronization i.e. use conditional wait only if thread is being initialized or will be initialized, else check for success or failure without waiting for conditional variables.

Fixes #73523.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/73524