### PR TITLE
[nrf noup] boards: nordic: Turn off MRAM suspend for NRF54H20 DK

### DIFF
--- a/boards/nordic/nrf54h20dk/CMakeLists.txt
+++ b/boards/nordic/nrf54h20dk/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+if(CONFIG_NRFS_MRAM_SERVICE_ENABLED)
+  zephyr_library_sources(board.c)
+endif()

--- a/boards/nordic/nrf54h20dk/board.c
+++ b/boards/nordic/nrf54h20dk/board.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/init.h>
+
+#define MODULE mram_suspend_off
+#include <zephyr/logging/log.h>
+LOG_MODULE_REGISTER(MODULE);
+
+#include <services/nrfs_mram.h>
+#include <nrfs_backend_ipc_service.h>
+
+#define MRAM_SUSPEND_OFF_INIT_PRIO 90
+
+void mram_latency_handler(nrfs_mram_latency_evt_t const *p_evt, void *context)
+{
+	switch (p_evt->type) {
+	case NRFS_MRAM_LATENCY_REQ_APPLIED:
+		LOG_INF("MRAM latency handler: response received");
+		break;
+	case NRFS_MRAM_LATENCY_REQ_REJECTED:
+		LOG_ERR("MRAM latency handler - request rejected!");
+		break;
+	default:
+		LOG_ERR("MRAM latency handler - unexpected event: 0x%x", p_evt->type);
+		break;
+	}
+}
+
+static int turn_off_suspend_mram(void)
+{
+	/* Turn off mram automatic suspend as it causes delays in time depended code sections. */
+
+	nrfs_err_t err = NRFS_SUCCESS;
+
+	/* Wait for ipc initialization */
+	nrfs_backend_wait_for_connection(K_FOREVER);
+
+	err = nrfs_mram_init(mram_latency_handler);
+	if (err != NRFS_SUCCESS) {
+		LOG_ERR("MRAM service init failed: %d", err);
+	} else {
+		LOG_INF("MRAM service initialized");
+	}
+
+	LOG_INF("MRAM: set latency: NOT ALLOWED");
+	err = nrfs_mram_set_latency(MRAM_LATENCY_NOT_ALLOWED, NULL);
+	if (err) {
+		LOG_ERR("MRAM: set latency failed (%d)", err);
+	}
+
+	return err;
+}
+
+SYS_INIT(turn_off_suspend_mram, APPLICATION, MRAM_SUSPEND_OFF_INIT_PRIO);

--- a/modules/hal_nordic/nrfs/Kconfig
+++ b/modules/hal_nordic/nrfs/Kconfig
@@ -72,6 +72,7 @@ config NRFS_RESET_SERVICE_ENABLED
 config NRFS_MRAM_SERVICE_ENABLED
 	bool "MRAM latency service"
 	depends on NRFS_HAS_MRAM_SERVICE
+	default y
 
 config NRFS_TEMP_SERVICE_ENABLED
 	bool "Temperature service"


### PR DESCRIPTION
Turn off suspending MRAM for NRF54H20 DK
This change is required so sections of code
depending on critical timings will not have unacceptable latency.