### PR TITLE
[nrf fromtree] manifest: Update hal_nordic with nonsecure PPIB fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: ab5cb2e2faeb1edfad7a25286dcb513929ae55da
+      revision: 0b6040d9b440b769a65f25c6fd9320eeff88ee94
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Secure PPIB instances were accessed even when building for nonsecure


(cherry picked from commit af314643a32db3452dd77f20dee2807197b179cf)