### PR TITLE
[nrf fromtree] samples: drivers: Enable SPI MEMORY driver samples for…

### DIFF
--- a/samples/drivers/jesd216/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/jesd216/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mx25r64 {
+	status = "okay";
+};

--- a/samples/drivers/spi_flash/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
+++ b/samples/drivers/spi_flash/boards/nrf54l15pdk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mx25r64 {
+	status = "okay";
+};


### PR DESCRIPTION
… nrfl54l15

Add SPI MEMORY driver testing for nrf54l15

Signed-off-by: Bartosz Miller <bartosz.miller@nordicsemi.no>
(cherry picked from commit e9fef2a29ba0e936b94bdb7364f0ddcb745cd15c)