### PR TITLE
fix pwm1 devicetree macro errors

### DIFF
--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840-pinctrl.dtsi
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840-pinctrl.dtsi
@@ -88,6 +88,20 @@
 		};
 	};
 
+	pwm1_default: pwm1_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 14)>;
+			nordic,invert;
+		};
+	};
+
+	pwm1_sleep: pwm1_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 14)>;
+			low-power-enable;
+		};
+	};
+
 	spi0_default: spi0_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 27)>,

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
@@ -203,6 +203,13 @@ arduino_i2c: &i2c0 {
 	pinctrl-names = "default", "sleep";
 };
 
+&pwm1 {
+	status = "disabled";
+	pinctrl-0 = <&pwm1_default>;
+	pinctrl-1 = <&pwm1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
 &spi0 {
 	compatible = "nordic,nrf-spi";
 	/* Cannot be used together with i2c0. */


### PR DESCRIPTION
Adding pwm1 to the board definition fixes macro errors when using it in an overlay.

To reproduce the problem:

```sh
cd ncs/zephyr/samples/basic/blinky
echo "CONFIG_PWM=y" >> prj.conf
cat >> app.overlay <<EOF
&pinctrl {
    test_pwm_default: test_pwm_default {
        group1 {
            psels = <NRF_PSEL(PWM_OUT0, 0, 14)>;
        };
    };
};

&pwm1 {
    status = "okay";
    pinctrl-0 = <&test_pwm_default>;
};
EOF
west build -b nrf52840dk/nrf52840 --pristine
```

There seems to be a deeper problem here, but this at least allows using `&pwm1`.

See [here](https://devzone.nordicsemi.com/f/nordic-q-a/87203/bug-cannot-enable-pwm1-pwm2-or-pwm3-on-nrf52840-dk) for a devzone discussion about it.