### PR TITLE
Revert "[nrf noup] doc: extensions: domain: skip patching doxygen gro…

### DIFF
--- a/doc/_extensions/zephyr/domain.py
+++ b/doc/_extensions/zephyr/domain.py
@@ -339,7 +339,7 @@ def setup(app):
     app.add_post_transform(ProcessRelatedCodeSamplesNode)
 
     # monkey-patching of the DoxygenGroupDirective
-    # app.add_directive("doxygengroup", CustomDoxygenGroupDirective, override=True)
+    app.add_directive("doxygengroup", CustomDoxygenGroupDirective, override=True)
 
     return {
         "version": __version__,


### PR DESCRIPTION
…ups"

This reverts commit a3c63a400ba857ee6b73397562454c90203c2850.

This is no longer needed as NCS no longer uses breathe.