### PR TITLE
[nrf fromlist] tests: bluetooth: tester: refactor CSIP btp command

### DIFF
--- a/tests/bluetooth/tester/src/btp/btp_csip.h
+++ b/tests/bluetooth/tester/src/btp/btp_csip.h
@@ -25,12 +25,14 @@ struct btp_csip_start_ordered_access_cmd {
 
 #define BTP_CSIP_SET_COORDINATOR_LOCK		0x04
 struct btp_csip_set_coordinator_lock_cmd {
-	uint8_t count;
+	uint8_t addr_cnt;
+	bt_addr_le_t addr[];
 } __packed;
 
 #define BTP_CSIP_SET_COORDINATOR_RELEASE	0x05
 struct btp_csip_set_coordinator_release_cmd {
-	uint8_t count;
+	uint8_t addr_cnt;
+	bt_addr_le_t addr[];
 } __packed;
 
 /* CSIP Events */


### PR DESCRIPTION
_Note: The corresponding changes from this are already in our auto-pts repo, so this should fix a discrepancy..._

Refactor CSIP btp commands by removing the 'count' parameter from set_coordinator_lock and set_coordinator_release functions. If we want to support lock/release procedure on subset of set members in the future, 'count' param doesn't indicate a specific set member. Instead, introduce 'address_count' and 'addr' array params, although their usage is not yet implemented.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/71059