### PR TITLE
[nrf fromtree] testsuite: coverage: don't lock scheduler in ISR

### DIFF
--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -261,7 +261,9 @@ void gcov_coverage_dump(void)
 	struct gcov_info *gcov_list_first = gcov_info_head;
 	struct gcov_info *gcov_list = gcov_info_head;
 
-	k_sched_lock();
+	if (!k_is_in_isr()) {
+		k_sched_lock();
+	}
 	printk("\nGCOV_COVERAGE_DUMP_START");
 	while (gcov_list) {
 
@@ -290,7 +292,9 @@ void gcov_coverage_dump(void)
 	}
 coverage_dump_end:
 	printk("\nGCOV_COVERAGE_DUMP_END\n");
-	k_sched_unlock();
+	if (!k_is_in_isr()) {
+		k_sched_unlock();
+	}
 	return;
 }
 


### PR DESCRIPTION
Don't attempt to lock the scheduler is trying to dump coverage information from an ISR. The scheduler won't run while the ISR is in progress.

Signed-off-by: Jordan Yates <jordan@embeint.com>
(cherry picked from commit e881445065f468652da6c77c59909ee3e9afa53b)