### PR TITLE
net: lwm2m: Fix NUM field on CoAP Block-Wise write

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2066,6 +2066,10 @@ static int parse_write_op(struct lwm2m_message *msg, uint16_t format)
 			free_block_ctx(block_ctx);
 
 			r = init_block_ctx(&msg->path, &block_ctx);
+			/* If we have already parsed the packet, we can handle the block size
+			 * given by the server.
+			 */
+			block_ctx->ctx.block_size = block_size;
 		}
 
 		if (r < 0) {

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -1004,7 +1004,7 @@ static int lwm2m_write_handler_opaque(struct lwm2m_engine_obj_inst *obj_inst,
 				return ret;
 			}
 		}
-		if (msg->in.block_ctx) {
+		if (msg->in.block_ctx && !last_pkt_block) {
 			msg->in.block_ctx->ctx.current += len;
 		}
 	}


### PR DESCRIPTION
Fix the error where we reply with wrong NUM field on block-wise write.
