### PR TITLE
[nrf noup] Sysbuild support for MCUboot crypto backend selection

### DIFF
--- a/share/sysbuild/images/bootloader/Kconfig
+++ b/share/sysbuild/images/bootloader/Kconfig
@@ -55,6 +55,35 @@ config BOOT_SIGNATURE_TYPE_ED25519
 
 endchoice
 
+choice BOOT_CRYPTO_LIBRARY
+	prompt "Library used by cryptographic functions of MCUboot"
+	default BOOT_CRYPTO_LIBRARY_DEFAULT
+
+config BOOT_CRYPTO_LIBRARY_PSA
+	bool "Enforce use of PSA as cryptographic library"
+
+config BOOT_CRYPTO_LIBRARY_DEFAULT
+	bool "Use whatever library used, by default, to support selected algorithm"
+
+endchoice
+
+# Dependencies that are required by BOOT_CRYPTO_LIBRARY_PSA in contest of sdk-nrf
+if BOOT_CRYPTO_LIBRARY_PSA
+
+config MBEDTLS
+	bool
+	default n
+
+config MBEDTLS_PSA_CRYPTO_C
+	bool
+	default y
+
+config NRF_SECURITY
+	bool
+	default y
+
+endif
+
 config BOOT_SIGNATURE_KEY_FILE
 	string "Signing PEM key file" if !BOOT_SIGNATURE_TYPE_NONE
 	default "$(ZEPHYR_MCUBOOT_MODULE_DIR)/root-ec-p256.pem" if BOOT_SIGNATURE_TYPE_ECDSA_P256


### PR DESCRIPTION
The commit adds support for selecting MCUboot crypto backend, when building with sysbuild.

This currently adds two options:
 - SB_CONFIG_BOOT_CRYPTO_LIBRARY_DEFAULT -- which keeps current behaviour where a library is selected depending on preferred signature method
 - SB_CONFIG_BOOT_CRYPTO_LIBRARY_PSA -- enforces usage of PSA, regardless of signature algorithm; the option currently supports the ED25519 only.