### PR TITLE
[nrf fromtree] drivers: serial: nrfx_uarte: Use of legacy shim on RISCV

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -31,7 +31,8 @@ config UART_NRFX_UARTE
 config UART_NRFX_UARTE_LEGACY_SHIM
 	bool "Legacy UARTE shim"
 	depends on UART_NRFX_UARTE
-	depends on !SOC_SERIES_NRF54LX && !SOC_SERIES_NRF54HX
+	depends on !SOC_SERIES_NRF54LX
+	depends on RISCV || !SOC_SERIES_NRF54HX
 	# New shim takes more ROM. Until it is fixed use legacy shim.
 	default y
 

--- a/drivers/serial/Kconfig.nrfx_uart_instance
+++ b/drivers/serial/Kconfig.nrfx_uart_instance
@@ -54,6 +54,7 @@ config UART_$(nrfx_uart_num)_NRF_HW_ASYNC
 	depends on HAS_HW_NRF_UARTE$(nrfx_uart_num)
 	depends on UART_ASYNC_API
 	depends on UART_NRFX_UARTE_LEGACY_SHIM
+	depends on HAS_HW_NRF_PPI || HAS_HW_NRF_DPPIC
 	select NRFX_PPI if HAS_HW_NRF_PPI
 	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 	help

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -25,12 +25,12 @@ LOG_MODULE_REGISTER(uart_nrfx_uarte, CONFIG_UART_LOG_LEVEL);
 #include <zephyr/drivers/pinctrl.h>
 
 /* Generalize PPI or DPPI channel management */
-#if defined(CONFIG_HAS_HW_NRF_PPI)
+#if defined(PPI_PRESENT)
 #include <nrfx_ppi.h>
 #define gppi_channel_t nrf_ppi_channel_t
 #define gppi_channel_alloc nrfx_ppi_channel_alloc
 #define gppi_channel_enable nrfx_ppi_channel_enable
-#elif defined(CONFIG_HAS_HW_NRF_DPPIC)
+#elif defined(DPPI_PRESENT)
 #include <nrfx_dppi.h>
 #define gppi_channel_t uint8_t
 #define gppi_channel_alloc nrfx_dppi_channel_alloc
@@ -39,39 +39,49 @@ LOG_MODULE_REGISTER(uart_nrfx_uarte, CONFIG_UART_LOG_LEVEL);
 #error "No PPI or DPPI"
 #endif
 
+/* Execute macro f(x) for all instances. */
+#define UARTE_FOR_EACH_INSTANCE(f, sep, off_code) \
+	NRFX_FOREACH_PRESENT(UARTE, f, sep, off_code, _)
 
-#if	(defined(CONFIG_HAS_HW_NRF_UARTE0) &&         \
-	 defined(CONFIG_UART_0_INTERRUPT_DRIVEN)) || \
-	(defined(CONFIG_HAS_HW_NRF_UARTE1) &&         \
-	 defined(CONFIG_UART_1_INTERRUPT_DRIVEN)) || \
-	(defined(CONFIG_HAS_HW_NRF_UARTE2) &&         \
-	 defined(CONFIG_UART_2_INTERRUPT_DRIVEN)) || \
-	(defined(CONFIG_HAS_HW_NRF_UARTE3) &&         \
-	 defined(CONFIG_UART_3_INTERRUPT_DRIVEN))
+/* Determine if any instance is using interrupt driven API. */
+#define IS_INT_DRIVEN(unused, prefix, i, _) \
+	(IS_ENABLED(CONFIG_HAS_HW_NRF_UARTE##prefix##i) && \
+	 IS_ENABLED(CONFIG_UART_##prefix##i##_INTERRUPT_DRIVEN))
+
+#if UARTE_FOR_EACH_INSTANCE(IS_INT_DRIVEN, (||), (0))
 	#define UARTE_INTERRUPT_DRIVEN	1
 #endif
 
-#if	(defined(CONFIG_HAS_HW_NRF_UARTE0) && !defined(CONFIG_UART_0_ASYNC)) || \
-	(defined(CONFIG_HAS_HW_NRF_UARTE1) && !defined(CONFIG_UART_1_ASYNC)) || \
-	(defined(CONFIG_HAS_HW_NRF_UARTE2) && !defined(CONFIG_UART_2_ASYNC)) || \
-	(defined(CONFIG_HAS_HW_NRF_UARTE3) && !defined(CONFIG_UART_3_ASYNC))
+/* Determine if any instance is not using asynchronous API. */
+#define IS_NOT_ASYNC(unused, prefix, i, _) \
+	(IS_ENABLED(CONFIG_HAS_HW_NRF_UARTE##prefix##i) && \
+	 !IS_ENABLED(CONFIG_UART_##prefix##i##_ASYNC))
+
+#if UARTE_FOR_EACH_INSTANCE(IS_NOT_ASYNC, (||), (0))
 #define UARTE_ANY_NONE_ASYNC 1
 #endif
 
-#if	(defined(CONFIG_HAS_HW_NRF_UARTE0) && defined(CONFIG_UART_0_ASYNC)) || \
-	(defined(CONFIG_HAS_HW_NRF_UARTE1) && defined(CONFIG_UART_1_ASYNC)) || \
-	(defined(CONFIG_HAS_HW_NRF_UARTE2) && defined(CONFIG_UART_2_ASYNC)) || \
-	(defined(CONFIG_HAS_HW_NRF_UARTE3) && defined(CONFIG_UART_3_ASYNC))
+/* Determine if any instance is using asynchronous API. */
+#define IS_ASYNC(unused, prefix, i, _) \
+	(IS_ENABLED(CONFIG_HAS_HW_NRF_UARTE##prefix##i) && \
+	 IS_ENABLED(CONFIG_UART_##prefix##i##_ASYNC))
+
+#if UARTE_FOR_EACH_INSTANCE(IS_ASYNC, (||), (0))
 #define UARTE_ANY_ASYNC 1
 #endif
 
-#if	defined(CONFIG_UART_0_NRF_HW_ASYNC) || defined(CONFIG_UART_1_NRF_HW_ASYNC) || \
-	defined(CONFIG_UART_2_NRF_HW_ASYNC) || defined(CONFIG_UART_3_NRF_HW_ASYNC)
+/* Determine if any instance is using asynchronous API with HW byte counting. */
+#define IS_HW_ASYNC(unused, prefix, i, _) IS_ENABLED(CONFIG_UART_##prefix##i##_NRF_HW_ASYNC)
+
+#if UARTE_FOR_EACH_INSTANCE(IS_HW_ASYNC, (||), (0))
 #define UARTE_HW_ASYNC 1
 #endif
 
-#if	defined(CONFIG_UART_0_ENHANCED_POLL_OUT) || defined(CONFIG_UART_1_ENHANCED_POLL_OUT) || \
-	defined(CONFIG_UART_2_ENHANCED_POLL_OUT) || defined(CONFIG_UART_3_ENHANCED_POLL_OUT)
+/* Determine if any instance is using enhanced poll_out feature. */
+#define IS_ENHANCED_POLL_OUT(unused, prefix, i, _) \
+	IS_ENABLED(CONFIG_UART_##prefix##i##_ENHANCED_POLL_OUT)
+
+#if UARTE_FOR_EACH_INSTANCE(IS_ENHANCED_POLL_OUT, (||), (0))
 #define UARTE_ENHANCED_POLL_OUT 1
 #endif
 
@@ -2074,18 +2084,7 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 			DT_PHANDLE(UARTE(idx), memory_regions)))))),	       \
 		())
 
-#ifdef CONFIG_HAS_HW_NRF_UARTE0
-UART_NRF_UARTE_DEVICE(0);
-#endif
+#define COND_UART_NRF_UARTE_DEVICE(unused, prefix, i, _) \
+	IF_ENABLED(CONFIG_HAS_HW_NRF_UARTE##prefix##i, (UART_NRF_UARTE_DEVICE(prefix##i);))
 
-#ifdef CONFIG_HAS_HW_NRF_UARTE1
-UART_NRF_UARTE_DEVICE(1);
-#endif
-
-#ifdef CONFIG_HAS_HW_NRF_UARTE2
-UART_NRF_UARTE_DEVICE(2);
-#endif
-
-#ifdef CONFIG_HAS_HW_NRF_UARTE3
-UART_NRF_UARTE_DEVICE(3);
-#endif
+UARTE_FOR_EACH_INSTANCE(COND_UART_NRF_UARTE_DEVICE, (), ())


### PR DESCRIPTION
Legacy shim takes less flash so it should be a first choice on cores with less code memory (like RISCV cores on nrf54h20). Adding new instances support to the legacy shim.

Signed-off-by: Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>
(cherry picked from commit d07b13dbc203be8066e9f840edf917dd8969ce00)