### PR TITLE
[nrf fromtree] scripts: west: flash: Fix issue with loading outdated …

### DIFF
--- a/scripts/west_commands/flash.py
+++ b/scripts/west_commands/flash.py
@@ -9,7 +9,8 @@
 from west.commands import WestCommand
 
 from run_common import add_parser_common, do_run_common, get_build_dir
-from build_helpers import load_domains
+
+from pathlib import Path
 
 
 class Flash(WestCommand):
@@ -28,6 +29,5 @@ class Flash(WestCommand):
 
     def do_run(self, my_args, runner_args):
         build_dir = get_build_dir(my_args)
-        domains = load_domains(build_dir).get_domains(my_args.domain,
-                                                      default_flash_order=True)
-        do_run_common(self, my_args, runner_args, domains=domains)
+        domains_file = Path(build_dir) / 'domains.yaml'
+        do_run_common(self, my_args, runner_args, domain_file=domains_file)

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -161,7 +161,7 @@ def add_parser_common(command, parser_adder=None, parser=None):
 
     return parser
 
-def do_run_common(command, user_args, user_runner_args, domains=None):
+def do_run_common(command, user_args, user_runner_args, domain_file=None):
     # This is the main routine for all the "west flash", "west debug",
     # etc. commands.
 
@@ -186,7 +186,7 @@ def do_run_common(command, user_args, user_runner_args, domains=None):
     if not user_args.skip_rebuild:
         rebuild(command, build_dir, user_args)
 
-    if domains is None:
+    if domain_file is None:
         if user_args.domain is None:
             # No domains are passed down and no domains specified by the user.
             # So default domain will be used.
@@ -195,6 +195,9 @@ def do_run_common(command, user_args, user_runner_args, domains=None):
             # No domains are passed down, but user has specified domains to use.
             # Get the user specified domains.
             domains = load_domains(build_dir).get_domains(user_args.domain)
+    else:
+        domains = load_domains(build_dir).get_domains(user_args.domain,
+                                                      default_flash_order=True)
 
     if len(domains) > 1:
         if len(user_runner_args) > 0:


### PR DESCRIPTION
…domain file

Fixes an issue whereby the domains file in sysbuild projects would be loaded and used with outdated information if sysbuild configuration was changed then west flash was ran directly after it

Signed-off-by: Jamie McCrae <jamie.mccrae@nordicsemi.no>
(cherry picked from commit c0c51a8d40c28254c059474c30fdd4b275b4abdb)