### PR TITLE
[nrf fromtree] Bluetooth: Host: Avoid processing "no change" encryption changes

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2092,6 +2092,12 @@ static void hci_encrypt_change(struct net_buf *buf)
 		return;
 	}
 
+	if (conn->encrypt == evt->encrypt) {
+		LOG_WRN("No change to encryption state (encrypt 0x%02x)", evt->encrypt);
+		bt_conn_unref(conn);
+		return;
+	}
+
 	conn->encrypt = evt->encrypt;
 
 #if defined(CONFIG_BT_SMP)


### PR DESCRIPTION

If the new encryption state is the same as the old one, there's no point in doing additional processing or callbacks. Simply log a warning and ignore the HCI event in such a case.


(cherry picked from commit bf363d7c3e4614ebc9b7e7a051657ae6fde6283b)