### PR TITLE
[nrf noup] mgmt: mcumgr: grp: img_mgmt: Add handling for QSPI XIP

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -185,6 +185,14 @@ config MCUMGR_GRP_IMG_TOO_LARGE_BOOTLOADER_INFO
 
 endchoice
 
+config MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_IMAGE
+	bool "QSPI XIP Split image mode"
+	depends on MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP
+	help
+	  This option should not be selected by users and should automatically be selected by
+	  sysbuild if needed. This enables selecting the correct slot when running a QSPI XIP
+	  split image application in DirectXIP mode.
+
 module = MCUMGR_GRP_IMG
 module-str = mcumgr_grp_img
 source "subsys/logging/Kconfig.template.log_config"

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt.c
@@ -159,6 +159,12 @@ int img_mgmt_active_slot(int image)
 	/* Multi image does not support DirectXIP currently */
 #if CONFIG_MCUMGR_GRP_IMG_UPDATABLE_IMAGE_NUMBER > 1
 	slot = (image << 1);
+
+#if CONFIG_MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_IMAGE
+	if (FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot1_partition)) {
+		slot += 1;
+	}
+#endif
 #else
 	/* This covers single image, including DirectXiP */
 	if (FIXED_PARTITION_IS_RUNNING_APP_PARTITION(slot1_partition)) {


### PR DESCRIPTION
Adds handling code to allow selecting the correct image slot when using QSPI XIP in DirectXIP mode

manifest-pr-skip