### PR TITLE
[nrf noup] dts: nordic: LFXO crystal settings adjustment

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_bicr.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_bicr.dtsi
@@ -22,7 +22,7 @@
 		ioport-drivectrls = <&gpio6 50>, <&gpio7 50>;
 
 		lfosc-mode = "crystal";
-		lfosc-loadcap = <14>;
+		lfosc-loadcap = <15>;
 
 		lfrc-autocalibration = <20 40 3>;
 


### PR DESCRIPTION
Adjustment LFXO CLOAD value. New value is a resualt of DK's characterization.