### PR TITLE
[nrf noup] bluetooth: conn: Skip buffer ref count check in send_buf

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -654,13 +654,17 @@ static int send_buf(struct bt_conn *conn, struct net_buf *buf,
 
 	uint16_t frag_len = MIN(conn_mtu(conn), len);
 
-	if (buf->ref > 1 + (cb ? 1 : 0)) {
-		/* Allow for an additional buffer reference if callback is provided.
-		 * This can be used to extend lifetime of the net buffer until the
-		 * data transmission is confirmed by ACK of the remote.
-		 */
-		__ASSERT_NO_MSG(false);
-	}
+	/* If ATT sent callback is delayed until data transmission is done by BLE controller, the
+	 * transmitted buffer may have an additional reference. The reference is used to extend
+	 * lifetime of the net buffer until the data transmission is confirmed by ACK of the remote.
+	 *
+	 * send_buf function can be called multiple times, if buffer has to be fragmented over HCI.
+	 * In that case, the callback is provided as an argument only for the last transmitted
+	 * fragment. The `buf->ref == 1` check is skipped because it's impossible to properly
+	 * validate number of references for the sent fragments if buffers may have the additional
+	 * reference.
+	 */
+	__ASSERT_NO_MSG(IS_ENABLED(CONFIG_BT_ATT_SENT_CB_AFTER_TX) || (buf->ref == 1));
 
 	if (buf->len > frag_len) {
 		LOG_DBG("keep %p around", buf);


### PR DESCRIPTION
If ATT sent callback is delayed until data transmission is done by BLE controller, the transmitted buffer may have an additional reference. The reference is used to extend lifetime of the net buffer until the data transmission is confirmed by ACK of the remote.

send_buf function can be called multiple times, if buffer has to be fragmented over HCI. In that case, the callback is provided as an argument only for the last transmitted fragment. The `buf->ref == 1` check is skipped because it's impossible to properly validate number of references for the sent fragments if buffers may have the additional reference.

Jira: NCSDK-28624
