### PR TITLE
[nrf fromlist] hal_nordic: Fix reserved PPI faulty logic

### DIFF
--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -9,6 +9,10 @@ menu "nrfx drivers"
 
 rsource "Kconfig.logging"
 
+config MPSL
+	bool
+	# Dummy kconfig to allow compiling outside of NCS
+
 config NRFX_ADC
 	bool "ADC driver"
 	depends on $(dt_has_compat,$(DT_COMPAT_NORDIC_NRF_ADC))

--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -378,7 +378,7 @@ void nrfx_busy_wait(uint32_t usec_to_wait);
 #define NRFX_PPI_GROUPS_USED_BY_802154_DRV     0
 #endif // CONFIG_NRF_802154_RADIO_DRIVER
 
-#if defined(CONFIG_NRF_802154_RADIO_DRIVER) && !defined(CONFIG_NRF_802154_SL_OPENSOURCE)
+#if defined(CONFIG_MPSL)
 #include <mpsl.h>
 #define NRFX_PPI_CHANNELS_USED_BY_MPSL   MPSL_RESERVED_PPI_CHANNELS
 #define NRFX_PPI_GROUPS_USED_BY_MPSL     0


### PR DESCRIPTION
The list of reserved PPIs by MPSL should be kept if MPSL is enabled. The 802154 radio driver is not the only user of MPSL.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/74139

Quoting original PR

> This is a blocker for Garmin's ANT stack that also uses MPSL.
Their application/stack doesn't start up at all without this fix.