### PR TITLE
[nrf fromtree] Bluetooth: Controller: Add Kconfigs to enable Connection Subrating

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -104,6 +104,9 @@ config BT_CTLR_READ_ISO_LINK_QUALITY_SUPPORT
 config BT_CTLR_LE_POWER_CONTROL_SUPPORT
 	bool
 
+config BT_CTLR_SUBRATING_SUPPORT
+	bool
+
 config BT_CTLR
 	bool "Bluetooth Controller"
 	help
@@ -1001,6 +1004,14 @@ config BT_CTLR_HCI_CODEC_AND_DELAY_INFO
 	help
 	  Enable HCI commands to read information about supported
 	  codecs, codec capabilities, and controller delay.
+
+config BT_CTLR_SUBRATING
+	bool "LE Connection Subrating"
+	depends on BT_CTLR_SUBRATING_SUPPORT
+	select BT_CTLR_SET_HOST_FEATURE
+	help
+	  Enable support for Bluetooth v5.3 LE Connection Subrating
+	  in the Controller.
 
 rsource "Kconfig.df"
 rsource "Kconfig.ll_sw_split"


### PR DESCRIPTION
Add Kconfigs to enable experimental subrating HCI commands.
    
Signed-off-by: Timothy Keys <timothy.keys@nordicsemi.no>
(cherry picked from commit 570c86d1efb9409993571f139e9aad0fc181964d)
    
Signed-off-by: Timothy Keys <timothy.keys@nordicsemi.no>