### PR TITLE
[nrf fromlist] tests: drivers: adc_accuracy: parametrize expected acc…

### DIFF
--- a/tests/drivers/adc/adc_accuracy_test/boards/frdm_kl25z.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/frdm_kl25z.overlay
@@ -8,6 +8,7 @@
 	zephyr,user {
 		io-channels = <&adc0 12>;
 		reference_mv = <1100>;
+		expected_accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf52840dk_nrf52840.overlay
@@ -9,6 +9,7 @@
 	zephyr,user {
 		io-channels = <&adc 0>;
 		reference_mv = <3000>;
+		expected_accuracy = <32>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -8,6 +8,7 @@
 	zephyr,user {
 		io-channels = <&adc 0>;
 		reference_mv = <1800>;
+		expected_accuracy = <64>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/adc/adc_accuracy_test/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -8,6 +8,7 @@
 	zephyr,user {
 		io-channels = <&adc 0>;
 		reference_mv = <1800>;
+		expected_accuracy = <64>;
 	};
 };
 

--- a/tests/drivers/adc/adc_accuracy_test/src/ref_volt.c
+++ b/tests/drivers/adc/adc_accuracy_test/src/ref_volt.c
@@ -8,6 +8,7 @@
 #include <zephyr/ztest.h>
 
 #define REF_V DT_PROP(DT_PATH(zephyr_user), reference_mv)
+#define EXP_ACC DT_PROP(DT_PATH(zephyr_user), expected_accuracy)
 
 extern const struct adc_dt_spec *get_adc_channel(void);
 
@@ -31,7 +32,7 @@ static int test_ref_to_adc(void)
 	ret = adc_raw_to_millivolts_dt(adc_channel, &sample_buffer);
 	zassert_equal(ret, 0, "adc_raw_to_millivolts_dt() failed with code %d",
 		      ret);
-	zassert_within(sample_buffer, REF_V, 32,
+	zassert_within(sample_buffer, REF_V, EXP_ACC,
 		"Value %d mV read from ADC does not match expected range (%d mV).",
 		sample_buffer, REF_V);
 


### PR DESCRIPTION
…uracy

On nrf boards expected accuracy from ref voltage is 64 instead of 32.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/76088