### PR TITLE
[nrf fromtree]  scripts: pylib: twister: fix missing newlines at handl…

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -422,7 +422,7 @@ class DeviceHandler(Handler):
             # is available yet.
             if serial_line:
                 # can be more lines in serial_line so split them before handling
-                for sl in serial_line.decode('utf-8', 'ignore').splitlines():
+                for sl in serial_line.decode('utf-8', 'ignore').splitlines(keepends=True):
                     log_out_fp.write(strip_ansi_sequences(sl).encode('utf-8'))
                     log_out_fp.flush()
                     if sl := sl.strip():


### PR DESCRIPTION
…er.log

Keep new lines at handler.log.

(cherry picked from commit f0bfaa4c1903a51647a76a6565994377e9ba8d10)