### PR TITLE
[nrf noup] board: nordic: thingy53: Default to update only MCUboot type

### DIFF
--- a/boards/nordic/thingy53/Kconfig.sysbuild
+++ b/boards/nordic/thingy53/Kconfig.sysbuild
@@ -7,6 +7,10 @@ choice BOOTLOADER
 	default BOOTLOADER_MCUBOOT
 endchoice
 
+choice MCUBOOT_MODE
+	default MCUBOOT_MODE_OVERWRITE_ONLY
+endchoice
+
 config SECURE_BOOT
 	default y
 


### PR DESCRIPTION
Changes the default MCUboot mode to update only for the thingy53, to align with previous bootloader builds