### PR TITLE
[nrf noup] boards: nordic: Turn on NRFS globally

### DIFF
--- a/modules/hal_nordic/nrfs/Kconfig
+++ b/modules/hal_nordic/nrfs/Kconfig
@@ -38,6 +38,8 @@ config NRFS
 	bool "nRF Services Support"
 	select NRFS_LOCAL_DOMAIN if (SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD)
 	depends on HAS_NRFS
+	depends on !MISRA_SANE
+	default y
 	help
 	  This option enables the nRF Services library.
 


### PR DESCRIPTION
Turn on NRFS globaly so turning off
suspending MRAM for NRF54H20 DK will work.