### PR TITLE
Bsim: Update to latest revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 36b12714a5ed32450d907c89bb118f6280da3483
+      revision: 53635212495e4575955fc717369be4362126456a
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5

--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 53635212495e4575955fc717369be4362126456a
+      revision: 4447a22aea5e791c9bd18e7d71cc092623ddd2bb
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5

--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 6c389b9b5fa0a079cd4502e69d375da4c0c289b7
+      revision: 3ede17158a9fe85c160e0384c0ad0306e24ee47e
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5

--- a/west.yml
+++ b/west.yml
@@ -295,7 +295,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 4447a22aea5e791c9bd18e7d71cc092623ddd2bb
+      revision: 6c389b9b5fa0a079cd4502e69d375da4c0c289b7
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: da78aea63159771956fe0c9263f2e6985b66e9d5


### PR DESCRIPTION
Brings in bsim updates that will unblock some testing efforts:
Including the following:
* 53635212 nRF54L15 MDK: Redefine NRF_RADIO_*_BASE to point to model
* 4a92c424 NHW_IPC: Fix out of bounds read
* 2dae79b5 RADIO: Add nRF54 support
* 4447a22a CLOCK,POWER,RESET: Add stubs for the 54L
* 6c389b9 PPI (52): Connect CCM TASK_RATEOVERRIDE
* 2056253 CCM: Change TASK RATEOVERRIDE warning to info
* 3ede171 GRTC: Expose nhw_GRTC_counter_to_time()
* 2726f8b RTC: Define nhw_rtc_start_time_get()
* cc6fb0f hal: hack: Add nrf_hack function for triggering a task
* 03ca9b5 MWU: Add registers stub
