### PR TITLE
[nrf fromtree] Bluetooth: Mesh: Clarify log to run out of retransmiss…

### DIFF
--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1220,7 +1220,7 @@ static void seg_ack(struct k_work *work)
 	rx->last_ack = k_uptime_get_32();
 
 	if (rx->attempts_left == 0) {
-		LOG_DBG("Ran out of retransmit attempts");
+		LOG_DBG("Ran out of ack retransmit attempts");
 		return;
 	}
 


### PR DESCRIPTION
…ion attempt

The logs for retransmission attempts for sending segments and ack retransmission attempts for receiving segments were the same, making it difficult to distinguish between them. This can be solved by adding information to the log of ack retransmission.

Signed-off-by: Junho Lee <tot0roprog@gmail.com>
(cherry picked from commit fe24cac70b5d6e587b051fe4b945696a9cef5e80)