### PR TITLE
[nrf fromlist] boards: nordic: nrf54l15pdk: Added arduino i2c

### DIFF
--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-common.dtsi
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-common.dtsi
@@ -98,3 +98,11 @@
 	pinctrl-1 = <&pwm20_sleep>;
 	pinctrl-names = "default", "sleep";
 };
+
+arduino_i2c: &i2c21 {
+	compatible = "nordic,nrf-twim";
+	status = "okay";
+	pinctrl-0 = <&i2c21_default>;
+	pinctrl-1 = <&i2c21_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-pinctrl.dtsi
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15-pinctrl.dtsi
@@ -77,4 +77,19 @@
 			low-power-enable;
 		};
 	};
+
+	/omit-if-no-ref/ i2c21_default: i2c21_default {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 12)>;
+		};
+	};
+
+	/omit-if-no-ref/ i2c21_sleep: i2c21_sleep {
+		group1 {
+			psels = <NRF_PSEL(TWIM_SDA, 1, 11)>,
+				<NRF_PSEL(TWIM_SCL, 1, 12)>;
+			low-power-enable;
+		};
+	};
 };


### PR DESCRIPTION
Added arduino_i2c for nRF54L15PDK.  Needed for shields.

Signed-off-by: Andy Sinclair <andy.sinclair@nordicsemi.no>
(cherry picked from commit b392d31fa992d5d082905b2b2f272311e658d8a1)