### PR TITLE
Revert "[nrf noup] dts: Select SoftDevice Controller DTS binding as d…

### DIFF
--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -88,13 +88,12 @@
 			status = "okay";
 			ble-2mbps-supported;
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -5,7 +5,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -92,13 +92,12 @@
 			status = "okay";
 			ble-2mbps-supported;
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -104,13 +104,12 @@
 				status = "disabled";
 			};
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -10,7 +10,7 @@
 / {
 
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -100,13 +100,12 @@
 				status = "disabled";
 			};
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK another Bluetooth controller
+			 * is added and set as the default.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -5,7 +5,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -92,13 +92,12 @@
 			status = "okay";
 			ble-2mbps-supported;
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -99,13 +99,12 @@
 				status = "disabled";
 			};
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -5,7 +5,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &cryptocell;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -94,13 +94,12 @@
 				status = "disabled";
 			};
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -9,7 +9,7 @@
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &rng;
 		zephyr,flash-controller = &flash_controller;
 	};
@@ -102,13 +102,12 @@
 				status = "disabled";
 			};
 
-			bt_hci_sdc: bt_hci_sdc {
-				compatible = "nordic,bt-hci-sdc";
-				status = "okay";
-			};
+			/* Note: In the nRF Connect SDK the SoftDevice Controller
+			 * is added and set as the default Bluetooth Controller.
+			 */
 			bt_hci_controller: bt_hci_controller {
 				compatible = "zephyr,bt-hci-ll-sw-split";
-				status = "disabled";
+				status = "okay";
 			};
 		};
 

--- a/dts/arm/nordic/nrf54h20_cpurad.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpurad.dtsi
@@ -22,7 +22,7 @@ wdt011: &cpurad_wdt011 {};
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 	};
 
 	soc {
@@ -97,6 +97,6 @@ wdt011: &cpurad_wdt011 {};
 	status = "okay";
 };
 
-&bt_hci_sdc {
+&bt_hci_controller {
 	status = "okay";
 };

--- a/dts/arm/nordic/nrf54l15_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l15_cpuapp.dtsi
@@ -17,7 +17,7 @@ nvic: &cpuapp_nvic {};
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_sdc;
+		zephyr,bt-hci = &bt_hci_controller;
 		zephyr,entropy = &psa_rng;
 	};
 
@@ -33,7 +33,7 @@ nvic: &cpuapp_nvic {};
 	};
 };
 
-&bt_hci_sdc {
+&bt_hci_controller {
 	status = "okay";
 };
 

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -359,10 +359,9 @@
 					status = "disabled";
 				};
 
-				bt_hci_sdc: bt_hci_sdc {
-					compatible = "nordic,bt-hci-sdc";
-					status = "disabled";
-				};
+				/* Note: In the nRF Connect SDK the SoftDevice Controller
+				 * is added and set as the default Bluetooth Controller.
+				 */
 				bt_hci_controller: bt_hci_controller {
 					compatible = "zephyr,bt-hci-ll-sw-split";
 					status = "disabled";

--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -216,10 +216,9 @@
 					status = "disabled";
 				};
 
-				bt_hci_sdc: bt_hci_sdc {
-					compatible = "nordic,bt-hci-sdc";
-					status = "disabled";
-				};
+				/* Note: In the nRF Connect SDK the SoftDevice Controller
+				 * is added and set as the default Bluetooth Controller.
+				 */
 				bt_hci_controller: bt_hci_controller {
 					compatible = "zephyr,bt-hci-ll-sw-split";
 					status = "disabled";


### PR DESCRIPTION
…efault"

This reverts commit 7a0f9ef20fe7625d7555fb5d181b9f9d3bb9a570.

manifest-pr-skip