### PR TITLE
Updates for radio driver with nRF54H20

### DIFF
--- a/dts/arm/nordic/nrf54h20_cpurad.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpurad.dtsi
@@ -59,21 +59,36 @@ wdt011: &cpurad_wdt011 {};
 };
 
 &dppic130 {
-	owned-channels = <0>;
-	sink-channels = <0>;
-	nonsecure-channels = <0>;
+	owned-channels = <0 2 3>;
+	sink-channels = <0 2>;
+	source-channels = <3>;
+	nonsecure-channels = <0 2 3>;
 	status = "okay";
 };
 
 &dppic132 {
-	owned-channels = <0>;
-	source-channels = <0>;
-	nonsecure-channels = <0>;
+	owned-channels = <0 2 3>;
+	sink-channels = <3>;
+	source-channels = <0 2>;
+	nonsecure-channels = <0 2 3>;
 	status = "okay";
 };
 
 &ipct130 {
-	owned-channels = <0>;
-	source-channel-links = <0 3 0>;
+	status = "okay";
+	owned-channels = <0 2>;
+	sink-channel-links = <2 NRF_DOMAIN_ID_RADIOCORE 2>;
+	source-channel-links = <0 NRF_DOMAIN_ID_RADIOCORE 0>,
+			       <2 NRF_DOMAIN_ID_RADIOCORE 2>;
+};
+
+&cpurad_ipct {
+	status = "okay";
+	sink-channel-links = <0 NRF_DOMAIN_ID_GLOBALSLOW 0>,
+			     <2 NRF_DOMAIN_ID_GLOBALSLOW 2>;
+	source-channel-links = <2 NRF_DOMAIN_ID_GLOBALSLOW 2>;
+};
+
+&dppic020 {
 	status = "okay";
 };

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
@@ -78,7 +78,8 @@ void nrf_802154_clock_hfclk_stop(void)
 #elif defined(NRF54H_SERIES)
 
 #define NRF_LRCCONF_RADIO_PD NRF_LRCCONF010
-#define MAX_HFXO_RAMP_UP_TIME_US 1000
+/* HF clock time to ramp-up. */
+#define MAX_HFXO_RAMP_UP_TIME_US 550
 
 static void hfclk_started_timer_handler(struct k_timer *dummy)
 {


### PR DESCRIPTION
* Adds missing device tree configs for dppic and ipct connections between the Radio core and the Global domains.
* Changes the ramp-up time from 1000us to 550us on nRF54H20. The time must fit inside general preconditions ramp up.
The hfclk time can be adjusted this way because the current solution is not precise until the clock_control is available.


manifest-pr-skip