### PR TITLE
[nrf noup] bluetooth: att: Allow ATT sent callback after data TX is done

### DIFF
--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -30,6 +30,23 @@ config BT_ATT_RETRY_ON_SEC_ERR
 	  If an ATT request fails due to insufficient security, the host will
 	  try to elevate the security level and retry the ATT request.
 
+config BT_ATT_SENT_CB_AFTER_TX
+	bool "Delay ATT sent callback until data transmission is done by controller [EXPERIMENTAL]"
+	select EXPERIMENTAL
+	help
+	  By default, the BLE stack calls sent callback for ATT data when the
+	  data is passed to BLE controller for transmission. Enabling this
+	  Kconfig option delays calling the sent callback until data
+	  transmission is finished by BLE controller (the callback is called
+	  upon receiving the Number of Completed Packets HCI Event).
+
+	  The feature is not available in Zephyr RTOS (it's specific to NCS
+	  Zephyr fork). It is a temporary solution allowing to control flow of
+	  GATT notifications with HID reports for HID use-case.
+
+	  Enabling this option may require increasing CONFIG_BT_CONN_TX_MAX in
+	  configuration, because ATT would use additional TX contexts.
+
 config BT_EATT
 	bool "Enhanced ATT Bearers support [EXPERIMENTAL]"
 	depends on BT_L2CAP_ECRED

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -260,6 +260,13 @@ static void att_sent(void *user_data)
 	bt_att_sent(chan);
 }
 
+static void chan_sent_cb(struct bt_conn *conn, void *user_data, int err)
+{
+	struct net_buf *nb = user_data;
+
+	net_buf_unref(nb);
+}
+
 /* In case of success the ownership of the buffer is transferred to the stack
  * which takes care of releasing it when it completes transmitting to the
  * controller.
@@ -353,7 +360,16 @@ static int chan_send(struct bt_att_chan *chan, struct net_buf *buf)
 
 	data->att_chan = chan;
 
-	err = bt_l2cap_send(chan->att->conn, BT_L2CAP_CID_ATT, buf);
+	if (IS_ENABLED(CONFIG_BT_ATT_SENT_CB_AFTER_TX)) {
+		err = bt_l2cap_send_cb(chan->att->conn, BT_L2CAP_CID_ATT, buf, chan_sent_cb,
+				       net_buf_ref(buf));
+		if (err) {
+			net_buf_unref(buf);
+		}
+	} else {
+		err = bt_l2cap_send(chan->att->conn, BT_L2CAP_CID_ATT, buf);
+	}
+
 	if (err) {
 		if (err == -ENOBUFS) {
 			LOG_ERR("Ran out of TX buffers or contexts.");

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -478,7 +478,11 @@ int bt_conn_send_cb(struct bt_conn *conn, struct net_buf *buf,
 	LOG_DBG("conn handle %u buf len %u cb %p user_data %p", conn->handle, buf->len, cb,
 		user_data);
 
-	if (buf->ref != 1) {
+	/* Allow for an additional buffer reference if callback is provided. This can be used to
+	 * extend lifetime of the net buffer until the data transmission is confirmed by ACK of the
+	 * remote.
+	 */
+	if (buf->ref > 1 + (cb ? 1 : 0)) {
 		/* The host may alter the buf contents when fragmenting. Higher
 		 * layers cannot expect the buf contents to stay intact. Extra
 		 * refs suggests a silent data corruption would occur if not for


### PR DESCRIPTION
By default, the BLE stack calls sent callback for ATT data when the data is passed to BLE controller for transmission. Enabling this Kconfig option delays calling the sent callback until data transmission is finished by BLE controller (the callback is delayed until receiving the num complete packets event).

PR also allows for an extra ref in bt_conn_send_cb (needed for the newly added feature).

Jira: NCSDK-27422