### PR TITLE
[nrf noup] samples: basic: blinky: align eGPIO overlay to L15 DK

### DIFF
--- a/samples/basic/blinky/boards/nrf54l15dk_nrf54l15_cpuapp_egpio.overlay
+++ b/samples/basic/blinky/boards/nrf54l15dk_nrf54l15_cpuapp_egpio.overlay
@@ -5,5 +5,5 @@
  */
 
 &led0 {
-	gpios = <&egpio 7 GPIO_ACTIVE_HIGH>;
+	gpios = <&egpio 9 GPIO_ACTIVE_HIGH>;
 };


### PR DESCRIPTION
Align eGPIO overlay to nRF54L15 DK.