### PR TITLE
[nrf noup] ci: Enable action-manifest-pr

### DIFF
--- a/.github/workflows/manifest-PR.yml
+++ b/.github/workflows/manifest-PR.yml
@@ -1,0 +1,17 @@
+name: handle manifest PR
+on:
+  pull_request_target:
+    types: [opened, synchronize, closed]
+    branches:
+      - main
+
+
+jobs:
+  call-manifest-pr-action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: handle manifest PR
+        uses: nrfconnect/action-manifest-pr@main
+        with:
+          token: ${{ secrets.NCS_GITHUB_TOKEN }}
+          manifest-pr-title-details: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
This action will automatically manage a PR to sdk-nrf once a PR to sdk-zephyr is created.

This includes:
 - Creating an initial PR
 - Updating and (optionally) rebase it once the PR to sdk-nrf is merged.

The action can be disabled by adding the string
"manifest-pr-skip" to the title or body of the PR.

This will simplify cherry-picking changes from upstream zephyr.