### PR TITLE
[nrf fromtree] tests: drivers: Extend coverage for NRF GRTC timer

### DIFF
--- a/tests/drivers/timer/nrf_grtc_timer/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/timer/nrf_grtc_timer/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,5 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+&grtc {
+	/delete-property/ child-owned-channels;
+};

--- a/tests/drivers/timer/nrf_grtc_timer/src/main.c
+++ b/tests/drivers/timer/nrf_grtc_timer/src/main.c
@@ -11,6 +11,18 @@
 #define NUMBER_OF_TRIES 2000
 #define CYC_PER_TICK                                                                               \
 	((uint64_t)sys_clock_hw_cycles_per_sec() / (uint64_t)CONFIG_SYS_CLOCK_TICKS_PER_SEC)
+#define TIMER_COUNT_TIME_MS 10
+#define WAIT_FOR_TIMER_EVENT_TIME_MS TIMER_COUNT_TIME_MS + 5
+
+static volatile uint8_t compare_isr_call_counter;
+
+/* GRTC timer compare interrupt handler */
+static void timer_compare_interrupt_handler(int32_t id, uint64_t expire_time, void *user_data)
+{
+	compare_isr_call_counter++;
+	TC_PRINT("Compare value reached, user data: '%s'\n", (char *)user_data);
+	TC_PRINT("Call counter: %d\n", compare_isr_call_counter);
+}
 
 ZTEST(nrf_grtc_timer, test_get_ticks)
 {
@@ -46,6 +58,77 @@ ZTEST(nrf_grtc_timer, test_get_ticks)
 			     "Unexpected result %" PRId64 " (expected: %" PRId64 ")", ticks,
 			     exp_ticks);
 	}
+}
+
+ZTEST(nrf_grtc_timer, test_timer_count_in_compare_mode)
+{
+	int err;
+	uint64_t test_ticks = 0;
+	uint64_t compare_value = 0;
+	char user_data[] = "test_timer_count_in_compare_mode\n";
+	int32_t channel = z_nrf_grtc_timer_chan_alloc();
+
+	TC_PRINT("Allocated GRTC channel %d\n", channel);
+	if (channel < 0) {
+		TC_PRINT("Failed to allocate GRTC channel, chan=%d\n", channel);
+		ztest_test_fail();
+	}
+
+	compare_isr_call_counter = 0;
+	test_ticks = z_nrf_grtc_timer_get_ticks(K_MSEC(TIMER_COUNT_TIME_MS));
+	err = z_nrf_grtc_timer_set(channel, test_ticks, timer_compare_interrupt_handler,
+				   (void *)user_data);
+
+	zassert_equal(err, 0, "z_nrf_grtc_timer_set raised an error: %d", err);
+
+	z_nrf_grtc_timer_compare_read(channel, &compare_value);
+	zassert_true(K_TIMEOUT_EQ(K_TICKS(compare_value), K_TICKS(test_ticks)),
+		     "Compare register set failed");
+	zassert_equal(err, 0, "Unexpected error raised when setting timer, err: %d", err);
+
+	k_sleep(K_MSEC(WAIT_FOR_TIMER_EVENT_TIME_MS));
+
+	TC_PRINT("Compare event generated ?: %d\n", z_nrf_grtc_timer_compare_evt_check(channel));
+	TC_PRINT("Compare event register address: %X\n",
+		 z_nrf_grtc_timer_compare_evt_address_get(channel));
+
+	zassert_equal(compare_isr_call_counter, 1, "Compare isr call counter: %d",
+		      compare_isr_call_counter);
+	z_nrf_grtc_timer_chan_free(channel);
+}
+
+ZTEST(nrf_grtc_timer, test_timer_abort_in_compare_mode)
+{
+	int err;
+	uint64_t test_ticks = 0;
+	uint64_t compare_value = 0;
+	char user_data[] = "test_timer_abort_in_compare_mode\n";
+	int32_t channel = z_nrf_grtc_timer_chan_alloc();
+
+	TC_PRINT("Allocated GRTC channel %d\n", channel);
+	if (channel < 0) {
+		TC_PRINT("Failed to allocate GRTC channel, chan=%d\n", channel);
+		ztest_test_fail();
+	}
+
+	compare_isr_call_counter = 0;
+	test_ticks = z_nrf_grtc_timer_get_ticks(K_MSEC(TIMER_COUNT_TIME_MS));
+	err = z_nrf_grtc_timer_set(channel, test_ticks, timer_compare_interrupt_handler,
+				   (void *)user_data);
+	zassert_equal(err, 0, "z_nrf_grtc_timer_set raised an error: %d", err);
+
+	z_nrf_grtc_timer_abort(channel);
+
+	z_nrf_grtc_timer_compare_read(channel, &compare_value);
+	zassert_true(K_TIMEOUT_EQ(K_TICKS(compare_value), K_TICKS(test_ticks)),
+		     "Compare register set failed");
+
+	zassert_equal(err, 0, "Unexpected error raised when setting timer, err: %d", err);
+
+	k_sleep(K_MSEC(WAIT_FOR_TIMER_EVENT_TIME_MS));
+	zassert_equal(compare_isr_call_counter, 0, "Compare isr call counter: %d",
+		      compare_isr_call_counter);
+	z_nrf_grtc_timer_chan_free(channel);
 }
 
 ZTEST_SUITE(nrf_grtc_timer, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Add more test cases for nRF GRTC timer

Signed-off-by: Bartosz Miller <bartosz.miller@nordicsemi.no>
(cherry picked from commit a49c649b9015f9c46e801363f95d65a6ed1b2efa)