### PR TITLE
[nrf fromlist] scripts: ci: test_plan: use find_modules only when com…

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -149,7 +149,7 @@ class Filters:
             os.remove(fname)
 
     def find_modules(self):
-        if 'west.yml' in self.modified_files:
+        if 'west.yml' in self.modified_files and args.commits is not None:
             print(f"Manifest file 'west.yml' changed")
             print("=========")
             old_manifest_content = repo_to_scan.git.show(f"{args.commits[:-2]}:west.yml")


### PR DESCRIPTION
…mits are provided

Current implementation will not work if comits were not provided. ie. use case with list of changed files will fail as args.commits is None.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/75927