### PR TITLE
drivers: adc: saadc: Disable burst mode on unused channels

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -435,6 +435,10 @@ static int start_read(const struct device *dev,
 				m_data.positive_inputs[channel_id]);
 			++active_channels;
 		} else {
+			nrf_saadc_burst_set(
+				NRF_SAADC,
+				channel_id,
+				NRF_SAADC_BURST_DISABLED);
 			nrf_saadc_channel_pos_input_set(
 				NRF_SAADC,
 				channel_id,


### PR DESCRIPTION
Hello,

I discovered that mixing channels with oversampling and without doesn't work right. It turned out that left-over burst mode on unused channels inhibit operation of channels combined into a sequence.

Discovered on nRF52832 (nRF52-DK) using the following approach:
  channels 0-3 are used for application purposes as a sequence
  channel 4 is used for battery measurements with oversampling

After few successful conversions the sequence (channels 0-3) freezes the thread while waiting for semaphore to end the conversion.

P.S.: Should I create a separate pull-request to the upstream zephyr repository? Or pull-request to  upstream should be done in the first place and you'll eventually pull the changes here?