### PR TITLE
[nrf fromtree] manifest: Update hal_nordic with nrfx changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: d4030afcc0befef645eda11e82c0d7c0e1d604f1
+      revision: af7b21c4f875bea26689307daa8e52e9a8e8323c
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Moving hash to include new radio symbols from hal_nordic/nrfx.

Signed-off-by: Karol Lasończyk <karol.lasonczyk@nordicsemi.no>
(cherry picked from commit 45dd39590087d2947ebd4ef440b703674988cdb2)