### PR TITLE
[WIP] Bluetooth: Fix building tests for the zephyr link layer

### DIFF
--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -88,13 +88,12 @@
 			status = "okay";
 			ble-2mbps-supported;
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -5,7 +5,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -92,13 +92,12 @@
 			status = "okay";
 			ble-2mbps-supported;
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -104,13 +104,12 @@
 				status = "disabled";
 			};
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -10,7 +10,7 @@
 / {
 
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -100,13 +100,12 @@
 				status = "disabled";
 			};
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK another Bluetooth controller
+			 * is added and set as the default.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -5,7 +5,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -92,13 +92,12 @@
 			status = "okay";
 			ble-2mbps-supported;
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -99,13 +99,12 @@
 				status = "disabled";
 			};
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -5,7 +5,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &cryptocell;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -94,13 +94,12 @@
 				status = "disabled";
 			};
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -102,13 +102,12 @@
 				status = "disabled";
 			};
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf54h20_cpurad.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpurad.dtsi
@@ -22,7 +22,7 @@ wdt011: &cpurad_wdt011 {};
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 	};
 
 	soc {
@@ -97,6 +97,6 @@ wdt011: &cpurad_wdt011 {};
 	status = "okay";
 };
 
-&bt_hci_sdc {
+&bt_hci_controller {
 	status = "okay";
 };

--- a/dts/arm/nordic/nrf54l15_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l15_cpuapp.dtsi
@@ -17,7 +17,7 @@ nvic: &cpuapp_nvic {};
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &psa_rng;
 	};
 
@@ -33,7 +33,7 @@ nvic: &cpuapp_nvic {};
 	};
 };
 
-&bt_hci_sdc {
+&bt_hci_controller {
 	status = "okay";
 };
 

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -359,10 +359,9 @@
 					status = "disabled";
 				};
 
-				bt_hci_sdc: bt_hci_sdc {
-					compatible = "nordic,bt-hci-sdc";
-					status = "disabled";
-				};
+				/* Note: In the nRF Connect SDK the SoftDevice Controller
+				 * is added and set as the default Bluetooth Controller.
+				 */
 				bt_hci_controller: bt_hci_controller {
 					compatible = "zephyr,bt-hci-ll-sw-split";
 					status = "disabled";

--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -216,10 +216,9 @@
 					status = "disabled";
 				};
 
-				bt_hci_sdc: bt_hci_sdc {
-					compatible = "nordic,bt-hci-sdc";
-					status = "disabled";
-				};
+				/* Note: In the nRF Connect SDK the SoftDevice Controller
+				 * is added and set as the default Bluetooth Controller.
+				 */
 				bt_hci_controller: bt_hci_controller {
 					compatible = "zephyr,bt-hci-ll-sw-split";
 					status = "disabled";

--- a/samples/bluetooth/beacon/sample.yaml
+++ b/samples/bluetooth/beacon/sample.yaml
@@ -12,7 +12,9 @@ tests:
       - qemu_cortex_m3
 
   sample.bluetooth.beacon-coex:
-    extra_args: CONF_FILE="prj-coex.conf"
+    extra_args:
+      - CONF_FILE="prj-coex.conf"
+      - SNIPPET="bt-ll-sw-split"
     harness: bluetooth
     platform_allow: nrf52840dk/nrf52840
     tags: bluetooth

--- a/samples/bluetooth/broadcast_audio_sink/sample.yaml
+++ b/samples/bluetooth/broadcast_audio_sink/sample.yaml
@@ -24,5 +24,5 @@ tests:
       - nrf52_bsim
       - nrf52833dk/nrf52833
       - nrf52840dongle/nrf52840
-    extra_args: OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+    extra_args: OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf SNIPPET="bt-ll-sw-split"
     tags: bluetooth

--- a/samples/bluetooth/broadcast_audio_source/sample.yaml
+++ b/samples/bluetooth/broadcast_audio_source/sample.yaml
@@ -25,5 +25,5 @@ tests:
       - nrf52_bsim
       - nrf52833dk/nrf52833
       - nrf52840dongle/nrf52840
-    extra_args: OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+    extra_args: OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf SNIPPET="bt-ll-sw-split"
     tags: bluetooth

--- a/samples/bluetooth/central_iso/sample.yaml
+++ b/samples/bluetooth/central_iso/sample.yaml
@@ -11,11 +11,9 @@ tests:
   sample.bluetooth.central_iso.bt_ll_sw_split:
     harness: bluetooth
     platform_allow:
-      - qemu_cortex_m3
-      - qemu_x86
       - nrf52_bsim
       - nrf52833dk/nrf52833
     integration_platforms:
       - nrf52833dk/nrf52833
-    extra_args: OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+    extra_args: OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf SNIPPET="bt-ll-sw-split"
     tags: bluetooth

--- a/samples/bluetooth/direction_finding_central/sample.yaml
+++ b/samples/bluetooth/direction_finding_central/sample.yaml
@@ -14,15 +14,23 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
       - nrf5340dk/nrf5340/cpuapp
-  sample.bluetooth.direction_finding.central.aod:
+  sample.bluetooth.direction_finding.central.aod_with_controller:
     harness: bluetooth
-    extra_args: OVERLAY_CONFIG="overlay-aod.conf"
+    extra_args:
+      - OVERLAY_CONFIG="overlay-aod.conf"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
-      - nrf5340dk/nrf5340/cpuapp
     tags: bluetooth
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
+  sample.bluetooth.direction_finding.central.aod_host_only:
+    harness: bluetooth
+    extra_args: OVERLAY_CONFIG="overlay-aod.conf"
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+    tags: bluetooth
+    integration_platforms:
       - nrf5340dk/nrf5340/cpuapp

--- a/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
@@ -12,14 +12,21 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
       - nrf5340dk/nrf5340/cpuapp
-  sample.bluetooth.direction_finding_connectionless_rx.aod:
+  sample.bluetooth.direction_finding_connectionless_rx.aod_with_controller:
     harness: bluetooth
-    extra_args: OVERLAY_CONFIG="overlay-aod.conf"
+    extra_args:
+      - OVERLAY_CONFIG="overlay-aod.conf"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
-      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
+  sample.bluetooth.direction_finding_connectionless_rx.aod_host_only:
+    harness: bluetooth
+    extra_args: OVERLAY_CONFIG="overlay-aod.conf"
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+    integration_platforms:
       - nrf5340dk/nrf5340/cpuapp

--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -12,14 +12,19 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
       - nrf5340dk/nrf5340/cpuapp
-  sample.bluetooth.direction_finding_connectionless.aoa:
+  sample.bluetooth.direction_finding_connectionless.aoa_with_controller:
     harness: bluetooth
-    extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
+    extra_args: OVERLAY_CONFIG="overlay-aoa.conf" SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
-      - nrf5340dk/nrf5340/cpuapp
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
+  sample.bluetooth.direction_finding_connectionless.aoa_host_only:
+    harness: bluetooth
+    extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+    integration_platforms:
       - nrf5340dk/nrf5340/cpuapp

--- a/samples/bluetooth/direction_finding_peripheral/sample.yaml
+++ b/samples/bluetooth/direction_finding_peripheral/sample.yaml
@@ -14,15 +14,24 @@ tests:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
       - nrf5340dk/nrf5340/cpuapp
-  sample.bluetooth.direction_finding.peripheral.aod:
+  sample.bluetooth.direction_finding.peripheral.aod_with_controller:
     harness: bluetooth
-    extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
+    extra_args:
+      - OVERLAY_CONFIG="overlay-aoa.conf"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
-      - nrf5340dk/nrf5340/cpuapp
     tags: bluetooth
     integration_platforms:
       - nrf52833dk/nrf52833
       - nrf52833dk/nrf52820
+  sample.bluetooth.direction_finding.peripheral.aod_host_only:
+    harness: bluetooth
+    extra_args:
+      - OVERLAY_CONFIG="overlay-aoa.conf"
+    platform_allow:
+      - nrf5340dk/nrf5340/cpuapp
+    tags: bluetooth
+    integration_platforms:
       - nrf5340dk/nrf5340/cpuapp

--- a/samples/bluetooth/hci_ipc/sample.yaml
+++ b/samples/bluetooth/hci_ipc/sample.yaml
@@ -15,7 +15,9 @@ tests:
   sample.bluetooth.hci_ipc.iso_broadcast.bt_ll_sw_split:
     harness: bluetooth
     tags: bluetooth
-    extra_args: CONF_FILE="nrf5340_cpunet_iso_broadcast-bt_ll_sw_split.conf"
+    extra_args:
+      - CONF_FILE="nrf5340_cpunet_iso_broadcast-bt_ll_sw_split.conf"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpunet
       - nrf5340_audio_dk/nrf5340/cpunet
@@ -26,7 +28,9 @@ tests:
   sample.bluetooth.hci_ipc.iso_receive.bt_ll_sw_split:
     harness: bluetooth
     tags: bluetooth
-    extra_args: CONF_FILE="nrf5340_cpunet_iso_receive-bt_ll_sw_split.conf"
+    extra_args:
+      - CONF_FILE="nrf5340_cpunet_iso_receive-bt_ll_sw_split.conf"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpunet
       - nrf5340_audio_dk/nrf5340/cpunet
@@ -36,7 +40,9 @@ tests:
   sample.bluetooth.hci_ipc.bis.bt_ll_sw_split:
     harness: bluetooth
     tags: bluetooth
-    extra_args: CONF_FILE="nrf5340_cpunet_bis-bt_ll_sw_split.conf"
+    extra_args:
+      - CONF_FILE="nrf5340_cpunet_bis-bt_ll_sw_split.conf"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpunet
       - nrf5340_audio_dk/nrf5340/cpunet
@@ -46,7 +52,9 @@ tests:
   sample.bluetooth.hci_ipc.iso_central.bt_ll_sw_split:
     harness: bluetooth
     tags: bluetooth
-    extra_args: CONF_FILE="nrf5340_cpunet_iso_central-bt_ll_sw_split.conf"
+    extra_args:
+      - CONF_FILE="nrf5340_cpunet_iso_central-bt_ll_sw_split.conf"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpunet
       - nrf5340_audio_dk/nrf5340/cpunet
@@ -56,7 +64,9 @@ tests:
   sample.bluetooth.hci_ipc.iso_peripheral.bt_ll_sw_split:
     harness: bluetooth
     tags: bluetooth
-    extra_args: CONF_FILE="nrf5340_cpunet_iso_peripheral-bt_ll_sw_split.conf"
+    extra_args:
+      - CONF_FILE="nrf5340_cpunet_iso_peripheral-bt_ll_sw_split.conf"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpunet
       - nrf5340_audio_dk/nrf5340/cpunet
@@ -66,7 +76,9 @@ tests:
   sample.bluetooth.hci_ipc.cis.bt_ll_sw_split:
     harness: bluetooth
     tags: bluetooth
-    extra_args: CONF_FILE="nrf5340_cpunet_cis-bt_ll_sw_split.conf"
+    extra_args:
+      - CONF_FILE="nrf5340_cpunet_cis-bt_ll_sw_split.conf"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpunet
       - nrf5340_audio_dk/nrf5340/cpunet
@@ -76,7 +88,9 @@ tests:
   sample.bluetooth.hci_ipc.iso.bt_ll_sw_split:
     harness: bluetooth
     tags: bluetooth
-    extra_args: CONF_FILE="nrf5340_cpunet_iso-bt_ll_sw_split.conf"
+    extra_args:
+      - CONF_FILE="nrf5340_cpunet_iso-bt_ll_sw_split.conf"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpunet
       - nrf5340bsim/nrf5340/cpunet
@@ -88,6 +102,7 @@ tests:
     extra_args:
       - CONF_FILE="nrf5340_cpunet_df-bt_ll_sw_split.conf"
       - DTC_OVERLAY_FILE="nrf5340_cpunet_df-bt_ll_sw_split.overlay"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow: nrf5340dk/nrf5340/cpunet
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
@@ -98,13 +113,16 @@ tests:
       - CONF_FILE="nrf5340_cpunet_df-bt_ll_sw_split.conf"
       - DTC_OVERLAY_FILE="nrf5340_cpunet_df-bt_ll_sw_split.overlay"
       - CONFIG_BT_CTLR_PHY_CODED=n
+      - SNIPPET="bt-ll-sw-split"
     platform_allow: nrf5340dk/nrf5340/cpunet
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet
   sample.bluetooth.hci_ipc.mesh.bt_ll_sw_split:
     harness: bluetooth
     tags: bluetooth
-    extra_args: CONF_FILE="nrf5340_cpunet_bt_mesh-bt_ll_sw_split.conf"
+    extra_args:
+      - CONF_FILE="nrf5340_cpunet_bt_mesh-bt_ll_sw_split.conf"
+      - SNIPPET="bt-ll-sw-split"
     platform_allow: nrf5340dk/nrf5340/cpunet
     integration_platforms:
       - nrf5340dk/nrf5340/cpunet

--- a/samples/bluetooth/hci_vs_scan_req/sample.yaml
+++ b/samples/bluetooth/hci_vs_scan_req/sample.yaml
@@ -9,4 +9,5 @@ tests:
       - nrf52dk/nrf52832
     extra_configs:
       - CONFIG_BT_LL_SW_SPLIT=y
+    extra_args: SNIPPET="bt-ll-sw-split"
     tags: bluetooth

--- a/samples/bluetooth/public_broadcast_sink/sample.yaml
+++ b/samples/bluetooth/public_broadcast_sink/sample.yaml
@@ -23,5 +23,7 @@ tests:
     integration_platforms:
       - nrf52_bsim
       - nrf52833dk/nrf52833
-    extra_args: OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+    extra_args:
+      - OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+      - SNIPPET="bt-ll-sw-split"
     tags: bluetooth

--- a/samples/bluetooth/public_broadcast_source/sample.yaml
+++ b/samples/bluetooth/public_broadcast_source/sample.yaml
@@ -23,5 +23,7 @@ tests:
     integration_platforms:
       - nrf52_bsim
       - nrf52833dk/nrf52833
-    extra_args: OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+    extra_args:
+      - OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+      - SNIPPET="bt-ll-sw-split"
     tags: bluetooth

--- a/samples/bluetooth/unicast_audio_client/sample.yaml
+++ b/samples/bluetooth/unicast_audio_client/sample.yaml
@@ -22,5 +22,7 @@ tests:
       - nrf52840dk/nrf52840
     integration_platforms:
       - nrf52dk/nrf52832
-    extra_args: OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+    extra_args:
+      - OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+      - SNIPPET="bt-ll-sw-split"
     tags: bluetooth

--- a/samples/bluetooth/unicast_audio_server/sample.yaml
+++ b/samples/bluetooth/unicast_audio_server/sample.yaml
@@ -22,5 +22,7 @@ tests:
       - nrf52840dk/nrf52840
     integration_platforms:
       - nrf52dk/nrf52832
-    extra_args: OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+    extra_args:
+      - OVERLAY_CONFIG=overlay-bt_ll_sw_split.conf
+      - SNIPPET="bt-ll-sw-split"
     tags: bluetooth

--- a/tests/bluetooth/controller/ctrl_api/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_api/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_api.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_chmu/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_chmu/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_chmu.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_cis_create/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_cis_create/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_cis_create.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_cis_terminate/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_cis_terminate/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_cis_terminate.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_collision/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_collision/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_collision.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_conn_update/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_conn_update/testcase.yaml
@@ -7,11 +7,13 @@ common:
 tests:
   bluetooth.controller.ctrl_conn_update.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"
 
   bluetooth.controller.ctrl_conn_update.apm_test:
     type: unit
-    extra_args: CONF_FILE=prj_apm.conf
+    extra_args: CONF_FILE=prj_apm.conf SNIPPET="bt-ll-sw-split"
+
 
   bluetooth.controller.ctrl_conn_update.no_param_req_test:
     type: unit
-    extra_args: CONF_FILE=prj_no_param_req.conf
+    extra_args: CONF_FILE=prj_no_param_req.conf SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_cte_req/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_cte_req/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_cte_req.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_data_length_update/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_data_length_update/testcase.yaml
@@ -6,11 +6,12 @@ common:
 tests:
   bluetooth.controller.ctrl_data_length_update.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"
 
   bluetooth.controller.ctrl_data_length_update.test_nocodedphy:
     type: unit
-    extra_args: CONF_FILE=prj_nocoded.conf
+    extra_args: CONF_FILE=prj_nocoded.conf SNIPPET="bt-ll-sw-split"
 
   bluetooth.controller.ctrl_data_length_update.test_nophy:
     type: unit
-    extra_args: CONF_FILE=prj_nophy.conf
+    extra_args: CONF_FILE=prj_nophy.conf SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_encrypt/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_encrypt/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_encrypt.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_feature_exchange/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_feature_exchange.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_hci/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_hci/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_hci.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_invalid/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_invalid/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_invalid.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_le_ping/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_le_ping/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_le_ping.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_min_used_chans/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_min_used_chans.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_phy_update/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_phy_update/testcase.yaml
@@ -6,6 +6,7 @@ common:
 tests:
   bluetooth.controller.ctrl_phy_update.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"
   bluetooth.controller.ctrl_phy_update.test_reduced_buf:
     type: unit
-    extra_args: CONF_FILE=prj_rx_cnt.conf
+    extra_args: CONF_FILE=prj_rx_cnt.conf SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_sca_update/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_sca_update/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_sca_update.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_terminate/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_terminate/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_terminate.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_tx_buffer_alloc/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_tx_buffer_alloc/testcase.yaml
@@ -6,23 +6,24 @@ common:
 tests:
   bluetooth.controller.ctrl_tx_buffer_alloc.test_0_per_conn:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"
 
   bluetooth.controller.ctrl_tx_buffer_alloc.test_1_per_conn:
     type: unit
-    extra_args: CONF_FILE=prj_1.conf
+    extra_args: CONF_FILE=prj_1.conf SNIPPET="bt-ll-sw-split"
 
   bluetooth.controller.ctrl_tx_buffer_alloc.test_2_per_conn:
     type: unit
-    extra_args: CONF_FILE=prj_2.conf
+    extra_args: CONF_FILE=prj_2.conf SNIPPET="bt-ll-sw-split"
 
   bluetooth.controller.ctrl_tx_buffer_alloc.test_3_per_conn:
     type: unit
-    extra_args: CONF_FILE=prj_3.conf
+    extra_args: CONF_FILE=prj_3.conf SNIPPET="bt-ll-sw-split"
 
   bluetooth.controller.ctrl_tx_buffer_alloc.test_max_per_conn_alloc:
     type: unit
-    extra_args: CONF_FILE=prj_max.conf
+    extra_args: CONF_FILE=prj_max.conf SNIPPET="bt-ll-sw-split"
 
   bluetooth.controller.ctrl_tx_buffer_alloc.test_max_common_alloc:
     type: unit
-    extra_args: CONF_FILE=prj_max_common.conf
+    extra_args: CONF_FILE=prj_max_common.conf SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_tx_queue/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_tx_queue/testcase.yaml
@@ -5,3 +5,4 @@ common:
 tests:
   bluetooth.ctrl_tx_queue.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_unsupported/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_unsupported/testcase.yaml
@@ -6,7 +6,8 @@ common:
 tests:
   bluetooth.controller.ctrl_unsupported.default.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"
 
   bluetooth.controller.ctrl_unsupported.test:
     type: unit
-    extra_args: CONF_FILE=prj_unsupported.conf
+    extra_args: CONF_FILE=prj_unsupported.conf SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/controller/ctrl_version/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_version/testcase.yaml
@@ -6,3 +6,4 @@ common:
 tests:
   bluetooth.controller.ctrl_version.test:
     type: unit
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/ctrl_sw_privacy/testcase.yaml
+++ b/tests/bluetooth/ctrl_sw_privacy/testcase.yaml
@@ -4,3 +4,4 @@ common:
 tests:
   bluetooth.ctrl_sw_privacy.test:
     platform_allow: nrf52_bsim
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/ctrl_user_ext/testcase.yaml
+++ b/tests/bluetooth/ctrl_user_ext/testcase.yaml
@@ -4,3 +4,4 @@ common:
 tests:
   bluetooth.ctrl_user_ext.test:
     platform_allow: nrf52_bsim
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/df/connection_cte_req/testcase.yaml
+++ b/tests/bluetooth/df/connection_cte_req/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   bluetooth.df.conection_cte_req:
     platform_allow: nrf52_bsim
     tags: bluetooth
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/df/connection_cte_tx_params/testcase.yaml
+++ b/tests/bluetooth/df/connection_cte_tx_params/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   bluetooth.df.conection_cte_tx_params:
     platform_allow: nrf52_bsim
     tags: bluetooth
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/df/connectionless_cte_chains/testcase.yaml
+++ b/tests/bluetooth/df/connectionless_cte_chains/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   bluetooth.df.connectionless_cte_chains:
     platform_allow: nrf52_bsim
     tags: bluetooth
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/df/connectionless_cte_rx/testcase.yaml
+++ b/tests/bluetooth/df/connectionless_cte_rx/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   bluetooth.df.connectionless_cte_rx:
     platform_allow: nrf52_bsim
     tags: bluetooth
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/df/connectionless_cte_tx/testcase.yaml
+++ b/tests/bluetooth/df/connectionless_cte_tx/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   bluetooth.df.connectionless_cte_tx:
     platform_allow: nrf52_bsim
     tags: bluetooth
+    extra_args: SNIPPET="bt-ll-sw-split"

--- a/tests/bluetooth/init/testcase.yaml
+++ b/tests/bluetooth/init/testcase.yaml
@@ -74,7 +74,7 @@ tests:
     extra_args: CONF_FILE=prj_9.conf
     platform_allow: qemu_cortex_m3
   bluetooth.init.test_ctlr:
-    extra_args: CONF_FILE=prj_ctlr.conf
+    extra_args: CONF_FILE=prj_ctlr.conf SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -86,7 +86,7 @@ tests:
       - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
   bluetooth.init.test_ctlr_4_0:
-    extra_args: CONF_FILE=prj_ctlr_4_0.conf
+    extra_args: CONF_FILE=prj_ctlr_4_0.conf SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -95,7 +95,7 @@ tests:
       - nrf52dk/nrf52832
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_4_0_dbg:
-    extra_args: CONF_FILE=prj_ctlr_4_0_dbg.conf
+    extra_args: CONF_FILE=prj_ctlr_4_0_dbg.conf SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -104,7 +104,7 @@ tests:
       - nrf52dk/nrf52832
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_tiny:
-    extra_args: CONF_FILE=prj_ctlr_tiny.conf
+    extra_args: CONF_FILE=prj_ctlr_tiny.conf SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -116,6 +116,7 @@ tests:
     extra_args:
       - CONF_FILE=prj_ctlr_dbg.conf
       - DTC_OVERLAY_FILE=pa_lna.overlay
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -126,6 +127,7 @@ tests:
     extra_args:
       - CONF_FILE=prj_ctlr_5_x_dbg.conf
       - DTC_OVERLAY_FILE=pa_lna.overlay
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -137,6 +139,7 @@ tests:
       - CONF_FILE=prj_ctlr.conf
       - CONFIG_BT_CTLR_ADVANCED_FEATURES=y
       - CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER=y
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf5340dk/nrf5340/cpunet
       - nrf52840dk/nrf52840
@@ -148,6 +151,7 @@ tests:
   bluetooth.init.test_ctlr_ticker:
     extra_args:
       - CONF_FILE=prj_ctlr_ticker.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -155,28 +159,36 @@ tests:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
   bluetooth.init.test_ctlr_broadcaster:
-    extra_args: CONF_FILE=prj_ctlr_broadcaster.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_broadcaster.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
   bluetooth.init.test_ctlr_peripheral:
-    extra_args: CONF_FILE=prj_ctlr_peripheral.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_peripheral.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
   bluetooth.init.test_ctlr_peripheral_priv:
-    extra_args: CONF_FILE=prj_ctlr_peripheral_priv.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_peripheral_priv.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
       - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
   bluetooth.init.test_ctlr_observer:
-    extra_args: CONF_FILE=prj_ctlr_observer.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_observer.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -187,7 +199,9 @@ tests:
       - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
   bluetooth.init.test_ctlr_central:
-    extra_args: CONF_FILE=prj_ctlr_central.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_central.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -198,7 +212,9 @@ tests:
       - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
   bluetooth.init.test_ctlr_central_priv:
-    extra_args: CONF_FILE=prj_ctlr_central_priv.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_central_priv.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -209,7 +225,9 @@ tests:
       - nrf51dk/nrf51822
       - rv32m1_vega/openisa_rv32m1/ri5cy
   bluetooth.init.test_ctlr_broadcaster_ext:
-    extra_args: CONF_FILE=prj_ctlr_broadcaster_ext.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_broadcaster_ext.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -218,7 +236,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_peripheral_ext:
-    extra_args: CONF_FILE=prj_ctlr_peripheral_ext.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_peripheral_ext.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -227,7 +247,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_peripheral_ext_priv:
-    extra_args: CONF_FILE=prj_ctlr_peripheral_ext_priv.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_peripheral_ext_priv.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -236,7 +258,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_oberver_ext:
-    extra_args: CONF_FILE=prj_ctlr_observer_ext.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_observer_ext.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -245,7 +269,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_central_ext:
-    extra_args: CONF_FILE=prj_ctlr_central_ext.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_central_ext.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -254,7 +280,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_central_ext_priv:
-    extra_args: CONF_FILE=prj_ctlr_central_ext_priv.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_central_ext_priv.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -263,7 +291,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_per_adv:
-    extra_args: CONF_FILE=prj_ctlr_per_adv.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_per_adv.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -272,7 +302,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_per_adv_no_adi:
-    extra_args: CONF_FILE=prj_ctlr_per_adv_no_adi.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_per_adv_no_adi.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -281,7 +313,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_per_sync:
-    extra_args: CONF_FILE=prj_ctlr_per_sync.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_per_sync.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -290,7 +324,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_per_sync_no_adi:
-    extra_args: CONF_FILE=prj_ctlr_per_sync_no_adi.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_per_sync_no_adi.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -299,7 +335,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_per_sync_no_filter:
-    extra_args: CONF_FILE=prj_ctlr_per_sync_no_filter.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_per_sync_no_filter.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -308,7 +346,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_peripheral_iso:
-    extra_args: CONF_FILE=prj_ctlr_peripheral_iso.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_peripheral_iso.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -317,7 +357,9 @@ tests:
       - nrf52840dk/nrf52840
       - nrf51dk/nrf51822
   bluetooth.init.test_ctlr_central_iso:
-    extra_args: CONF_FILE=prj_ctlr_central_iso.conf
+    extra_args:
+      - CONF_FILE=prj_ctlr_central_iso.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -336,7 +378,9 @@ tests:
       - DTC_OVERLAY_FILE=h5.overlay
     platform_allow: qemu_cortex_m3
   bluetooth.init.test_llcp:
-    extra_args: CONF_FILE=prj_llcp.conf
+    extra_args:
+      - CONF_FILE=prj_llcp.conf
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840
       - nrf52dk/nrf52832
@@ -349,5 +393,6 @@ tests:
     extra_args:
       - CONF_FILE=prj_ctlr.conf
       - CONFIG_BT_RECV_WORKQ_BT=y
+      - SNIPPET="bt-ll-sw-split"
     platform_allow:
       - nrf52840dk/nrf52840


### PR DESCRIPTION
After
https://github.com/nrfconnect/sdk-nrf/pull/16819
and
https://github.com/nrfconnect/sdk-zephyr/pull/1940 the Zephyr Link Layer device tree node is disabled.

This commit enables the node by applying the snippet for test cases that requires it.