### PR TITLE
[nrf noup] samples: sysbuild: hello_world: support PM on nRF53

### DIFF
--- a/samples/sysbuild/hello_world/sysbuild.cmake
+++ b/samples/sysbuild/hello_world/sysbuild.cmake
@@ -11,5 +11,12 @@ ExternalZephyrProject_Add(
   BOARD ${SB_CONFIG_REMOTE_BOARD}
 )
 
+if(SB_CONFIG_SOC_SERIES_NRF53X)
+  set_property(GLOBAL APPEND PROPERTY PM_DOMAINS CPUNET)
+  set_property(GLOBAL APPEND PROPERTY PM_CPUNET_IMAGES remote)
+  set_property(GLOBAL PROPERTY DOMAIN_APP_CPUNET remote)
+  set(CPUNET_PM_DOMAIN_DYNAMIC_PARTITION remote CACHE INTERNAL "")
+endif()
+
 add_dependencies(hello_world remote)
 sysbuild_add_dependencies(FLASH hello_world remote)


### PR DESCRIPTION
PM support is still required for nRF53 in the context of NCS.