### PR TITLE
[nrf noup] wifi_mgmt: Add support for PS data retrieval mechanism config

### DIFF
--- a/include/zephyr/net/wifi.h
+++ b/include/zephyr/net/wifi.h
@@ -384,6 +384,8 @@ enum wifi_ps_param_type {
 	WIFI_PS_PARAM_WAKEUP_MODE,
 	/** Power save mode. */
 	WIFI_PS_PARAM_MODE,
+	/** Power save exit strategy. */
+	WIFI_PS_PARAM_EXIT_STRATEGY,
 	/** Power save timeout. */
 	WIFI_PS_PARAM_TIMEOUT,
 };
@@ -398,6 +400,24 @@ enum wifi_ps_wakeup_mode {
 
 /** Helper function to get user-friendly ps wakeup mode name. */
 const char * const wifi_ps_wakeup_mode_txt(enum wifi_ps_wakeup_mode ps_wakeup_mode);
+
+/**
+ * Wi-Fi power save exit strategy
+ */
+enum wifi_ps_exit_strategy {
+	/** PS-Poll frame based */
+	WIFI_PS_EXIT_EVERY_TIM = 0,
+	/** QoS NULL frame based */
+	WIFI_PS_EXIT_CUSTOM_ALGO,
+
+	/** Last value */
+	WIFI_PS_EXIT_LAST,
+	/** Maximum value */
+	WIFI_PS_EXIT_MAX = WIFI_PS_EXIT_LAST - 1,
+};
+
+/** Helper function to get user-friendly ps exit strategy name. */
+const char * const wifi_ps_exit_strategy_txt(enum wifi_ps_exit_strategy ps_exit_strategy);
 
 /** Wi-Fi power save error codes. */
 enum wifi_config_ps_param_fail_reason {
@@ -415,6 +435,8 @@ enum wifi_config_ps_param_fail_reason {
 	WIFI_PS_PARAM_FAIL_DEVICE_CONNECTED,
 	/** Listen interval out of range */
 	WIFI_PS_PARAM_LISTEN_INTERVAL_RANGE_INVALID,
+	/** Invalid exit strategy */
+	WIFI_PS_PARAM_FAIL_INVALID_EXIT_STRATEGY,
 };
 
 /** @cond INTERNAL_HIDDEN */

--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -365,6 +365,8 @@ struct wifi_ps_params {
 	enum wifi_ps_param_type type;
 	/** Wi-Fi power save fail reason */
 	enum wifi_config_ps_param_fail_reason fail_reason;
+	/** Wi-Fi power save exit strategy */
+	enum wifi_ps_exit_strategy exit_strategy;
 };
 
 /** Wi-Fi TWT parameters */

--- a/subsys/net/l2/wifi/wifi_mgmt.c
+++ b/subsys/net/l2/wifi/wifi_mgmt.c
@@ -236,6 +236,18 @@ const char * const wifi_ps_wakeup_mode_txt(enum wifi_ps_wakeup_mode ps_wakeup_mo
 	}
 }
 
+const char * const wifi_ps_exit_strategy_txt(enum wifi_ps_exit_strategy ps_exit_strategy)
+{
+	switch (ps_exit_strategy) {
+	case WIFI_PS_EXIT_EVERY_TIM:
+		return "Every TIM";
+	case WIFI_PS_EXIT_CUSTOM_ALGO:
+		return "Custom algorithm";
+	default:
+		return "UNKNOWN";
+	}
+}
+
 static const struct wifi_mgmt_ops *const get_wifi_api(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
@@ -535,6 +547,13 @@ static int wifi_set_power_save(uint32_t mgmt_request, struct net_if *iface,
 	case WIFI_PS_PARAM_STATE:
 	case WIFI_PS_PARAM_WAKEUP_MODE:
 	case WIFI_PS_PARAM_TIMEOUT:
+		break;
+	case WIFI_PS_PARAM_EXIT_STRATEGY:
+		if (ps_params->exit_strategy > WIFI_PS_EXIT_MAX) {
+			ps_params->fail_reason =
+				WIFI_PS_PARAM_FAIL_INVALID_EXIT_STRATEGY;
+			return -EINVAL;
+		}
 		break;
 	default:
 		ps_params->fail_reason =

--- a/subsys/net/l2/wifi/wifi_shell.c
+++ b/subsys/net/l2/wifi/wifi_shell.c
@@ -757,6 +757,8 @@ static int cmd_wifi_ps(const struct shell *sh, size_t argc, char *argv[])
 			shell_fprintf(sh, SHELL_NORMAL, "PS timeout: disabled\n");
 		}
 
+		shell_fprintf(sh, SHELL_NORMAL, "PS exit strategy: %s\n",
+				wifi_ps_exit_strategy_txt(config.ps_params.exit_strategy));
 
 		if (config.num_twt_flows == 0) {
 			shell_fprintf(sh, SHELL_NORMAL, "No TWT flows\n");
@@ -1265,6 +1267,40 @@ static int cmd_wifi_ps_wakeup_mode(const struct shell *sh, size_t argc, char *ar
 	return 0;
 }
 
+static int cmd_wifi_ps_exit_strategy(const struct shell *sh, size_t argc,
+			    char *argv[])
+{
+	struct net_if *iface = net_if_get_first_wifi();
+	struct wifi_ps_params params = { 0 };
+
+	context.sh = sh;
+
+	if (!strncmp(argv[1], "tim", 3)) {
+		params.exit_strategy = WIFI_PS_EXIT_EVERY_TIM;
+	} else if (!strncmp(argv[1], "custom", 6)) {
+		params.exit_strategy = WIFI_PS_EXIT_CUSTOM_ALGO;
+	} else {
+		shell_fprintf(sh, SHELL_WARNING, "Invalid argument\n");
+		shell_fprintf(sh, SHELL_INFO, "Valid argument : <tim> / <custom>\n");
+		return -ENOEXEC;
+	}
+
+	params.type = WIFI_PS_PARAM_EXIT_STRATEGY;
+
+	if (net_mgmt(NET_REQUEST_WIFI_PS, iface, &params, sizeof(params))) {
+		shell_fprintf(sh, SHELL_WARNING,
+			      "Setting PS exit strategy to %s failed..Reason :%s\n",
+			      wifi_ps_exit_strategy_txt(params.exit_strategy),
+			      wifi_ps_get_config_err_code_str(params.fail_reason));
+		return -ENOEXEC;
+	}
+
+	shell_fprintf(sh, SHELL_NORMAL, "%s\n",
+		      wifi_ps_exit_strategy_txt(params.exit_strategy));
+
+	return 0;
+}
+
 void parse_mode_args_to_params(const struct shell *sh, int argc,
 			       char *argv[], struct wifi_mode_info *mode,
 			       bool *do_mode_oper)
@@ -1735,6 +1771,14 @@ SHELL_STATIC_SUBCMD_SET_CREATE(wifi_commands,
 		     cmd_wifi_ps_wakeup_mode,
 		     2,
 		     0),
+	SHELL_CMD_ARG(ps_exit_strategy,
+		      NULL,
+		      "<tim> : Set PS exit strategy to Every TIM\n"
+		      "<custom> : Set PS exit strategy to Custom",
+		      cmd_wifi_ps_exit_strategy,
+		      2,
+		      0),
+
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
In PS mode, buffered data can be retrieved in two different ways, add an API to configure the mechanism at runtime.