### PR TITLE
[nrf fromtree] soc: nordic: Fix APPROTECT with TF-M

### DIFF
--- a/soc/nordic/Kconfig
+++ b/soc/nordic/Kconfig
@@ -98,8 +98,7 @@ config NFCT_PINS_AS_GPIOS
 choice NRF_APPROTECT_HANDLING
 	bool "APPROTECT handling"
 	depends on SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET || \
-		   (SOC_NRF5340_CPUAPP && !TRUSTED_EXECUTION_NONSECURE) || \
-		   SOC_SERIES_NRF91X
+		   SOC_NRF5340_CPUAPP || SOC_SERIES_NRF91X
 	default NRF_APPROTECT_USE_UICR
 	help
 	  Specifies how the SystemInit() function should handle the APPROTECT
@@ -131,7 +130,7 @@ endchoice
 
 choice NRF_SECURE_APPROTECT_HANDLING
 	bool "Secure APPROTECT handling"
-	depends on (SOC_NRF5340_CPUAPP && !TRUSTED_EXECUTION_NONSECURE)
+	depends on SOC_NRF5340_CPUAPP || SOC_SERIES_NRF91X
 	default NRF_SECURE_APPROTECT_USE_UICR
 	help
 	  Specifies how the SystemInit() function should handle the secure


### PR DESCRIPTION
Allow CONFIG_NRF_APPROTECT_LOCK and
CONFIG_NRF_SECURE_APPROTECT_LOCK with TF-M with all the SOC's that support TF-M.

Signed-off-by: Markus Lassila <markus.lassila@nordicsemi.no>
(cherry picked from commit c44968486d2419334748fddf76690117c83d41af)