### PR TITLE
[nrf fromlist] tests: drivers: mbox: Fix for BUS FAULT on nrf54l15

### DIFF
--- a/tests/drivers/mbox/mbox_error_cases/sample.yaml
+++ b/tests/drivers/mbox/mbox_error_cases/sample.yaml
@@ -9,6 +9,12 @@ tests:
     platform_allow:
       - nrf54h20dk/nrf54h20/cpuapp
       - nrf54h20dk/nrf54h20/cpuppr
-      - nrf54l15pdk/nrf54l15/cpuapp
     integration_platforms:
       - nrf54h20dk/nrf54h20/cpuapp
+
+  tests.drivers.mbox_error_cases.nrf54l:
+    platform_allow:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf54l15pdk/nrf54l15/cpuapp
+    extra_args: SNIPPET=nordic-flpr

--- a/tests/drivers/mbox/mbox_error_cases/src/main.c
+++ b/tests/drivers/mbox/mbox_error_cases/src/main.c
@@ -450,7 +450,7 @@ ZTEST(mbox_error_cases, test_05c_mbox_set_enabled_on_already_enabled_rx_channel)
  * -EALREADY when user tries to disable already disabled RX mbox channel.
  *
  */
-ZTEST(mbox_error_cases, test_05d_mbox_set_enabled_on_already_disabled_rx_channel)
+ZTEST(mbox_error_cases, test_05d_mbox_set_disable_on_already_disabled_rx_channel)
 {
 	const struct mbox_dt_spec rx_channel =
 		MBOX_DT_SPEC_GET(DT_PATH(mbox_consumer), local_valid);


### PR DESCRIPTION
mbox_error_cases tests must be run with the nordic-flpr snippet to prevent bus fault error while accessing VPR registers.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/75114