### PR TITLE
[nrf fromlist]: cmake: tf-m: create tfm_api dependency on tfm_s.hex

### DIFF
--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -321,6 +321,13 @@ if (CONFIG_BUILD_WITH_TFM)
     interface/interface.c
     )
 
+  # A dependency on tfm_s.hex for zephyr.elf will not cause a Zephyr re-link when
+  # tfm_s.hex is updated, as the hex is not a direct input on the executable.
+  # Instead we establish a source file dependency which ensures that tfm_api is
+  # updated when there are changes in tfm itself, this again will trigger an re-link
+  # of Zephyr.elf.
+  set_property(SOURCE interface/interface.c APPEND PROPERTY OBJECT_DEPENDS ${TFM_S_HEX_FILE})
+
   # Non-Secure interface to request system reboot
   if (CONFIG_TFM_PARTITION_PLATFORM AND NOT CONFIG_TFM_PARTITION_PLATFORM_CUSTOM_REBOOT)
     zephyr_library_sources(src/reboot.c)


### PR DESCRIPTION
Incremental builds for TF-M are not picked up by Zephyr linking stage. Code changes to tf-m repository results in a rebuild of TF-M and thus an updated tfm_s.hex (and other files).

tfm_s.hex is merged together with the zephyr hex to form a final merged hex file for flashing. This is done as a post-build command, however such as step cannot take extra dependencies. The Zephyr target can have extra dependencies, however that will only ensure the dependency is brought up-to-date when Zephyr re-link, not re-linking Zephyr when the dependency changes.

Therefore an object dependency is placed on the interface.c file for Zephyr TF-M interface implementation, which ensures the tfm_api library is brought up-to-date whenever TF-M rebuilds, and this update again ensures the Zephyr itself is re-linked whenever TF-M rebuilds.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/75090