### PR TITLE
[nrf fromtree] Extend twister fixture options

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -1082,6 +1082,10 @@ can be used multiple times and all given fixtures will be appended as a list. An
 given fixtures will be assigned to all boards, this means that all boards set by
 current twister command can run those testcases which request the same fixtures.
 
+Some fixtures allow for configuration strings to be appended, separated from the
+fixture name by a ``:``. Only the fixture name is matched against the fixtures
+requested by testcases.
+
 Notes
 +++++
 

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -117,6 +117,10 @@ def pytest_addoption(parser: pytest.Parser):
         choices=('function', 'class', 'module', 'package', 'session'),
         help='The scope for which `dut` and `shell` fixtures are shared.'
     )
+    twister_harness_group.addoption(
+        '--twister-fixture', action='append', dest='fixtures', metavar='FIXTURE', default=[],
+        help='Twister fixture supported by this platform. May be given multiple times.'
+    )
 
 
 def pytest_configure(config: pytest.Config):

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -33,6 +33,7 @@ class DeviceConfig:
     pre_script: Path | None = None
     post_script: Path | None = None
     post_flash_script: Path | None = None
+    fixtures: list[str] = None
     app_build_dir: Path | None = None
 
     def __post_init__(self):
@@ -77,6 +78,7 @@ class TwisterHarnessConfig:
             pre_script=_cast_to_path(config.option.pre_script),
             post_script=_cast_to_path(config.option.post_script),
             post_flash_script=_cast_to_path(config.option.post_flash_script),
+            fixtures=config.option.fixtures,
         )
 
         devices.append(device_from_cli)

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -441,7 +441,7 @@ class DeviceHandler(Handler):
         dut_found = False
 
         for d in self.duts:
-            if fixture and fixture not in d.fixtures:
+            if fixture and fixture not in map(lambda f: f.split(sep=':')[0], d.fixtures):
                 continue
             if d.platform != device or (d.serial is None and d.serial_pty is None):
                 continue

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -354,6 +354,10 @@ class Pytest(Harness):
         else:
             raise PytestHarnessException(f'Support for handler {handler.type_str} not implemented yet')
 
+        if handler.type_str != 'device':
+            for fixture in handler.options.fixture:
+                command.append(f'--twister-fixture={fixture}')
+
         if handler.options.pytest_args:
             command.extend(handler.options.pytest_args)
             if pytest_args_yaml:
@@ -410,6 +414,9 @@ class Pytest(Harness):
 
         if hardware.flash_before:
             command.append(f'--flash-before={hardware.flash_before}')
+
+        for fixture in hardware.fixtures:
+            command.append(f'--twister-fixture={fixture}')
 
         return command
 

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -182,7 +182,7 @@ class TestInstance:
             # command-line, then we need to run the test, not just build it.
             fixture = testsuite.harness_config.get('fixture')
             if fixture:
-                can_run = fixture in fixtures
+                can_run = fixture in map(lambda f: f.split(sep=':')[0], fixtures)
 
         return can_run
 

--- a/scripts/tests/twister/pytest_integration/test_harness_pytest.py
+++ b/scripts/tests/twister/pytest_integration/test_harness_pytest.py
@@ -26,6 +26,7 @@ def testinstance() -> TestInstance:
     testinstance.handler = mock.Mock()
     testinstance.handler.options = mock.Mock()
     testinstance.handler.options.verbose = 1
+    testinstance.handler.options.fixture = ['fixture1:option1', 'fixture2']
     testinstance.handler.options.pytest_args = None
     testinstance.handler.type_str = 'native'
     return testinstance
@@ -42,7 +43,9 @@ def test_pytest_command(testinstance: TestInstance, device_type):
         'samples/hello/pytest',
         f'--build-dir={testinstance.build_dir}',
         f'--junit-xml={testinstance.build_dir}/report.xml',
-        f'--device-type={device_type}'
+        f'--device-type={device_type}',
+        '--twister-fixture=fixture1:option1',
+        '--twister-fixture=fixture2'
     ]
 
     command = pytest_harness.generate_command()

--- a/scripts/tests/twister/test_harness.py
+++ b/scripts/tests/twister/test_harness.py
@@ -345,6 +345,7 @@ def test_pytest__generate_parameters_for_hardware(tmp_path, pty_value, hardware_
     hardware.baud = 115200
     hardware.runner = "runner"
     hardware.runner_params = ["--runner-param1", "runner-param2"]
+    hardware.fixtures = ['fixture1:option1', 'fixture2']
 
     options = handler.options
     options.west_flash = "args"
@@ -386,6 +387,8 @@ def test_pytest__generate_parameters_for_hardware(tmp_path, pty_value, hardware_
         assert '--pre-script=pre_script' in command
         assert '--post-flash-script=post_flash_script' in command
         assert '--post-script=post_script' in command
+        assert '--twister-fixture=fixture1:option1' in command
+        assert '--twister-fixture=fixture2' in command
 
 
 def test__update_command_with_env_dependencies():

--- a/tests/drivers/can/host/README.rst
+++ b/tests/drivers/can/host/README.rst
@@ -28,10 +28,17 @@ The Zephyr end of the CAN fixture can be configured as follows:
 
 The host end of the CAN fixture can be configured through python-can. Available configuration
 options depend on the type of host CAN adapter used. The python-can library provides a lot of
-flexibility for configuration as decribed in the `python-can configuration`_ page. By default, the
-python-can configuration context is not specified, causing python-can to use the default
-configuration context. The context can be overridden using the ``--can-context`` test suite argument
-(see examples below).
+flexibility for configuration as decribed in the `python-can configuration`_ page, all centered
+around the concept of a configuration "context. The configuration context for this test suite can be
+configured as follows:
+
+* By default, the python-can configuration context is not specified, causing python-can to use the
+  default configuration context.
+* A specific configuration context can be provided along with the ``can`` fixture separated by a
+  ``:`` (i.e. specify fixture ``can:zcan0`` to use the ``zcan0`` python-can configuration context).
+* The configuration context can be overridden using the ``--can-context`` test suite argument
+  (i.e. run ``twister`` with the ``--pytest-args=--can-context=zcan0`` argument to use the ``zcan0``
+  python-can configuration context).
 
 Building and Running
 ********************
@@ -65,7 +72,7 @@ be launched using Twister:
 
 .. code-block:: shell
 
-   west twister -v -p native_sim/native/64 -X can -T tests/drivers/can/host/ --pytest-args=--can-context=zcan0
+   west twister -v -p native_sim/native/64 -X can:zcan0 -T tests/drivers/can/host/
 
 After the test suite has completed, the virtual SocketCAN interface can be removed again:
 
@@ -107,7 +114,7 @@ Twister. Below is an example for running on the :ref:`lpcxpresso55s36`:
 
 .. code-block:: shell
 
-   west twister -v -p lpcxpresso55s36/lpc55s36 --device-testing --device-serial /dev/ttyACM0 -X can -T tests/drivers/can/host/ --pytest-args=--can-context=can0
+   west twister -v -p lpcxpresso55s36/lpc55s36 --device-testing --device-serial /dev/ttyACM0 -X can:can0 -T tests/drivers/can/host/
 
 After the test suite has completed, the SocketCAN interface can be brought down again:
 

--- a/tests/drivers/can/host/pytest/conftest.py
+++ b/tests/drivers/can/host/pytest/conftest.py
@@ -23,9 +23,16 @@ def pytest_addoption(parser) -> None:
                      help='Configuration context to use for python-can (default: None)')
 
 @pytest.fixture(name='context', scope='session')
-def fixture_context(request) -> str:
+def fixture_context(request, dut: DeviceAdapter) -> str:
     """Return the name of the python-can configuration context to use."""
     ctx = request.config.getoption('--can-context')
+
+    if ctx is None:
+        for fixture in dut.device_config.fixtures:
+            if fixture.startswith('can:'):
+                ctx = fixture.split(sep=':', maxsplit=1)[1]
+                break
+
     logger.info('using python-can configuration context "%s"', ctx)
     return ctx
 


### PR DESCRIPTION
Required to make tests/can/driver/host to work