### PR TITLE
[nrf fromlist] test: drivers: pwm: add fast PWM

### DIFF
--- a/tests/drivers/pwm/pwm_api/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay
@@ -1,0 +1,21 @@
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 7, 0)>;
+			low-power-enable;
+		};
+	};
+};
+
+&pwm120 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+	memory-regions = <&dma_fast_region>;
+};

--- a/tests/drivers/pwm/pwm_api/testcase.yaml
+++ b/tests/drivers/pwm/pwm_api/testcase.yaml
@@ -8,3 +8,8 @@ tests:
       or dt_alias_exists("pwm-3") or dt_compat_enabled("st,stm32-pwm")
       or dt_compat_enabled("intel,blinky-pwm") or dt_compat_enabled("nordic,nrf-pwm")
     depends_on: pwm
+
+  drivers.pwm.pwm_fast:
+    extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
+    platform_allow:
+      - nrf54h20dk/nrf54h20/cpuapp


### PR DESCRIPTION
Add fast PWM instance for nRF54H20 device.
manifest-pr-skip