### PR TITLE
[nrf fromtree] tests: nordic: Enable I2C tests

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.yaml
@@ -15,6 +15,7 @@ supported:
   - can
   - counter
   - gpio
+  - i2c
   - pwm
   - spi
   - watchdog

--- a/tests/boards/nrf/i2c/i2c_slave/testcase.yaml
+++ b/tests/boards/nrf/i2c/i2c_slave/testcase.yaml
@@ -5,8 +5,13 @@ tests:
     harness: ztest
     harness_config:
       fixture: i2c_loopback
-    platform_allow: nrf52840dk/nrf52840 nrf5340dk/nrf5340/cpuapp nrf54l15pdk/nrf54l15/cpuapp
+    platform_allow:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15pdk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Add i2c to supported peripheral to enable i2c testing.

Signed-off-by: Sebastian Głąb <sebastian.glab@nordicsemi.no>
(cherry picked from commit 955dbf47f8ca8c0151807df88eefa9b1c910852b)