### PR TITLE
[nrf fromtree] twister: Pass device flash timeout to pytest-harness.

### DIFF
--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/device/hardware_adapter.py
@@ -30,7 +30,7 @@ class HardwareAdapter(DeviceAdapter):
 
     def __init__(self, device_config: DeviceConfig) -> None:
         super().__init__(device_config)
-        self._flashing_timeout: float = self.base_timeout
+        self._flashing_timeout: float = device_config.flash_timeout
         self._serial_connection: serial.Serial | None = None
         self._serial_pty_proc: subprocess.Popen | None = None
         self._serial_buffer: bytearray = bytearray()

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/plugin.py
@@ -36,8 +36,13 @@ def pytest_addoption(parser: pytest.Parser):
         type=float,
         default=60.0,
         help='Set base timeout (in seconds) used during monitoring if some '
-             'operations are finished in a finite amount of time (e.g. waiting '
-             'for flashing).'
+             'operations are finished in a finite amount of time.'
+    )
+    twister_harness_group.addoption(
+        '--flash-timeout',
+        type=float,
+        default=60.0,
+        help='Set timeout for device flashing (in seconds).'
     )
     twister_harness_group.addoption(
         '--build-dir',

--- a/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
+++ b/scripts/pylib/pytest-twister-harness/src/twister_harness/twister_harness_config.py
@@ -19,6 +19,7 @@ class DeviceConfig:
     type: str
     build_dir: Path
     base_timeout: float = 60.0  # [s]
+    flash_timeout: float = 60.0  # [s]
     platform: str = ''
     serial: str = ''
     baud: int = 115200
@@ -65,6 +66,7 @@ class TwisterHarnessConfig:
             type=config.option.device_type,
             build_dir=_cast_to_path(config.option.build_dir),
             base_timeout=config.option.base_timeout,
+            flash_timeout=config.option.flash_timeout,
             platform=config.option.platform,
             serial=config.option.device_serial,
             baud=config.option.device_serial_baud,

--- a/scripts/pylib/twister/twisterlib/harness.py
+++ b/scripts/pylib/twister/twisterlib/harness.py
@@ -386,6 +386,9 @@ class Pytest(Harness):
                 f'--device-serial-baud={hardware.baud}'
             ])
 
+        if hardware.flash_timeout:
+            command.append(f'--flash-timeout={hardware.flash_timeout}')
+
         options = handler.options
         if runner := hardware.runner or options.west_runner:
             command.append(f'--runner={runner}')


### PR DESCRIPTION
Pass flashing timeout to pytest-harness and use them.

Takes changes from Upstream Zephyr: https://github.com/zephyrproject-rtos/zephyr/pull/77788

