### PR TITLE
[nrf fromtree] tests: drivers: counter: counter_nrf_rtc: Run test on …

### DIFF
--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/testcase.yaml
@@ -7,3 +7,5 @@ tests:
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52_bsim
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad


### PR DESCRIPTION
…nrf54h20

Add nrf54h20dk to platform allow list.
Overlay for tht target was already added.

Signed-off-by: Sebastian Głąb <sebastian.glab@nordicsemi.no>
(cherry picked from commit https://github.com/zephyrproject-rtos/zephyr/commit/89489d6e2d36c2b711610d1156accb445c081927)