### PR TITLE
[nrf fromtree] twister: scripts: Split lines before processing

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -5,17 +5,19 @@
 # Copyright 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import pkg_resources
-import sys
-from pathlib import Path
+import argparse
 import json
 import logging
-import subprocess
-import shutil
+import os
 import re
-import argparse
+import shutil
+import subprocess
+import sys
 from datetime import datetime, timezone
+from importlib import metadata
+from pathlib import Path
+from typing import Generator
+
 from twisterlib.coverage import supported_coverage_formats
 
 logger = logging.getLogger('twister')
@@ -40,12 +42,21 @@ import zephyr_module
 # Note "normalization" is different from canonicalization, see os.path.
 canonical_zephyr_base = os.path.realpath(ZEPHYR_BASE)
 
-installed_packages = [pkg.project_name for pkg in pkg_resources.working_set]  # pylint: disable=not-an-iterable
+
+def _get_installed_packages() -> Generator[str, None, None]:
+    """Return list of installed python packages."""
+    for dist in metadata.distributions():
+        yield dist.metadata['Name']
+
+
+installed_packages: list[str] = list(_get_installed_packages())
 PYTEST_PLUGIN_INSTALLED = 'pytest-twister-harness' in installed_packages
+
 
 def norm_path(astring):
     newstring = os.path.normpath(astring).replace(os.sep, '/')
     return newstring
+
 
 def add_parse_arguments(parser = None):
     if parser is None:

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -16,7 +16,7 @@ import sys
 from datetime import datetime, timezone
 from importlib import metadata
 from pathlib import Path
-from typing import Generator
+from typing import Generator, List
 
 from twisterlib.coverage import supported_coverage_formats
 
@@ -49,7 +49,7 @@ def _get_installed_packages() -> Generator[str, None, None]:
         yield dist.metadata['Name']
 
 
-installed_packages: list[str] = list(_get_installed_packages())
+installed_packages: List[str] = list(_get_installed_packages())
 PYTEST_PLUGIN_INSTALLED = 'pytest-twister-harness' in installed_packages
 
 

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -421,12 +421,13 @@ class DeviceHandler(Handler):
             # Just because ser_fileno has data doesn't mean an entire line
             # is available yet.
             if serial_line:
-                sl = serial_line.decode('utf-8', 'ignore').lstrip()
-                logger.debug("DEVICE: {0}".format(sl.rstrip()))
-
-                log_out_fp.write(strip_ansi_sequences(sl).encode('utf-8'))
-                log_out_fp.flush()
-                harness.handle(sl.rstrip())
+                # can be more lines in serial_line so split them before handling
+                for sl in serial_line.decode('utf-8', 'ignore').splitlines():
+                    log_out_fp.write(strip_ansi_sequences(sl).encode('utf-8'))
+                    log_out_fp.flush()
+                    if sl := sl.strip():
+                        logger.debug("DEVICE: {0}".format(sl))
+                        harness.handle(sl)
 
             if harness.state:
                 if not harness.capture_coverage:

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -624,6 +624,7 @@ class Gtest(Harness):
 
 
 class Test(Harness):
+    __test__ = False  # for pytest to skip this class when collects tests
     RUN_PASSED = "PROJECT EXECUTION SUCCESSFUL"
     RUN_FAILED = "PROJECT EXECUTION FAILED"
     test_suite_start_pattern = r"Running TESTSUITE (?P<suite_name>.*)"

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -77,7 +77,9 @@ class TestLevel:
     levels = []
     scenarios = []
 
+
 class TestPlan:
+    __test__ = False  # for pytest to skip this class when collects tests
     config_re = re.compile('(CONFIG_[A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
     dt_re = re.compile('([A-Za-z0-9_]+)[=]\"?([^\"]*)\"?$')
 


### PR DESCRIPTION
Readline method sometimes receives more lines in buffer. Split them to avoid misinterpreting data in harness module.

(cherry picked from commit 79ef0b6b10dd97d8e734fe6a4104fe3bc5589640)