### PR TITLE
[nrf fromlist] testsuite: coverage: allow disabled multithreading

### DIFF
--- a/subsys/testsuite/coverage/coverage.c
+++ b/subsys/testsuite/coverage/coverage.c
@@ -262,7 +262,9 @@ void gcov_coverage_dump(void)
 	struct gcov_info *gcov_list = gcov_info_head;
 
 	if (!k_is_in_isr()) {
+#ifdef CONFIG_MULTITHREADING
 		k_sched_lock();
+#endif
 	}
 	printk("\nGCOV_COVERAGE_DUMP_START");
 	while (gcov_list) {
@@ -293,7 +295,9 @@ void gcov_coverage_dump(void)
 coverage_dump_end:
 	printk("\nGCOV_COVERAGE_DUMP_END\n");
 	if (!k_is_in_isr()) {
+#ifdef CONFIG_MULTITHREADING
 		k_sched_unlock();
+#endif
 	}
 	return;
 }


### PR DESCRIPTION
k_sched* are not avaliable when there is CONFIG_MULTITHREADING=n

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/76550