### PR TITLE
[nrf fromtree] tests: bsim: run_parallel: Avoid escape sequences in xml

### DIFF
--- a/tests/bsim/run_parallel.sh
+++ b/tests/bsim/run_parallel.sh
@@ -70,7 +70,7 @@ echo "Attempting to run ${n_cases} cases (logging to \
  `realpath ${RESULTS_FILE}`)"
 
 export CLEAN_XML="sed -E -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g' \
-                  -e 's/\"/&quot;/g'"
+                  -e 's/\"/&quot;/g' -e $'s/\x1b\[[0-9;]*[a-zA-Z]//g'"
 
 echo -n "" > $tmp_res_file
 


### PR DESCRIPTION
Let's filter out escape sequences from the tests
output (for ex. color escapes) as those corrupt
the xml.

Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
(cherry picked from commit c11fccdaddf9a5a9d1578fa77ef2ce5f661cbad3)