### PR TITLE
[nrf noup] drivers: flash: kconfig: nrf_rram region resolution

### DIFF
--- a/drivers/flash/Kconfig.nrf_rram
+++ b/drivers/flash/Kconfig.nrf_rram
@@ -69,14 +69,14 @@ config SOC_FLASH_NRF_TIMEOUT_MULTIPLIER
 
 config NRF_RRAM_REGION_ADDRESS_RESOLUTION
 	hex
-	default 0x400
+	default 0x1000
 	help
 	  RRAMC's region protection address resolution.
 	  Applies to region with configurable start address.
 
 config NRF_RRAM_REGION_SIZE_UNIT
 	hex
-	default 0x400
+	default 0x1000
 	help
 	  Base unit for the size of RRAMC's region protection.
 


### PR DESCRIPTION
adjusting region resolution to match erase-block-size