### PR TITLE
[nrf fromtree] boards: shields: Allow adding source code to shields

### DIFF
--- a/boards/CMakeLists.txt
+++ b/boards/CMakeLists.txt
@@ -17,3 +17,5 @@ if(EXISTS ${BOARD_DIR}/CMakeLists.txt)
 
   add_subdirectory(${BOARD_DIR} ${build_dir})
 endif()
+
+add_subdirectory(shields)

--- a/boards/shields/CMakeLists.txt
+++ b/boards/shields/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Shield directories may contain multiple shields. Filter out duplicate
+# directories to avoid including the same CMakeLists.txt file multiple times
+set(unique_shield_dirs ${SHIELD_DIRS})
+list(REMOVE_DUPLICATES unique_shield_dirs)
+
+foreach(shield_dir ${unique_shield_dirs})
+  # To avoid a lot of empty CMakeLists.txt files we assume it is not an
+  # error if it is missing
+  if(EXISTS ${shield_dir}/CMakeLists.txt)
+    # Out-of-tree shield directories will not be a subdirectory,
+    # use the filename portion of the shield directory path as a
+    # relative cmake binary_dir
+    cmake_path(GET shield_dir FILENAME binary_dir)
+    add_subdirectory(${shield_dir} ${binary_dir})
+  endif()
+endforeach()


### PR DESCRIPTION
Add shield CMakeLists.txt if it exists.
Useful for one-off shields that require C code

Signed-off-by: Grant Ramsay <gramsay@enphaseenergy.com>
(cherry picked from commit 4a21035aa5cd4ed3629dba5f7b361ea7f5a10dec)