### PR TITLE
[nrf noup] soc: nrf54l: Add custom section for KMU

### DIFF
--- a/soc/nordic/nrf54l/CMakeLists.txt
+++ b/soc/nordic/nrf54l/CMakeLists.txt
@@ -10,3 +10,12 @@ zephyr_include_directories(.)
 if(CONFIG_ELV_GRTC_LFXO_ALLOWED)
   message(WARNING "WARNING! ELV mode feature is EXPERIMENTAL and may brick your device!")
 endif()
+
+# We need a buffer in memory in a static location which can be used by
+# the KMU peripheral. The KMU has a static destination address, we chose
+# this address to be 0x20000000, which is the first address in the SRAM.
+if(NOT CONFIG_BUILD_WITH_TFM AND CONFIG_PSA_NEED_CRACEN_KMU_DRIVER)
+# Exclamation mark is printable character with the lowest number in ASCII table.
+# We are sure that this file will be included first.
+zephyr_linker_sources(RAM_SECTIONS SORT_KEY ! kmu_push_area_section.ld)
+endif()

--- a/soc/nordic/nrf54l/kmu_push_area_section.ld
+++ b/soc/nordic/nrf54l/kmu_push_area_section.ld
@@ -1,0 +1,19 @@
+# This section must be loaded first of all the
+# custom sections because we want it to be placed
+# at the top address of RAM.
+SECTION_PROLOGUE(NRF_KMU_RESERVED_PUSH_SECTION,(NOLOAD) ,)
+{
+    __nrf_kmu_reserved_push_area = .;
+    *(.nrf_kmu_reserved_push_area)
+    __nrf_kmu_reserved_push_area_end = .;
+} GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
+
+# It doesn't seem to be possible to enforce placing a section
+# at a specific address in memory using the Zephyr SECTION macros.
+# So this assert is necessary to avoid accidentatly moving this
+# section to a different address.
+ASSERT(__nrf_kmu_reserved_push_area == RAM_ADDR, "Error:  \
+ The section NRF_KMU_RESERVED_PUSH_SECTION needs to be    \
+ placed on the top RAM address but it is not, please edit \
+ your linker scripts to make sure that it is placed on    \
+ the to RAM address.")


### PR DESCRIPTION
Add a custom section in the linker which should always be placed in the top of RAM. This will be used by the KMU to push keys into it. Since when you provision a key into the KMU you need to set specific a memory location for the PUSH operation we need to keep this memory location static across images/dfus.

This is a noup since the KMU is not supported upstream.

Ref: NCSDK-25121