### PR TITLE
[nrf fromlist] drivers: serial: fix cfg.baudrate may be used uninitia…

### DIFF
--- a/drivers/serial/uart_async_to_irq.c
+++ b/drivers/serial/uart_async_to_irq.c
@@ -42,7 +42,7 @@ static const struct uart_async_to_irq_config *get_config(const struct device *de
 /* Function calculates RX timeout based on baudrate. */
 static uint32_t get_rx_timeout(const struct device *dev)
 {
-	struct uart_config cfg;
+	struct uart_config cfg = { 0 };
 	int err;
 	uint32_t baudrate;
 


### PR DESCRIPTION
…lized

drivers/serial/uart_async_to_irq.c: In function 'get_rx_timeout': drivers/serial/uart_async_to_irq.c:51:26:
warning: 'cfg.baudrate' may be used uninitialized
   51 |                 baudrate = cfg.baudrate;
      |                 ~~~~~~~~~^~~~~~~~~~~~~~
drivers/serial/uart_async_to_irq.c:45:28: note: 'cfg' declared here
   45 |         struct uart_config cfg;

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/74530