### PR TITLE
[nrf fromlist] tests: drivers: nrf_grtc: Add nRF54H20 PPR target

### DIFF
--- a/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
+++ b/tests/drivers/timer/nrf_grtc_timer/testcase.yaml
@@ -6,3 +6,4 @@ tests:
       - nrf54l15pdk/nrf54l15/cpuflpr
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpurad
+      - nrf54h20dk/nrf54h20/cpuppr


### PR DESCRIPTION
Add nRF54H20 cpu PPR target to GRTC tests.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/76215