### PR TITLE
[nrf noup] scripts: west_commands: build: Add ant to sysbuild list

### DIFF
--- a/scripts/west_commands/build.py
+++ b/scripts/west_commands/build.py
@@ -586,7 +586,7 @@ class Build(Forceable):
             # Check if this is an ncs-repo directory
             allow_list = [ 'mcuboot', 'sidewalk', 'find-my', 'nrf', 'matter', 'suit-processor',
                            'memfault-firmware-sdk', 'zscilib', 'uoscore-uedhoc', 'zcbor',
-                           'hal_nordic', 'ncs-example-application' ]
+                           'hal_nordic', 'ncs-example-application', 'ant' ]
             config_sysbuild = False
 
             for module in zephyr_module.parse_modules(ZEPHYR_BASE, self.manifest):


### PR DESCRIPTION
nrf-squash! [nrf noup] scripts: west: build: Use sysbuild by default if in NCS dir

Adds the ANT project to the list of repos that should be built using sysbuild by default