### PR TITLE
soc: nordic: nrf54l: integrate normal voltage mode fixes

### DIFF
--- a/soc/nordic/nrf54l/Kconfig
+++ b/soc/nordic/nrf54l/Kconfig
@@ -77,6 +77,9 @@ config SOC_NRF_FORCE_CONSTLAT
 	  and predictable latency will be at the cost of having increased power consumption.
 
 config SOC_NRF54L_NORMAL_VOLTAGE_MODE
+	select DEPRECATED
+	help
+	  This mode is deprecated and shall no longer be used.
 	bool "NRF54L Normal Voltage Mode."
 
 if NRF_GRTC_TIMER

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -154,10 +154,6 @@ static inline void power_and_clock_configuration(void)
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
 #endif
 
-	if (IS_ENABLED(CONFIG_SOC_NRF54L_NORMAL_VOLTAGE_MODE)) {
-		nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MEDIUM, false);
-	}
-
 #if defined(CONFIG_ELV_GRTC_LFXO_ALLOWED)
 	nrf_regulators_elv_mode_allow_set(NRF_REGULATORS, NRF_REGULATORS_ELV_ELVGRTCLFXO_MASK);
 #endif /* CONFIG_ELV_GRTC_LFXO_ALLOWED */

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: d4030afcc0befef645eda11e82c0d7c0e1d604f1
+      revision: pull/216/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
MDK 8.67.0 deprecates normal voltage mode for nRF54L, so it should no longer be used by the end users.