### PR TITLE
[nrf noup] dts: nordic: Add support for BICR generation

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_bicr.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_bicr.dtsi
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/ {
+	bicr: bicr@fff87b0 {
+		compatible = "nordic,nrf-bicr";
+		reg = <0xfff87b0 0x48>;
+
+		power-vddao5v0 = "external";
+		power-vddao1v8 = "internal";
+		power-vdd1v0 = "internal";
+		power-vddrf1v0 = "shorted";
+		power-vddao0v8 = "internal";
+		power-vddvs0v8 = "internal";
+
+		inductor-present;
+
+		ioport-power-rails = <&gpio1 2>, <&gpio2 2>, <&gpio6 2>, <&gpio7 2>, <&gpio9 4>;
+		ioport-drivectrls = <&gpio6 50>, <&gpio7 50>;
+
+		lfosc-mode = "crystal";
+		lfosc-loadcap = <14>;
+
+		lfrc-autocalibration = <20 40 3>;
+
+		hfxo-mode = "crystal";
+		hfxo-loadcap = <56>;
+	};
+};
+
+&gpio1 {
+	#ioport-power-rail-cells = <1>;
+};
+
+&gpio2 {
+	#ioport-power-rail-cells = <1>;
+};
+
+&gpio6 {
+	#ioport-power-rail-cells = <1>;
+	#ioport-drivectrl-cells = <1>;
+};
+
+&gpio7 {
+	#ioport-power-rail-cells = <1>;
+	#ioport-drivectrl-cells = <1>;
+};
+
+&gpio9 {
+	#ioport-power-rail-cells = <1>;
+};

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -10,6 +10,7 @@
 #include "nrf54h20dk_nrf54h20-memory_map.dtsi"
 #include "nrf54h20dk_nrf54h20-ipc_conf.dtsi"
 #include "nrf54h20dk_nrf54h20-pinctrl.dtsi"
+#include "nrf54h20dk_bicr.dtsi"
 
 /delete-node/ &cpurad_cpusys_ipc;
 /delete-node/ &cpusec_cpurad_ipc;

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -5,7 +5,7 @@ description: NRF5 GPIO node
 
 compatible: "nordic,nrf-gpio"
 
-include: [gpio-controller.yaml, base.yaml]
+include: [gpio-controller.yaml, base.yaml, "nordic,nrf-port-configs.yaml"]
 
 properties:
   reg:

--- a/dts/bindings/gpio/nordic,nrf-port-configs.yaml
+++ b/dts/bindings/gpio/nordic,nrf-port-configs.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+
+description: |
+  Nordic Port Configs
+
+  Hardware configurations that apply to IO ports.
+
+properties:
+  ioport-power-rails:
+    type: phandle-array
+    description: |
+      Power supply configurations for GPIO ports. The configuration is board-
+      specific and stored in BICR.
+      The property is encoded as <&phandle rail>, where:
+
+      - phandle is the phandle of the associated GPIO port
+      - rail is the 8-bit power rail configuration to apply to the port
+
+  ioport-drivectrls:
+    type: phandle-array
+    description: |
+      Drive control settings for GPIO ports. The configuration is board-specific
+      and stored in BICR.
+      The property is encoded as <&phandle resistance>, where:
+
+      - phandle is the phandle of the associated GPIO port
+      - resistance is the resistance in ohms to adjust in the port's drive
+      control, and can be one of the following: [33, 40, 50, 66, 100].
+
+ioport-power-rail-cells:
+  - rail
+
+ioport-drivectrl-cells:
+  - resistance

--- a/dts/bindings/misc/nordic,nrf-bicr.yaml
+++ b/dts/bindings/misc/nordic,nrf-bicr.yaml
@@ -1,0 +1,117 @@
+# Copyright (c) 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+
+description: |
+  Nordic Board Information Configuration Registers (BICR)
+
+compatible: "nordic,nrf-bicr"
+
+include: [base.yaml, "nordic,nrf-port-configs.yaml"]
+
+properties:
+  power-vddao5v0:
+    type: string
+    description: VDD_AO_5V0 power rail configuration.
+    enum:
+      - "external"
+      - "shorted"
+
+  power-vddao1v8:
+    type: string
+    description: VDD_AO_1V8 power rail configuration.
+    enum:
+      - "internal"
+      - "external"
+
+  power-vdd1v0:
+    type: string
+    description: VDD_1V0 power rail configuration.
+    enum:
+      - "internal"
+      - "external"
+
+  power-vddrf1v0:
+    type: string
+    description: VDD_RF_1V0 power rail configuration.
+    enum:
+      - "external"
+      - "shorted"
+
+  power-vddao0v8:
+    type: string
+    description: VDD_AO_0V8 power rail configuration.
+    enum:
+      - "internal"
+      - "external"
+
+  power-vddvs0v8:
+    type: string
+    description: VDD_VS_0V8 power rail configuration.
+    enum:
+      - "internal"
+      - "external"
+
+  inductor-present:
+    type: boolean
+    description: DC/DC inductor present.
+
+  lfosc-accuracy:
+    type: int
+    description: LFXO crystal or external signal accuracy in ppm.
+    enum:
+      - 500
+      - 250
+      - 150
+      - 100
+      - 75
+      - 50
+      - 30
+      - 20
+
+  lfosc-mode:
+    type: string
+    description: |
+      LFXO operational mode.
+    enum:
+      - "crystal"
+      - "external-sine"
+      - "external-square"
+
+  lfosc-loadcap:
+    type: int
+    description: |
+      Built-in load capacitors selection in 1pF steps, up to 25pF max. If 0,
+      only external capacitors will be used.
+
+  lfosc-startup:
+    type: int
+    description: LFXO startup time in milliseconds.
+
+  lfrc-autocalibration:
+    type: array
+    description: |
+      A list of values pertaining to LFRC autocalibration settings. The prop
+      is encoded as <temp-interval temp-delta interval-max-count>, where:
+      - temp-interval is the temperature measurement interval in 0.25s steps
+      - temp-delta is the temperature delta that should trigger a calibration
+        in 0.25 degree steps
+      - interval-max-count are the max number of temp-interval periods in
+        between calibrations, independent of temperature changes.
+
+  hfxo-mode:
+    type: string
+    description: |
+      HFXO operational mode.
+    enum:
+      - "crystal"
+      - "external-square"
+
+  hfxo-loadcap:
+    type: int
+    description: |
+      Built-in load capacitors selection in 0.25 pF steps, up to 25.75 pF max.
+      If 0, only external capacitors will be used.
+
+  hfxo-startup:
+    type: int
+    description: HFXO startup time in milliseconds.

--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -11,8 +11,11 @@ add_subdirectory_ifdef(CONFIG_HAS_NRFS nrfs)
 if(CONFIG_NRF_REGTOOL_GENERATE_UICR)
   list(APPEND nrf_regtool_components GENERATE:UICR)
 endif()
+if(CONFIG_NRF_REGTOOL_GENERATE_BICR)
+  list(APPEND nrf_regtool_components GENERATE:BICR)
+endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 5.3.0 REQUIRED
+  find_package(nrf-regtool 5.3.2 REQUIRED
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH

--- a/modules/hal_nordic/Kconfig.nrf_regtool
+++ b/modules/hal_nordic/Kconfig.nrf_regtool
@@ -11,6 +11,13 @@ config NRF_REGTOOL_GENERATE_UICR
 	  CPU domains that require UICR allocation aren't bootable without it
 	  being programmed alongside the firmware.
 
+config NRF_REGTOOL_GENERATE_BICR
+	bool "Generate BICR"
+	help
+	  Generate a BICR hex based on devicetree contents using nrf-regtool.
+	  If not already present, the BICR must be included alongside
+	  any firmware programmed to the board for the first time.
+
 config NRF_REGTOOL_VERBOSITY
 	int "Verbosity level of console output"
 	range 0 3

--- a/modules/hal_nordic/nrf-regtool/nrf-regtoolConfig.cmake
+++ b/modules/hal_nordic/nrf-regtool/nrf-regtoolConfig.cmake
@@ -24,6 +24,10 @@ function(nrf_regtool_generate_hex_from_dts peripheral)
   )
   message(STATUS "Generated ${peripheral} hex file: ${generated_hex_file}")
 
+  if(NOT peripheral STREQUAL "UICR")
+    return()
+  endif()
+
   set(merged_hex_file ${PROJECT_BINARY_DIR}/${merged_hex_name})
   set_property(GLOBAL APPEND PROPERTY extra_post_build_commands
     COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/scripts/build/mergehex.py

--- a/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuapp
+++ b/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuapp
@@ -11,4 +11,7 @@ config NUM_IRQS
 config NRF_REGTOOL_GENERATE_UICR
 	default y
 
+config NRF_REGTOOL_GENERATE_BICR
+	default y
+
 endif # SOC_NRF54H20_CPUAPP


### PR DESCRIPTION
This will be replaced by a different solution upstream (NCSDK-27673).

Migrate the existing BICR bindings from NCS 2.4.99-cs3 to NCS 2.7.0. They are updated to remove obsoleted values. Enable generating bicr.hex for Application core by default.