### PR TITLE
[nrf fromtree] samples: basic: fade_led: add testing base on console …

### DIFF
--- a/samples/basic/fade_led/sample.yaml
+++ b/samples/basic/fade_led/sample.yaml
@@ -6,7 +6,14 @@ tests:
       - drivers
       - pwm
     depends_on: pwm
-    harness: led
     filter: dt_alias_exists("pwm-led0") and dt_compat_enabled("pwm-leds")
     integration_platforms:
       - nrf51dk/nrf51822
+    harness: console
+    harness_config:
+      type: multi_line
+      ordered: true
+      regex:
+        - "PWM-based LED fade"
+        - "Using pulse width [0-9]+%"
+        - "Using pulse width [0-9]+%"

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -40,6 +40,7 @@ int main(void)
 			printk("Error %d: failed to set pulse width\n", ret);
 			return 0;
 		}
+		printk("Using pulse width %d%%\n", 100 * pulse_width / pwm_led0.period);
 
 		if (dir) {
 			pulse_width += step;


### PR DESCRIPTION
…output

Extend automated testing on HW by veryfing console output.

Signed-off-by: Sebastian Głąb <sebastian.glab@nordicsemi.no>
(cherry picked from commit 5a4fa06c6793fd4a62fa79872cb1073f7d9e192a)