### PR TITLE
[nrf fromtree] Bluetooth: Mesh: Fix missing model extensions

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1167,6 +1167,7 @@ endif # BT_MESH_OP_AGG_CLI
 
 config BT_MESH_LARGE_COMP_DATA_SRV
 	bool "Support for Large Composition Data Server Model"
+	depends on BT_MESH_MODEL_EXTENSIONS
 	help
 	  Enable support for the Large Composition Data Server model.
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1190,6 +1190,7 @@ if BT_MESH_PRIV_BEACONS
 
 config BT_MESH_PRIV_BEACON_SRV
 	bool "Support for Private Beacon Server Model"
+	depends on BT_MESH_MODEL_EXTENSIONS
 	help
 	  Enable support for the Private Beacon Server model.
 

--- a/subsys/bluetooth/mesh/large_comp_data_srv.c
+++ b/subsys/bluetooth/mesh/large_comp_data_srv.c
@@ -170,8 +170,11 @@ const struct bt_mesh_model_op _bt_mesh_large_comp_data_srv_op[] = {
 
 static int large_comp_data_srv_init(const struct bt_mesh_model *model)
 {
-	if (!bt_mesh_model_in_primary(model)) {
-		LOG_ERR("Large Composition Data Server only allowed in primary element");
+	const struct bt_mesh_model *config_srv =
+		bt_mesh_model_find(bt_mesh_model_elem(model), BT_MESH_MODEL_ID_CFG_SRV);
+
+	if (config_srv == NULL) {
+		LOG_ERR("Large Composition Data Server cannot extend Configuration server");
 		return -EINVAL;
 	}
 
@@ -180,6 +183,8 @@ static int large_comp_data_srv_init(const struct bt_mesh_model *model)
 	model->rt->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
 	srv.model = model;
+
+	bt_mesh_model_extend(model, config_srv);
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/od_priv_proxy_srv.c
+++ b/subsys/bluetooth/mesh/od_priv_proxy_srv.c
@@ -83,26 +83,26 @@ static int od_priv_proxy_srv_init(const struct bt_mesh_model *mod)
 {
 	od_priv_proxy_srv = mod;
 
-	const struct bt_mesh_model *priv_beacon_srv = bt_mesh_model_find(
-		bt_mesh_model_elem(mod), BT_MESH_MODEL_ID_PRIV_BEACON_SRV);
-	const struct bt_mesh_model *sol_pdu_rpl_srv = bt_mesh_model_find(
-		bt_mesh_model_elem(mod), BT_MESH_MODEL_ID_SOL_PDU_RPL_SRV);
+	const struct bt_mesh_model *priv_beacon_srv =
+		bt_mesh_model_find(bt_mesh_model_elem(mod), BT_MESH_MODEL_ID_PRIV_BEACON_SRV);
+	const struct bt_mesh_model *sol_pdu_rpl_srv =
+		bt_mesh_model_find(bt_mesh_model_elem(mod), BT_MESH_MODEL_ID_SOL_PDU_RPL_SRV);
 
 	if (priv_beacon_srv == NULL) {
-		return -EINVAL;
-	}
-
-	if (!bt_mesh_model_in_primary(mod)) {
-		LOG_ERR("On-Demand Private Proxy server not in primary element");
+		LOG_ERR("On-Demand Private Proxy server cannot extend Private Beacon server");
 		return -EINVAL;
 	}
 
 	mod->keys[0] = BT_MESH_KEY_DEV_LOCAL;
 	mod->rt->flags |= BT_MESH_MOD_DEVKEY_ONLY;
 
-	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
-		bt_mesh_model_extend(mod, priv_beacon_srv);
+	bt_mesh_model_extend(mod, priv_beacon_srv);
+
+	if (sol_pdu_rpl_srv != NULL) {
 		bt_mesh_model_correspond(mod, sol_pdu_rpl_srv);
+	} else {
+		LOG_WRN("On-Demand Private Proxy server cannot be corresponded by Solicitation PDU "
+			"RPL Configuration server");
 	}
 
 	return 0;

--- a/subsys/bluetooth/mesh/priv_beacon_srv.c
+++ b/subsys/bluetooth/mesh/priv_beacon_srv.c
@@ -195,13 +195,18 @@ const struct bt_mesh_model_op bt_mesh_priv_beacon_srv_op[] = {
 
 static int priv_beacon_srv_init(const struct bt_mesh_model *mod)
 {
-	if (!bt_mesh_model_in_primary(mod)) {
-		LOG_ERR("Priv beacon server not in primary element");
+	const struct bt_mesh_model *config_srv =
+		bt_mesh_model_find(bt_mesh_model_elem(mod), BT_MESH_MODEL_ID_CFG_SRV);
+
+	if (config_srv == NULL) {
+		LOG_ERR("Private Beacon server cannot extend Configuration server");
 		return -EINVAL;
 	}
 
 	priv_beacon_srv = mod;
 	mod->keys[0] = BT_MESH_KEY_DEV_LOCAL;
+
+	bt_mesh_model_extend(mod, config_srv);
 
 	return 0;
 }


### PR DESCRIPTION
PR adds extension of the configuration model server by private beacon server and large composition data server.
According to Mesh Protocol specification v 1.1
4.4.11.1
The Mesh Private Beacon Server model is a main model
that extends the Configuration Server model.
4.4.21.1
The Large Composition Data Server is a main model
that extends the Configuration Server model.