### PR TITLE
[nrf fromlist] logging: STM fixes

### DIFF
--- a/subsys/logging/frontends/Kconfig
+++ b/subsys/logging/frontends/Kconfig
@@ -95,6 +95,12 @@ config LOG_FRONTEND_STMESP_DEMUX_BUFFER_SIZE
 config LOG_FRONTEND_STMESP_DEMUX_MAX_UTILIZATION
 	bool "Track maximum utilization"
 
+config LOG_FRONTEND_STMESP_DEMUX_GC_TIMEOUT
+	int "Message timeout (in milliseconds)"
+	default 100
+	help
+	  If log message is not completed within that time frame it is discarded.
+
 endif # LOG_FRONTEND_STMESP_DEMUX
 
 config LOG_FRONTEND_STMESP_FLUSH_PORT_ID

--- a/subsys/logging/frontends/log_frontend_stmesp.c
+++ b/subsys/logging/frontends/log_frontend_stmesp.c
@@ -26,15 +26,15 @@ BUILD_ASSERT(sizeof(void *) == sizeof(uint32_t));
 
 #define STMESP_FLUSH_WORD 0xaabbccdd
 
-#define STM_FLAG(reg) \
+#define STM_FLAG(reg)                                                                              \
 	stmesp_flag(reg, 1, false, IS_ENABLED(CONFIG_LOG_FRONTEND_STMESP_GUARANTEED_ACCESS))
 
-#define STM_D8(reg, data, timestamp, marked)       \
-	stmesp_data8(reg, data, timestamp, marked, \
+#define STM_D8(reg, data, timestamp, marked)                                                       \
+	stmesp_data8(reg, data, timestamp, marked,                                                 \
 		     IS_ENABLED(CONFIG_LOG_FRONTEND_STMESP_GUARANTEED_ACCESS))
 
-#define STM_D32(reg, data, timestamp, marked)       \
-	stmesp_data32(reg, data, timestamp, marked, \
+#define STM_D32(reg, data, timestamp, marked)                                                      \
+	stmesp_data32(reg, data, timestamp, marked,                                                \
 		      IS_ENABLED(CONFIG_LOG_FRONTEND_STMESP_GUARANTEED_ACCESS))
 
 /* Buffer for storing frontend data before STM/ETR is ready for usage.
@@ -95,7 +95,7 @@ union stm_log_dict_hdr {
 /* Dictionary header initializer. */
 #define DICT_HDR_INITIALIZER(_level, _source_id, _data_len)                                        \
 	{                                                                                          \
-		.hdr = {.ver = CONFIG_LOG_FRONTEND_STMESP_DICT_VER,                         \
+		.hdr = {.ver = CONFIG_LOG_FRONTEND_STMESP_DICT_VER,                                \
 			.type = STM_MSG_TYPE_LOG_DICT,                                             \
 			.level = _level,                                                           \
 			.data_len = _data_len,                                                     \
@@ -281,8 +281,8 @@ void log_frontend_msg(const void *source, const struct log_msg_desc desc, uint8_
 	size_t sname_len;
 	int package_len;
 	int total_len;
-	static const uint32_t flags = CBPRINTF_PACKAGE_CONVERT_RW_STR |
-				      CBPRINTF_PACKAGE_CONVERT_RO_STR;
+	static const uint32_t flags =
+		CBPRINTF_PACKAGE_CONVERT_RW_STR | CBPRINTF_PACKAGE_CONVERT_RO_STR;
 
 	sname = log_source_name_get(0, get_source_id(source));
 	if (sname) {
@@ -293,8 +293,8 @@ void log_frontend_msg(const void *source, const struct log_msg_desc desc, uint8_
 	}
 	total_len = desc.data_len + sname_len /* null terminator */;
 
-	package_len = cbprintf_package_convert(package, desc.package_len, NULL, NULL, flags,
-					       strl, ARRAY_SIZE(strl));
+	package_len = cbprintf_package_convert(package, desc.package_len, NULL, NULL, flags, strl,
+					       ARRAY_SIZE(strl));
 	hdr.log.total_len = total_len + package_len;
 	hdr.log.package_len = package_len;
 
@@ -308,8 +308,8 @@ void log_frontend_msg(const void *source, const struct log_msg_desc desc, uint8_
 		}
 
 		STM_D32(stm_esp, hdr.raw, use_timestamp, true);
-		(void)cbprintf_package_convert(package, desc.package_len,
-					       package_cb, stm_esp, flags, strl, ARRAY_SIZE(strl));
+		(void)cbprintf_package_convert(package, desc.package_len, package_cb, stm_esp,
+					       flags, strl, ARRAY_SIZE(strl));
 		write_data(sname, sname_len, stm_esp);
 		if (data) {
 			write_data(data, desc.data_len, stm_esp);
@@ -327,8 +327,8 @@ void log_frontend_msg(const void *source, const struct log_msg_desc desc, uint8_
 		}
 
 		early_buf_put_data((const uint8_t *)&hdr, sizeof(hdr));
-		(void)cbprintf_package_convert(package, desc.package_len, early_package_cb,
-					       NULL, flags, strl, ARRAY_SIZE(strl));
+		(void)cbprintf_package_convert(package, desc.package_len, early_package_cb, NULL,
+					       flags, strl, ARRAY_SIZE(strl));
 		early_buf_put_data(sname, sname_len);
 		if (data) {
 			early_buf_put_data(data, desc.data_len);
@@ -357,8 +357,8 @@ void log_frontend_msg(const void *source, const struct log_msg_desc desc, uint8_
 		}
 
 		STM_D32(stm_esp, dict_desc.raw, true, true);
-		(void)cbprintf_package_convert(package, desc.package_len, package_cb,
-					       stm_esp, flags, NULL, 0);
+		(void)cbprintf_package_convert(package, desc.package_len, package_cb, stm_esp,
+					       flags, NULL, 0);
 		if (data) {
 			package_cb(data, desc.data_len, stm_esp);
 		}
@@ -370,8 +370,8 @@ void log_frontend_msg(const void *source, const struct log_msg_desc desc, uint8_
 		key = k_spin_lock(&lock);
 		len_loc = early_buf_len_loc();
 		early_package_cb(&dict_desc.raw, sizeof(dict_desc.raw), NULL);
-		(void)cbprintf_package_convert(package, desc.package_len, early_package_cb,
-					       NULL, flags, NULL, 0);
+		(void)cbprintf_package_convert(package, desc.package_len, early_package_cb, NULL,
+					       flags, NULL, 0);
 		if (data) {
 			early_package_cb(data, desc.data_len, NULL);
 		}
@@ -383,8 +383,8 @@ void log_frontend_msg(const void *source, const struct log_msg_desc desc, uint8_
 /* Common function for optimized message (log with 0-2 arguments) which is used in
  * case when STMESP is not yet ready.
  */
-static inline uint32_t *early_msg_start(uint32_t level, const void *source,
-					uint32_t package_hdr, const char *fmt)
+static inline uint32_t *early_msg_start(uint32_t level, const void *source, uint32_t package_hdr,
+					const char *fmt)
 {
 	union stm_log_dict_hdr dict_desc = DICT_HDR_INITIALIZER(level, get_source_id(source), 0);
 	uint32_t fmt32 = (uint32_t)fmt;
@@ -398,8 +398,8 @@ static inline uint32_t *early_msg_start(uint32_t level, const void *source,
 }
 
 /* Common function for optimized message (log with 0-2 arguments) which writes to STMESP */
-static inline void msg_start(STMESP_Type *stm_esp, uint32_t level,
-			     const void *source, uint32_t package_hdr, const char *fmt)
+static inline void msg_start(STMESP_Type *stm_esp, uint32_t level, const void *source,
+			     uint32_t package_hdr, const char *fmt)
 
 {
 	union stm_log_dict_hdr dict_desc = DICT_HDR_INITIALIZER(level, get_source_id(source), 0);


### PR DESCRIPTION
Fixes for:
- unaligned access in STM frontend (RISCV only)
- ETR processing hanging when there is an incomplete message in the buffer