### PR TITLE
Need exactly nrf-regtool v5.5.1 for SSF IPC

### DIFF
--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -15,7 +15,7 @@ if(CONFIG_NRF_REGTOOL_GENERATE_BICR)
   list(APPEND nrf_regtool_components GENERATE:BICR)
 endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 5.3.2 REQUIRED
+  find_package(nrf-regtool 5.5.1 EXACT REQUIRED
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH


### PR DESCRIPTION
Version 5.5.1 of nrf-regtool is required for the IPC communication to/from secdom to work after the mbox compatible rename.

This noup commit is to be removed when synchronizing sdk-zephyr with upstream zephyr and a newer version of nrf-regtool is required.