### PR TITLE
[nrf fromlist] nordic: dts: Fix grtc interrupt line for secure nRF54L

### DIFF
--- a/dts/arm/nordic/nrf54l15_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l15_cpuapp.dtsi
@@ -39,8 +39,12 @@ cpuflpr_vevif: &cpuflpr_vevif_remote {};
 };
 
 &grtc {
+#ifdef USE_NON_SECURE_ADDRESS_MAP
+	interrupts = <227 NRF_DEFAULT_IRQ_PRIORITY>,
+#else
 	interrupts = <228 NRF_DEFAULT_IRQ_PRIORITY>,
-			<229 NRF_DEFAULT_IRQ_PRIORITY>; /* reserved for Zero Latency IRQs */
+#endif
+		<229 NRF_DEFAULT_IRQ_PRIORITY>; /* reserved for Zero Latency IRQs */
 };
 
 &gpiote20 {


### PR DESCRIPTION
When TF-M is used, zephyr must use a different interrupt line for GRTC.

Signed-off-by: Vidar Lillebø <vidar.lillebo@nordicsemi.no>
(cherry picked from commit 1fcbddc02a462e6fe7d5c36a16ef2fe925d87ae4)