### PR TITLE
[nrf fromtree] samples: drivers: adc: Allow coverage calculation.

### DIFF
--- a/samples/drivers/adc/adc_dt/src/main.c
+++ b/samples/drivers/adc/adc_dt/src/main.c
@@ -53,8 +53,11 @@ int main(void)
 			return 0;
 		}
 	}
-
+#ifndef CONFIG_COVERAGE
 	while (1) {
+#else
+	for (int k = 0; k < 10; k++) {
+#endif
 		printk("ADC reading[%u]:\n", count++);
 		for (size_t i = 0U; i < ARRAY_SIZE(adc_channels); i++) {
 			int32_t val_mv;

--- a/samples/drivers/adc/adc_sequence/src/main.c
+++ b/samples/drivers/adc/adc_sequence/src/main.c
@@ -56,7 +56,11 @@ int main(void)
 		}
 	}
 
+#ifndef CONFIG_COVERAGE
 	while (1) {
+#else
+	for (int k = 0; k < 10; k++) {
+#endif
 		printf("ADC sequence reading [%u]:\n", count++);
 		k_msleep(1000);
 


### PR DESCRIPTION
Sample must end to dump coverage data.

Signed-off-by: Bartlomiej Buczek <bartlomiej.buczek@nordicsemi.no>
(cherry-picked from commit 79f4f2ac31cbba648ae4bc6066e7da77a1688fd7)