### PR TITLE
[nrf fromtree] twister: pytest: Sysbuild support in pytest-twister-ha…

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/binary_adapter.py
@@ -118,7 +118,7 @@ class NativeSimulatorAdapter(BinaryAdapterBase):
 
     def generate_command(self) -> None:
         """Set command to run."""
-        self.command = [str(self.device_config.build_dir / 'zephyr' / 'zephyr.exe')]
+        self.command = [str(self.device_config.app_build_dir / 'zephyr' / 'zephyr.exe')]
 
 
 class UnitSimulatorAdapter(BinaryAdapterBase):
@@ -126,10 +126,10 @@ class UnitSimulatorAdapter(BinaryAdapterBase):
 
     def generate_command(self) -> None:
         """Set command to run."""
-        self.command = [str(self.device_config.build_dir / 'testbinary')]
+        self.command = [str(self.device_config.app_build_dir / 'testbinary')]
 
 
 class CustomSimulatorAdapter(BinaryAdapterBase):
     def generate_command(self) -> None:
         """Set command to run."""
-        self.command = [self.west, 'build', '-d', str(self.device_config.build_dir), '-t', 'run']
+        self.command = [self.west, 'build', '-d', str(self.device_config.app_build_dir), '-t', 'run']

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/qemu_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/qemu_adapter.py
@@ -23,7 +23,7 @@ class QemuAdapter(BinaryAdapterBase):
 
     def generate_command(self) -> None:
         """Set command to run."""
-        self.command = [self.west, 'build', '-d', str(self.device_config.build_dir), '-t', 'run']
+        self.command = [self.west, 'build', '-d', str(self.device_config.app_build_dir), '-t', 'run']
         if 'stdin' in self.process_kwargs:
             self.process_kwargs.pop('stdin')
 

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/domains_helper.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/helpers/domains_helper.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import os
+import sys
+import logging
+
+from pathlib import Path
+
+ZEPHYR_BASE = os.environ['ZEPHYR_BASE']
+sys.path.insert(0, os.path.join(ZEPHYR_BASE, 'scripts', 'pylib', 'build_helpers'))
+
+from domains import Domains
+
+logger = logging.getLogger(__name__)
+logging.getLogger('pykwalify').setLevel(logging.ERROR)
+
+
+def get_default_domain_name(domains_file: Path | str) -> int:
+    """
+    Get the default domain name from the domains.yaml file
+    """
+    domains = Domains.from_file(domains_file)
+    logger.debug("Loaded sysbuild domain data from %s" % domains_file)
+    return domains.get_default_domain().name

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+from twister_harness.helpers.domains_helper import get_default_domain_name
 
 import pytest
 
@@ -32,6 +33,14 @@ class DeviceConfig:
     pre_script: Path | None = None
     post_script: Path | None = None
     post_flash_script: Path | None = None
+    app_build_dir: Path | None = None
+
+    def __post_init__(self):
+        domains = self.build_dir / 'domains.yaml'
+        if domains.exists():
+            self.app_build_dir = self.build_dir / get_default_domain_name(domains)
+        else:
+            self.app_build_dir = self.build_dir
 
 
 @dataclass

--- a/scripts/pylib/pytest-twister-harness/tests/device/qemu_adapter_test.py
+++ b/scripts/pylib/pytest-twister-harness/tests/device/qemu_adapter_test.py
@@ -27,7 +27,7 @@ def fixture_device_adapter(tmp_path) -> Generator[QemuAdapter, None, None]:
 
 @patch('shutil.which', return_value='west')
 def test_if_generate_command_creates_proper_command(patched_which, device: QemuAdapter):
-    device.device_config.build_dir = Path('build_dir')
+    device.device_config.app_build_dir = Path('build_dir')
     device.generate_command()
     assert device.command == ['west', 'build', '-d', 'build_dir', '-t', 'run']
 


### PR DESCRIPTION
…rness

Read default domain from domains.yaml file and update paths to proper build directory. It fixes native and qemu pytest scenarios, when application is build with sysbuild.

Signed-off-by: Grzegorz Chwierut <grzegorz.chwierut@nordicsemi.no>
(cherry picked from commit f52f08f877fff2ddd2cc61f134dfee1eaa599325)