### PR TITLE
[nrf fromtree] Bluetooth: DIS: integrate app version into FW revision…

### DIFF
--- a/subsys/bluetooth/services/Kconfig.dis
+++ b/subsys/bluetooth/services/Kconfig.dis
@@ -117,6 +117,8 @@ config BT_DIS_FW_REV
 config BT_DIS_FW_REV_STR
 	string "Firmware revision"
 	depends on BT_DIS_FW_REV
+	default "$(APP_VERSION_TWEAK_STRING)" if "$(VERSION_MAJOR)" != ""
+	default "0.0.0+0"
 	help
 	  Enable firmware revision characteristic in Device Information Service.
 


### PR DESCRIPTION
… characteristic

Integrated the application version feature of the build system with the default configuration of the Bluetooth DIS module and its Firmware Revision characteristic.

The firmware revision string now defaults to APP_VERSION_TWEAK_STRING if the application version feature is used in a project. This specific version format is used to unify version formatting with other parts of Zephyr like the MCUboot module and its versioning Kconfig: CONFIG_MCUBOOT_IMGTOOL_SIGN_VERSION

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>
(cherry picked from commit f9a5699bd8a0508c3bbf4b4774f3495b2a7e9490)