### PR TITLE
[nrf fromlist] doc: sysbuild: Add tag for application configuration s…

### DIFF
--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -588,6 +588,8 @@ a Kconfig option, which would make ``my_sample`` conditionally build-only.
    ``west flash --domain my_sample``. As such, the ``BUILD_ONLY`` option only
    controls the default behavior of ``west flash``.
 
+.. _sysbuild_application_configuration:
+
 Zephyr application configuration
 ================================
 


### PR DESCRIPTION
…ection

Adds a tag to the sysbuild application configuration section so it can be referenced in other documentation

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/74002