### PR TITLE
[nrf fromlist] drivers: spi: nrfx_spim: Add support for device PM

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
@@ -53,6 +53,7 @@
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -57,6 +57,7 @@
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
 		reg = <0>;
+		spi-max-frequency = <DT_FREQ_M(8)>;
 	};
 };
 

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -57,3 +57,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf54l15pdk/nrf54l15/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
+
+  drivers.spi.pm_runtime:
+    extra_configs:
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
+    filter: CONFIG_SOC_FAMILY_NORDIC_NRF

--- a/tests/drivers/spi/spi_loopback/testcase.yaml
+++ b/tests/drivers/spi/spi_loopback/testcase.yaml
@@ -173,3 +173,8 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/nrf54h20dk_nrf54h20_cpuapp_fast.overlay"
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
+  drivers.spi.nrf_pm_runtime:
+    extra_configs:
+      - CONFIG_PM_DEVICE=y
+      - CONFIG_PM_DEVICE_RUNTIME=y
+    filter: CONFIG_SOC_FAMILY_NORDIC_NRF


### PR DESCRIPTION
Enable the device runtime power management on the SPIM shim.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/75715

manifest-pr-skip