### PR TITLE
[nrf noup] scripts: west_commands: build: Add NCS example repo to sys…

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -579,7 +579,7 @@ class Build(Forceable):
             # Check if this is an ncs-repo directory
             allow_list = [ 'mcuboot', 'sidewalk', 'find-my', 'nrf', 'matter', 'suit-processor',
                            'memfault-firmware-sdk', 'zscilib', 'uoscore-uedhoc', 'zcbor',
-                           'hal_nordic' ]
+                           'hal_nordic', 'ncs-example-application' ]
             config_sysbuild = False
 
             for module in zephyr_module.parse_modules(ZEPHYR_BASE, self.manifest):


### PR DESCRIPTION
…build list

Adds the example NCS project to the list of repos that should build using sysbuild by default