### PR TITLE
[nrf fromlist] manifest: update hal_nordic for normal voltage mode fix for NCS 2.7.0

### DIFF
--- a/soc/nordic/nrf54l/Kconfig
+++ b/soc/nordic/nrf54l/Kconfig
@@ -59,6 +59,9 @@ config SOC_NRF54L_VREG_MAIN_DCDC
 	  To enable, an inductor must be connected to the DC/DC converter pin.
 
 config SOC_NRF54L_NORMAL_VOLTAGE_MODE
+	select DEPRECATED
+	help
+	  This mode is deprecated and shall no longer be used.
 	bool "NRF54L Normal Voltage Mode."
 
 if NRF_GRTC_TIMER

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -153,10 +153,6 @@ static int nordicsemi_nrf54l_init(void)
 		nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
 	}
 
-	if (IS_ENABLED(CONFIG_SOC_NRF54L_NORMAL_VOLTAGE_MODE)) {
-		nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MEDIUM, false);
-	}
-
 #if defined(CONFIG_ELV_GRTC_LFXO_ALLOWED)
 	nrf_regulators_elv_mode_allow_set(NRF_REGULATORS, NRF_REGULATORS_ELV_ELVGRTCLFXO_MASK);
 #endif /* CONFIG_ELV_GRTC_LFXO_ALLOWED */

--- a/west.yml
+++ b/west.yml
@@ -183,7 +183,8 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: ab5cb2e2faeb1edfad7a25286dcb513929ae55da
+      url: https://github.com/nrfconnect/sdk-hal_nordic
+      revision: 3e3ecc1483f221455dfd7333474ed3d3c5192844
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Normal voltage mode fix is part of MDK 8.67.0.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/78643