### PR TITLE
[nrf noup] boards: nordic: By default turn off NRFS for ztest

### DIFF
--- a/boards/nordic/nrf54h20dk/board.c
+++ b/boards/nordic/nrf54h20dk/board.c
@@ -19,7 +19,7 @@ void mram_latency_handler(nrfs_mram_latency_evt_t const *p_evt, void *context)
 {
 	switch (p_evt->type) {
 	case NRFS_MRAM_LATENCY_REQ_APPLIED:
-		LOG_INF("MRAM latency handler: response received");
+		LOG_DBG("MRAM latency handler: response received");
 		break;
 	case NRFS_MRAM_LATENCY_REQ_REJECTED:
 		LOG_ERR("MRAM latency handler - request rejected!");
@@ -43,10 +43,10 @@ static int turn_off_suspend_mram(void)
 	if (err != NRFS_SUCCESS) {
 		LOG_ERR("MRAM service init failed: %d", err);
 	} else {
-		LOG_INF("MRAM service initialized");
+		LOG_DBG("MRAM service initialized");
 	}
 
-	LOG_INF("MRAM: set latency: NOT ALLOWED");
+	LOG_DBG("MRAM: set latency: NOT ALLOWED");
 	err = nrfs_mram_set_latency(MRAM_LATENCY_NOT_ALLOWED, NULL);
 	if (err) {
 		LOG_ERR("MRAM: set latency failed (%d)", err);

--- a/modules/hal_nordic/nrfs/Kconfig
+++ b/modules/hal_nordic/nrfs/Kconfig
@@ -39,7 +39,7 @@ config NRFS
 	select NRFS_LOCAL_DOMAIN if (SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD)
 	depends on HAS_NRFS
 	depends on !MISRA_SANE
-	default y
+	default y if !ZTEST
 	help
 	  This option enables the nRF Services library.
 


### PR DESCRIPTION
nrf-squash! [nrf noup] boards: nordic: Turn on NRFS globally

Signed-off-by: Jan Zyczkowski <jan.zyczkowski@no