### PR TITLE
Bring the Zephyr HWinfo driver changes into NCS

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -67,7 +67,7 @@ config HWINFO_NRF
 	bool "NRF device ID"
 	default y
 	depends on SOC_FAMILY_NORDIC_NRF
-	depends on NRF_SOC_SECURE_SUPPORTED
+	depends on SOC_SERIES_NRF54HX || NRF_SOC_SECURE_SUPPORTED
 	help
 	  Enable Nordic NRF hwinfo driver.
 

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -386,6 +386,10 @@ static int uarte_nrfx_configure(const struct device *dev,
 	struct uarte_nrfx_data *data = dev->data;
 	nrf_uarte_config_t uarte_cfg;
 
+#if NRF_UARTE_HAS_FRAME_TIMEOUT
+	uarte_cfg.frame_timeout = NRF_UARTE_FRAME_TIMEOUT_DIS;
+#endif
+
 #if defined(UARTE_CONFIG_STOP_Msk)
 	switch (cfg->stop_bits) {
 	case UART_CFG_STOP_BITS_1:

--- a/drivers/serial/uart_nrfx_uarte2.c
+++ b/drivers/serial/uart_nrfx_uarte2.c
@@ -643,6 +643,10 @@ static int uarte_nrfx_configure(const struct device *dev,
 	struct uarte_nrfx_data *data = dev->data;
 	nrf_uarte_config_t uarte_cfg;
 
+#if NRF_UARTE_HAS_FRAME_TIMEOUT
+	uarte_cfg.frame_timeout = NRF_UARTE_FRAME_TIMEOUT_DIS;
+#endif
+
 #if defined(UARTE_CONFIG_STOP_Msk)
 	switch (cfg->stop_bits) {
 	case UART_CFG_STOP_BITS_1:

--- a/modules/hal_nordic/nrfx/nrfx_config_common.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_common.h
@@ -18,7 +18,7 @@
 
 /** @brief Symbol specifying minor version of the nrfx API to be used. */
 #ifndef NRFX_CONFIG_API_VER_MINOR
-#define NRFX_CONFIG_API_VER_MINOR 3
+#define NRFX_CONFIG_API_VER_MINOR 6
 #endif
 
 /** @brief Symbol specifying micro version of the nrfx API to be used. */

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf52805.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf52805.h
@@ -1013,6 +1013,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0 Maximum: 7

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf52810.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf52810.h
@@ -1148,6 +1148,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0 Maximum: 7

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf52811.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf52811.h
@@ -1175,6 +1175,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0 Maximum: 7

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf52820.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf52820.h
@@ -1112,6 +1112,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0 Maximum: 7

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf52832.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf52832.h
@@ -1504,6 +1504,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0 Maximum: 7

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf52833.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf52833.h
@@ -1472,6 +1472,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0 Maximum: 7

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf52840.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf52840.h
@@ -1499,6 +1499,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0 Maximum: 7

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf5340_application.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf5340_application.h
@@ -1378,6 +1378,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0 Maximum: 7

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf5340_network.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf5340_network.h
@@ -784,6 +784,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0 Maximum: 7

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf54h20_application.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf54h20_application.h
@@ -1734,6 +1734,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0. Maximum: 7.

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf54h20_ppr.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf54h20_ppr.h
@@ -1671,6 +1671,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0. Maximum: 3.

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf54h20_radiocore.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf54h20_radiocore.h
@@ -1798,6 +1798,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0. Maximum: 7.

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf54l15_enga_application.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf54l15_enga_application.h
@@ -1518,15 +1518,6 @@
 #endif
 
 /**
- * @brief NRFX_UARTE_CONFIG_RX_CACHE_ENABLED
- *
- * Boolean. Accepted values: 0 and 1.
- */
-#ifndef NRFX_UARTE_CONFIG_RX_CACHE_ENABLED
-#define NRFX_UARTE_CONFIG_RX_CACHE_ENABLED 1
-#endif
-
-/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0. Maximum: 7.

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf54l15_enga_application.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf54l15_enga_application.h
@@ -1518,6 +1518,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0. Maximum: 7.

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf54l15_enga_flpr.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf54l15_enga_flpr.h
@@ -1510,6 +1510,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0. Maximum: 3.

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf54l15_enga_flpr.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf54l15_enga_flpr.h
@@ -1510,15 +1510,6 @@
 #endif
 
 /**
- * @brief NRFX_UARTE_CONFIG_RX_CACHE_ENABLED
- *
- * Boolean. Accepted values: 0 and 1.
- */
-#ifndef NRFX_UARTE_CONFIG_RX_CACHE_ENABLED
-#define NRFX_UARTE_CONFIG_RX_CACHE_ENABLED 1
-#endif
-
-/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0. Maximum: 3.

--- a/modules/hal_nordic/nrfx/nrfx_config_nrf91.h
+++ b/modules/hal_nordic/nrfx/nrfx_config_nrf91.h
@@ -1098,6 +1098,15 @@
 #endif
 
 /**
+ * @brief NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+ *
+ * Integer value. Minimum: 0. Maximum: 255.
+ */
+#ifndef NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE
+#define NRFX_UARTE_RX_FIFO_FLUSH_WORKAROUND_MAGIC_BYTE 171
+#endif
+
+/**
  * @brief NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY
  *
  * Integer value. Minimum: 0 Maximum: 7

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: ab5cb2e2faeb1edfad7a25286dcb513929ae55da
+      revision: d4030afcc0befef645eda11e82c0d7c0e1d604f1
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
HWinfo depends on the nrfx v3.6.0 integration:

Combines commits from the following PRs:
- https://github.com/zephyrproject-rtos/zephyr/pull/75530 (HW info changes for nRF54H20)
- https://github.com/zephyrproject-rtos/zephyr/pull/76330 (nrf v3.6.0 integration)