### PR TITLE
[nrf noup] dts: common: nordic: nrf54l15 rram erase-block-size

### DIFF
--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -631,13 +631,13 @@
 			cpuapp_rram: rram@0 {
 				compatible = "soc-nv-flash";
 				reg = <0x0 DT_SIZE_K(1428)>;
-				erase-block-size = <4096>;
+				erase-block-size = <1024>;
 				write-block-size = <16>;
 			};
 			cpuflpr_rram: rram@165000 {
 				compatible = "soc-nv-flash";
 				reg = <0x165000 DT_SIZE_K(96)>;
-				erase-block-size = <4096>;
+				erase-block-size = <1024>;
 				write-block-size = <16>;
 			};
 		};


### PR DESCRIPTION
Adjusting erase block size to match resolution of
rram region protection.