### PR TITLE
[nrf fromlist] west: update build extension command to use APP_DIR

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -429,7 +429,14 @@ class Build(Forceable):
         if self.args.source_dir:
             source_dir = self.args.source_dir
         elif self.cmake_cache:
-            source_dir = self.cmake_cache.get('CMAKE_HOME_DIRECTORY')
+            source_dir = self.cmake_cache.get('APP_DIR')
+
+            if not source_dir:
+                source_dir = self.cmake_cache.get('APPLICATION_SOURCE_DIR')
+
+            if not source_dir:
+                source_dir = self.cmake_cache.get('CMAKE_HOME_DIRECTORY')
+
             if not source_dir:
                 # This really ought to be there. The build directory
                 # must be corrupted somehow. Let's see what we can do.


### PR DESCRIPTION
`west build` can be invoked without specifying the source directory when being invoked from the source directory itself.
When using `west build` for incremental builds, then the build command will examine the CMake cache to determine the application dir by using the value of CMAKE_HOME_DIRECTORY.

With sysbuild, this leads to the wrong assumption that the sysbuild itself is the application to build.

Instead, have west build look for APP_DIR which points to the correct source dir when sysbuild is used. Use APPLICATION_SOURCE_DIR when APP_DIR is not set, as this indicates a no-sysbuild build.

Keep CMAKE_HOME_DIRECTORY behavior as last fallback mechanism.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/74230