### PR TITLE
[nrf fromtree] fs: nvs: Add CRC to protect the data part of the NVS items

### DIFF
--- a/doc/services/storage/nvs/nvs.rst
+++ b/doc/services/storage/nvs/nvs.rst
@@ -19,11 +19,16 @@ combination of these.
 Each element is stored in flash as metadata (8 byte) and data. The metadata is
 written in a table starting from the end of a nvs sector, the data is
 written one after the other from the start of the sector. The metadata consists
-of: id, data offset in sector, data length, part (unused), and a CRC. The CRC is
+of: id, data offset in sector, data length, part (unused), and a CRC. This CRC is
 only calculated over the metadata and only ensures that a write has been
-completed. The actual data of the element is not protected by a CRC. It is
-encouraged to include a CRC as part of the data and to take appropriate
-corrective actions when the data CRC does not match its expected value.
+completed. The actual data of the element can be protected by a different (and optional)
+CRC-32. Use the :kconfig:option:`CONFIG_NVS_DATA_CRC` configuration item to enable
+the data part CRC.
+**Note:** the data CRC is checked only when the whole data of the element is read.
+The data CRC is not checked for a partial read, as it is stored at the end of the
+element data area.
+**Note 2:** enabling the data CRC feature on a previously existing NVS content without
+data CRC will make all existing data invalid.
 
 A write of data to nvs always starts with writing the data, followed by a write
 of the metadata. Data that is written in flash without metadata is ignored

--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -29,6 +29,15 @@ config NVS_LOOKUP_CACHE_SIZE
 	  Number of entries in Non-volatile Storage lookup cache.
 	  It is recommended that it be a power of 2.
 
+config NVS_LOOKUP_CACHE_FOR_SETTINGS
+	bool "Non-volatile Storage lookup cache optimized for settings"
+	depends on NVS_LOOKUP_CACHE
+	help
+	  Use the lookup cache hash function that results in the least number of
+	  collissions and, in turn, the best NVS performance provided that the NVS
+	  is used as the settings backend only. This option should NOT be enabled
+	  if the NVS is also written to directly, outside the settings layer.
+
 config NVS_DATA_CRC
 	bool "Non-volatile Storage CRC protection on the data"
 	help

--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -29,6 +29,14 @@ config NVS_LOOKUP_CACHE_SIZE
 	  Number of entries in Non-volatile Storage lookup cache.
 	  It is recommended that it be a power of 2.
 
+config NVS_DATA_CRC
+	bool "Non-volatile Storage CRC protection on the data"
+	help
+	  Enable a CRC-32 on the data part of each NVS element.
+	  The ATE CRC is not impacted by this feature and stays the same.
+	  The CRC-32 is transparently stored at the end of the data field,
+	  in the NVS data section, so 4 more bytes are needed per NVS element.
+
 module = NVS
 module-str = nvs
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/fs/nvs/Kconfig
+++ b/subsys/fs/nvs/Kconfig
@@ -29,15 +29,6 @@ config NVS_LOOKUP_CACHE_SIZE
 	  Number of entries in Non-volatile Storage lookup cache.
 	  It is recommended that it be a power of 2.
 
-config NVS_LOOKUP_CACHE_FOR_SETTINGS
-	bool "Non-volatile Storage lookup cache optimized for settings"
-	depends on NVS_LOOKUP_CACHE
-	help
-	  Use the lookup cache hash function that results in the least number of
-	  collissions and, in turn, the best NVS performance provided that the NVS
-	  is used as the settings backend only. This option should NOT be enabled
-	  if the NVS is also written to directly, outside the settings layer.
-
 module = NVS
 module-str = nvs
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -13,11 +13,6 @@
 #include <zephyr/sys/crc.h>
 #include "nvs_priv.h"
 
-#ifdef CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS
-#include <zephyr/sys/util.h>
-#include <settings/settings_nvs.h>
-#endif
-
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(fs_nvs, CONFIG_NVS_LOG_LEVEL);
 
@@ -25,45 +20,6 @@ static int nvs_prev_ate(struct nvs_fs *fs, uint32_t *addr, struct nvs_ate *ate);
 static int nvs_ate_valid(struct nvs_fs *fs, const struct nvs_ate *entry);
 
 #ifdef CONFIG_NVS_LOOKUP_CACHE
-
-#ifdef CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS
-
-static inline size_t nvs_lookup_cache_pos(uint16_t id)
-{
-	/*
-	 * 1. The NVS settings backend uses up to (NVS_NAME_ID_OFFSET - 1) NVS IDs to
-	      store keys and equal number of NVS IDs to store values.
-	 * 2. For each key-value pair, the value is stored at NVS ID greater by exactly
-	 *    NVS_NAME_ID_OFFSET than NVS ID that holds the key.
-	 * 3. The backend tries to minimize the range of NVS IDs used to store keys.
-	 *    That is, NVS IDs are allocated sequentially, and freed NVS IDs are reused
-	 *    before allocating new ones.
-	 *
-	 * Therefore, to assure the least number of collisions in the lookup cache,
-	 * the least significant bit of the hash indicates whether the given NVS ID
-	 * represents a key or a value, and remaining bits of the hash are set to
-	 * the ordinal number of the key-value pair. Consequently, the hash function
-	 * provides the following mapping:
-	 *
-	 * 1st settings key   => hash 0
-	 * 1st settings value => hash 1
-	 * 2nd settings key   => hash 2
-	 * 2nd settings value => hash 3
-	 * ...
-	 */
-	BUILD_ASSERT(IS_POWER_OF_TWO(NVS_NAMECNT_ID), "NVS_NAMECNT_ID is not power of 2");
-	BUILD_ASSERT(IS_POWER_OF_TWO(NVS_NAME_ID_OFFSET), "NVS_NAME_ID_OFFSET is not power of 2");
-
-	uint16_t key_value_bit;
-	uint16_t key_value_ord;
-
-	key_value_bit = (id >> LOG2(NVS_NAME_ID_OFFSET)) & 1;
-	key_value_ord = id & (NVS_NAME_ID_OFFSET - 1);
-
-	return ((key_value_ord << 1) | key_value_bit) % CONFIG_NVS_LOOKUP_CACHE_SIZE;
-}
-
-#else /* CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS */
 
 static inline size_t nvs_lookup_cache_pos(uint16_t id)
 {
@@ -79,8 +35,6 @@ static inline size_t nvs_lookup_cache_pos(uint16_t id)
 
 	return hash % CONFIG_NVS_LOOKUP_CACHE_SIZE;
 }
-
-#endif /* CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS */
 
 static int nvs_lookup_cache_rebuild(struct nvs_fs *fs)
 {

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -13,6 +13,11 @@
 #include <zephyr/sys/crc.h>
 #include "nvs_priv.h"
 
+#ifdef CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS
+#include <zephyr/sys/util.h>
+#include <settings/settings_nvs.h>
+#endif
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(fs_nvs, CONFIG_NVS_LOG_LEVEL);
 
@@ -20,6 +25,45 @@ static int nvs_prev_ate(struct nvs_fs *fs, uint32_t *addr, struct nvs_ate *ate);
 static int nvs_ate_valid(struct nvs_fs *fs, const struct nvs_ate *entry);
 
 #ifdef CONFIG_NVS_LOOKUP_CACHE
+
+#ifdef CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS
+
+static inline size_t nvs_lookup_cache_pos(uint16_t id)
+{
+	/*
+	 * 1. The NVS settings backend uses up to (NVS_NAME_ID_OFFSET - 1) NVS IDs to
+	      store keys and equal number of NVS IDs to store values.
+	 * 2. For each key-value pair, the value is stored at NVS ID greater by exactly
+	 *    NVS_NAME_ID_OFFSET than NVS ID that holds the key.
+	 * 3. The backend tries to minimize the range of NVS IDs used to store keys.
+	 *    That is, NVS IDs are allocated sequentially, and freed NVS IDs are reused
+	 *    before allocating new ones.
+	 *
+	 * Therefore, to assure the least number of collisions in the lookup cache,
+	 * the least significant bit of the hash indicates whether the given NVS ID
+	 * represents a key or a value, and remaining bits of the hash are set to
+	 * the ordinal number of the key-value pair. Consequently, the hash function
+	 * provides the following mapping:
+	 *
+	 * 1st settings key   => hash 0
+	 * 1st settings value => hash 1
+	 * 2nd settings key   => hash 2
+	 * 2nd settings value => hash 3
+	 * ...
+	 */
+	BUILD_ASSERT(IS_POWER_OF_TWO(NVS_NAMECNT_ID), "NVS_NAMECNT_ID is not power of 2");
+	BUILD_ASSERT(IS_POWER_OF_TWO(NVS_NAME_ID_OFFSET), "NVS_NAME_ID_OFFSET is not power of 2");
+
+	uint16_t key_value_bit;
+	uint16_t key_value_ord;
+
+	key_value_bit = (id >> LOG2(NVS_NAME_ID_OFFSET)) & 1;
+	key_value_ord = id & (NVS_NAME_ID_OFFSET - 1);
+
+	return ((key_value_ord << 1) | key_value_bit) % CONFIG_NVS_LOOKUP_CACHE_SIZE;
+}
+
+#else /* CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS */
 
 static inline size_t nvs_lookup_cache_pos(uint16_t id)
 {
@@ -35,6 +79,8 @@ static inline size_t nvs_lookup_cache_pos(uint16_t id)
 
 	return hash % CONFIG_NVS_LOOKUP_CACHE_SIZE;
 }
+
+#endif /* CONFIG_NVS_LOOKUP_CACHE_FOR_SETTINGS */
 
 static int nvs_lookup_cache_rebuild(struct nvs_fs *fs)
 {

--- a/subsys/fs/nvs/nvs_priv.h
+++ b/subsys/fs/nvs/nvs_priv.h
@@ -30,6 +30,15 @@ extern "C" {
 
 #define NVS_LOOKUP_CACHE_NO_ADDR 0xFFFFFFFF
 
+/*
+ * Allow to use the NVS_DATA_CRC_SIZE macro in computations whether data CRC is enabled or not
+ */
+#ifdef CONFIG_NVS_DATA_CRC
+#define NVS_DATA_CRC_SIZE 4 /* CRC-32 size in bytes */
+#else
+#define NVS_DATA_CRC_SIZE 0
+#endif
+
 /* Allocation Table Entry */
 struct nvs_ate {
 	uint16_t id;	/* data id */

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -560,7 +560,8 @@ ZTEST_F(nvs, test_nvs_full_sector)
 				     len);
 		} else {
 			zassert_true(len == sizeof(data_read),
-				     "nvs_read failed: %d", i, len);
+				     "nvs_read #%d failed: len is %zd instead of %zu",
+				     i, len, sizeof(data_read));
 			zassert_equal(data_read, i,
 				      "read unexpected data: %d instead of %d",
 				      data_read, i);
@@ -639,6 +640,9 @@ ZTEST_F(nvs, test_nvs_gc_corrupt_close_ate)
 	uint32_t data;
 	ssize_t len;
 	int err;
+#ifdef CONFIG_NVS_DATA_CRC
+	uint32_t data_crc;
+#endif
 
 	close_ate.id = 0xffff;
 	close_ate.offset = fixture->fs.sector_size - sizeof(struct nvs_ate) * 5;
@@ -648,6 +652,9 @@ ZTEST_F(nvs, test_nvs_gc_corrupt_close_ate)
 	ate.id = 0x1;
 	ate.offset = 0;
 	ate.len = sizeof(data);
+#ifdef CONFIG_NVS_DATA_CRC
+	ate.len += sizeof(data_crc);
+#endif
 	ate.crc8 = crc8_ccitt(0xff, &ate,
 			      offsetof(struct nvs_ate, crc8));
 
@@ -666,6 +673,12 @@ ZTEST_F(nvs, test_nvs_gc_corrupt_close_ate)
 	data = 0xaa55aa55;
 	err = flash_write(fixture->fs.flash_device, fixture->fs.offset, &data, sizeof(data));
 	zassert_true(err == 0,  "flash_write failed: %d", err);
+#ifdef CONFIG_NVS_DATA_CRC
+	data_crc = crc32_ieee((const uint8_t *) &data, sizeof(data));
+	err = flash_write(fixture->fs.flash_device, fixture->fs.offset + sizeof(data), &data_crc,
+			  sizeof(data_crc));
+	zassert_true(err == 0,  "flash_write for data CRC failed: %d", err);
+#endif
 
 	/* Mark sector 1 as closed */
 	err = flash_write(fixture->fs.flash_device,

--- a/tests/subsys/fs/nvs/testcase.yaml
+++ b/tests/subsys/fs/nvs/testcase.yaml
@@ -11,3 +11,15 @@ tests:
       - CONFIG_NVS_LOOKUP_CACHE=y
       - CONFIG_NVS_LOOKUP_CACHE_SIZE=64
     platform_allow: native_sim
+  filesystem.nvs.data_crc:
+    extra_args:
+      - CONFIG_NVS_DATA_CRC=y
+    platform_allow:
+      - native_sim
+      - qemu_x86
+  filesystem.nvs.data_crc_cache:
+    extra_args:
+      - CONFIG_NVS_DATA_CRC=y
+      - CONFIG_NVS_LOOKUP_CACHE=y
+      - CONFIG_NVS_LOOKUP_CACHE_SIZE=64
+    platform_allow: native_sim


### PR DESCRIPTION
Cherry-picked upstream commits that add CRC-32 protection to NVS.