### PR TITLE
[nrf noup] soc: nordic: add delay after wake up

### DIFF
--- a/soc/nordic/nrf54h/power.c
+++ b/soc/nordic/nrf54h/power.c
@@ -63,6 +63,7 @@ void nrf_poweroff(void)
 /* Resume domain after local suspend to RAM. */
 static void sys_resume(void)
 {
+	k_busy_wait(100);
 	if (IS_ENABLED(CONFIG_ICACHE)) {
 		/* Power up and re-enable ICACHE */
 		nrf_memconf_ramblock_control_enable_set(NRF_MEMCONF, RAMBLOCK_POWER_ID,


### PR DESCRIPTION
An additional delay after wake-up is needed.