### PR TITLE
[nrf fromlist] soc: add deprecation warning if using HWMv1 SoCs

### DIFF
--- a/soc/CMakeLists.txt
+++ b/soc/CMakeLists.txt
@@ -12,6 +12,16 @@ unset(_SOC_IS_IN_TREE)
 add_subdirectory(common)
 
 if(HWMv1)
+  message(DEPRECATION "
+          ---------------------------------------------------------------------
+          --- WARNING: Functionality to describe SoCs in HWMv1 is           ---
+          --- deprecated and should be replaced with HWMv2, including       ---
+          --- boards. HWMv1 SoCs support remains only to ease the migration ---
+          --- of out-of-tree SoCs and associated boards. It will not be     ---
+          --- possible to build using HWMv1 SoCs at all in future releases. ---
+          ---------------------------------------------------------------------"
+         )
+
   if(EXISTS ${SOC_DIR}/${ARCH}/CMakeLists.txt)
     add_subdirectory(${SOC_DIR}/${ARCH} soc/${ARCH})
   else()


### PR DESCRIPTION
While all in-tree SoCs have been ported to HWMv2, Zephyr still supports out-of-tree SoCs in HWMv1 format, including boards. Add a clear deprecation message so that users get notified that this is a deprecated feature to be removed in the future.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/74143

Signed-off-by: Gerard Marull-Paretas <gerard@teslabs.com>
(cherry picked from commit 5301880b6f5b73337b02e7c9bd5498f70d11fd48)