### PR TITLE
logging: Fix case where logging strings were not stripped from the binary when dictionary logging was used

### DIFF
--- a/include/zephyr/logging/log_output.h
+++ b/include/zephyr/logging/log_output.h
@@ -190,11 +190,34 @@ void log_output_msg_syst_process(const struct log_output *log_output,
  */
 void log_output_dropped_process(const struct log_output *output, uint32_t cnt);
 
+/** @brief Write to the output buffer.
+ *
+ * @param outf Output function.
+ * @param buf  Buffer.
+ * @param len  Buffer length.
+ * @param ctx  Context passed to the %p outf.
+ */
+static inline void log_output_write(log_output_func_t outf, uint8_t *buf, size_t len, void *ctx)
+{
+	int processed;
+
+	while (len != 0) {
+		processed = outf(buf, len, ctx);
+		len -= processed;
+		buf += processed;
+	}
+}
+
 /** @brief Flush output buffer.
  *
  * @param output Pointer to the log output instance.
  */
-void log_output_flush(const struct log_output *output);
+static inline void log_output_flush(const struct log_output *output)
+{
+	log_output_write(output->func, output->buf, output->control_block->offset,
+			 output->control_block->ctx);
+	output->control_block->offset = 0;
+}
 
 /** @brief Function for setting user context passed to the output function.
  *

--- a/subsys/logging/Kconfig.template.log_format_config
+++ b/subsys/logging/Kconfig.template.log_format_config
@@ -7,6 +7,7 @@ choice "LOG_BACKEND_$(backend)_OUTPUT"
 
 config LOG_BACKEND_$(backend)_OUTPUT_TEXT
 	bool "Text"
+	select LOG_OUTPUT
 	help
 	  Output in text.
 

--- a/subsys/logging/backends/CMakeLists.txt
+++ b/subsys/logging/backends/CMakeLists.txt
@@ -74,3 +74,8 @@ zephyr_sources_ifdef(
   CONFIG_LOG_BACKEND_IPC_SERVICE
   log_backend_ipc_service.c
 )
+
+zephyr_sources_ifdef(
+  CONFIG_LOG_BACKEND_SEMIHOST
+  log_backend_semihost.c
+)

--- a/subsys/logging/backends/Kconfig
+++ b/subsys/logging/backends/Kconfig
@@ -16,5 +16,6 @@ rsource "Kconfig.swo"
 rsource "Kconfig.uart"
 rsource "Kconfig.xtensa_sim"
 rsource "Kconfig.multidomain"
+rsource "Kconfig.semihost"
 
 endmenu

--- a/subsys/logging/backends/Kconfig.adsp
+++ b/subsys/logging/backends/Kconfig.adsp
@@ -4,7 +4,6 @@
 config LOG_BACKEND_ADSP
 	bool "Intel ADSP buffer backend"
 	depends on SOC_FAMILY_INTEL_ADSP
-	select LOG_OUTPUT
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help
 	  Enable backend for the host trace protocol of the Intel ADSP

--- a/subsys/logging/backends/Kconfig.adsp_mtrace
+++ b/subsys/logging/backends/Kconfig.adsp_mtrace
@@ -4,7 +4,6 @@
 config LOG_BACKEND_ADSP_MTRACE
 	bool "Intel ADSP mtrace backend"
 	depends on SOC_FAMILY_INTEL_ADSP
-	select LOG_OUTPUT
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help
 	  Provide a logging backend which writes to SRAM window

--- a/subsys/logging/backends/Kconfig.ble
+++ b/subsys/logging/backends/Kconfig.ble
@@ -5,7 +5,6 @@ config LOG_BACKEND_BLE
 	bool "Bluetooth Low Energy (BLE) backend"
 	depends on BT
 	depends on LOG_PROCESS_THREAD_STACK_SIZE>=2048
-	select LOG_OUTPUT
 	select EXPERIMENTAL
 	help
 	  Backend that sends log messages over Bluetooth LE Notifications. This

--- a/subsys/logging/backends/Kconfig.efi_console
+++ b/subsys/logging/backends/Kconfig.efi_console
@@ -4,7 +4,6 @@
 config LOG_BACKEND_EFI_CONSOLE
 	bool "EFI_CONSOLE backend"
 	depends on X86_EFI_CONSOLE
-	select LOG_OUTPUT
 	default y if !UART_CONSOLE
 	help
 	  When enabled backend is using EFI CONSOLE to output logs.

--- a/subsys/logging/backends/Kconfig.fs
+++ b/subsys/logging/backends/Kconfig.fs
@@ -4,7 +4,6 @@
 config LOG_BACKEND_FS
 	bool "File system backend"
 	depends on FILE_SYSTEM
-	select LOG_OUTPUT
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help
 	  When enabled, backend is using the configured file system to output logs.

--- a/subsys/logging/backends/Kconfig.native_posix
+++ b/subsys/logging/backends/Kconfig.native_posix
@@ -5,7 +5,6 @@ config LOG_BACKEND_NATIVE_POSIX
 	bool "Native backend"
 	depends on ARCH_POSIX
 	default y
-	select LOG_OUTPUT
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help
 	  Enable backend in native_posix

--- a/subsys/logging/backends/Kconfig.net
+++ b/subsys/logging/backends/Kconfig.net
@@ -6,7 +6,6 @@
 config LOG_BACKEND_NET
 	bool "Networking backend"
 	depends on NETWORKING && (NET_UDP || NET_TCP) && !LOG_MODE_IMMEDIATE
-	select LOG_OUTPUT
 	help
 	  Send syslog messages to network server.
 	  See RFC 5424 (syslog protocol) and RFC 5426 (syslog over UDP) and

--- a/subsys/logging/backends/Kconfig.rtt
+++ b/subsys/logging/backends/Kconfig.rtt
@@ -6,7 +6,6 @@ config LOG_BACKEND_RTT
 	depends on USE_SEGGER_RTT
 	default y if !SHELL_BACKEND_RTT
 	select SEGGER_RTT_CUSTOM_LOCKING
-	select LOG_OUTPUT
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help
 	  When enabled, backend will use RTT for logging. This backend works on a per

--- a/subsys/logging/backends/Kconfig.semihost
+++ b/subsys/logging/backends/Kconfig.semihost
@@ -1,0 +1,30 @@
+# Copyright (c) 2024 Contributors to the logging subsystem.
+# SPDX-License-Identifier: Apache-2.0
+
+config LOG_BACKEND_SEMIHOST
+	bool "Semihost as backend"
+	depends on SEMIHOST
+	select LOG_OUTPUT
+	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
+	help
+	  Enable backend in semihost (using host stdout)
+
+if LOG_BACKEND_SEMIHOST
+
+config LOG_BACKEND_SEMIHOST_BUFFER_SIZE
+	int "Size of reserved up-buffer for logger output."
+	default 256
+	help
+	  Specify reserved size of up-buffer used for logger output.
+
+config LOG_BACKEND_SEMIHOST_AUTOSTART
+	bool "Autostart semihost backend"
+	default y
+	help
+	  Enable semihost backend to start automatically.
+
+backend = SEMIHOST
+backend-str = semihost
+source "subsys/logging/Kconfig.template.log_format_config"
+
+endif # LOG_BACKEND_SEMIHOST

--- a/subsys/logging/backends/Kconfig.semihost
+++ b/subsys/logging/backends/Kconfig.semihost
@@ -4,7 +4,6 @@
 config LOG_BACKEND_SEMIHOST
 	bool "Semihost as backend"
 	depends on SEMIHOST
-	select LOG_OUTPUT
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help
 	  Enable backend in semihost (using host stdout)

--- a/subsys/logging/backends/Kconfig.spinel
+++ b/subsys/logging/backends/Kconfig.spinel
@@ -5,7 +5,6 @@ config LOG_BACKEND_SPINEL
 	bool "OpenThread dedicated Spinel protocol backend"
 	depends on !LOG_BACKEND_UART
 	depends on NET_L2_OPENTHREAD
-	select LOG_OUTPUT
 	help
 	  When enabled, backend will use OpenThread dedicated SPINEL protocol for logging.
 	  This protocol is byte oriented and wraps given messages into serial frames.

--- a/subsys/logging/backends/Kconfig.swo
+++ b/subsys/logging/backends/Kconfig.swo
@@ -4,7 +4,6 @@
 config LOG_BACKEND_SWO
 	bool "Serial Wire Output (SWO) backend"
 	depends on HAS_SWO
-	select LOG_OUTPUT
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help
 	  When enabled, backend will use SWO for logging.

--- a/subsys/logging/backends/Kconfig.uart
+++ b/subsys/logging/backends/Kconfig.uart
@@ -5,7 +5,6 @@ config LOG_BACKEND_UART
 	bool "UART backend"
 	depends on UART_CONSOLE
 	default y if !SHELL_BACKEND_SERIAL && !SHELL_BACKEND_RTT
-	select LOG_OUTPUT
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help
 	  When enabled backend is using UART to output logs.

--- a/subsys/logging/backends/Kconfig.xtensa_sim
+++ b/subsys/logging/backends/Kconfig.xtensa_sim
@@ -5,7 +5,6 @@ config LOG_BACKEND_XTENSA_SIM
 	bool "Xtensa simulator backend"
 	depends on SOC_XTENSA_SAMPLE_CONTROLLER || SOC_XTENSA_DC233C || SOC_FAMILY_INTEL_ADSP
 	default y if SOC_XTENSA_SAMPLE_CONTROLLER || SOC_XTENSA_DC233C
-	select LOG_OUTPUT
 	select LOG_BACKEND_SUPPORTS_FORMAT_TIMESTAMP
 	help
 	  Enable backend in xtensa simulator

--- a/subsys/logging/backends/log_backend_semihost.c
+++ b/subsys/logging/backends/log_backend_semihost.c
@@ -1,0 +1,71 @@
+/* Copyright (c) 2024 Contributors to the logging subsystem.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdio.h>
+#include <stddef.h>
+#include <zephyr/logging/log_backend.h>
+#include <zephyr/logging/log_backend_std.h>
+#include <zephyr/logging/log_core.h>
+#include <zephyr/logging/log_output.h>
+#include <zephyr/arch/common/semihost.h>
+
+static uint8_t buf[CONFIG_LOG_BACKEND_SEMIHOST_BUFFER_SIZE];
+static uint32_t log_format_current = CONFIG_LOG_BACKEND_SEMIHOST_OUTPUT_DEFAULT;
+
+static int char_out(uint8_t *data, size_t length, void *ctx)
+{
+	ARG_UNUSED(ctx);
+#define SEMIHOST_STDOUT (1)
+	int ret = semihost_write(SEMIHOST_STDOUT, data, length);
+
+	if (ret) {
+		return ret;
+	}
+
+	return length;
+}
+
+LOG_OUTPUT_DEFINE(log_output_semihost, char_out, buf, sizeof(buf));
+
+static void panic(struct log_backend const *const backend)
+{
+	ARG_UNUSED(backend);
+
+	log_output_flush(&log_output_semihost);
+}
+
+static void dropped(const struct log_backend *const backend, uint32_t cnt)
+{
+	ARG_UNUSED(backend);
+
+	log_output_dropped_process(&log_output_semihost, cnt);
+}
+
+static void process(const struct log_backend *const backend, union log_msg_generic *msg)
+{
+	ARG_UNUSED(backend);
+
+	uint32_t flags = log_backend_std_get_flags();
+
+	log_format_func_t log_output_func = log_format_func_t_get(log_format_current);
+
+	log_output_func(&log_output_semihost, &msg->log, flags);
+}
+
+static int format_set(const struct log_backend *const backend, uint32_t log_type)
+{
+	ARG_UNUSED(backend);
+
+	log_format_current = log_type;
+	return 0;
+}
+
+const struct log_backend_api log_backend_semihost_api = {
+	.process = process,
+	.panic = panic,
+	.dropped = IS_ENABLED(CONFIG_LOG_MODE_IMMEDIATE) ? NULL : dropped,
+	.format_set = format_set,
+};
+
+LOG_BACKEND_DEFINE(log_backend_semihost, log_backend_semihost_api,
+		   IS_ENABLED(CONFIG_LOG_BACKEND_SEMIHOST_AUTOSTART));

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -148,28 +148,6 @@ static int print_formatted(const struct log_output *output,
 	return length;
 }
 
-static void buffer_write(log_output_func_t outf, uint8_t *buf, size_t len,
-			 void *ctx)
-{
-	int processed;
-
-	while (len != 0) {
-		processed = outf(buf, len, ctx);
-		len -= processed;
-		buf += processed;
-	}
-}
-
-
-void log_output_flush(const struct log_output *output)
-{
-	buffer_write(output->func, output->buf,
-		     output->control_block->offset,
-		     output->control_block->ctx);
-
-	output->control_block->offset = 0;
-}
-
 static inline bool is_leap_year(uint32_t year)
 {
 	return (((year % 4 == 0) && (year % 100 != 0)) || (year % 400 == 0));
@@ -741,11 +719,9 @@ void log_output_dropped_process(const struct log_output *output, uint32_t cnt)
 	cnt = MIN(cnt, 9999);
 	len = snprintk(buf, sizeof(buf), "%d", cnt);
 
-	buffer_write(outf, (uint8_t *)prefix, sizeof(prefix) - 1,
-		     output->control_block->ctx);
-	buffer_write(outf, buf, len, output->control_block->ctx);
-	buffer_write(outf, (uint8_t *)postfix, sizeof(postfix) - 1,
-		     output->control_block->ctx);
+	log_output_write(outf, (uint8_t *)prefix, sizeof(prefix) - 1, output->control_block->ctx);
+	log_output_write(outf, buf, len, output->control_block->ctx);
+	log_output_write(outf, (uint8_t *)postfix, sizeof(postfix) - 1, output->control_block->ctx);
 }
 
 void log_output_timestamp_freq_set(uint32_t frequency)

--- a/subsys/logging/log_output_dict.c
+++ b/subsys/logging/log_output_dict.c
@@ -12,18 +12,6 @@
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util.h>
 
-static void buffer_write(log_output_func_t outf, uint8_t *buf, size_t len,
-			 void *ctx)
-{
-	int processed;
-
-	do {
-		processed = outf(buf, len, ctx);
-		len -= processed;
-		buf += processed;
-	} while (len != 0);
-}
-
 void log_dict_output_msg_process(const struct log_output *output,
 				 struct log_msg *msg, uint32_t flags)
 {
@@ -44,19 +32,19 @@ void log_dict_output_msg_process(const struct log_output *output,
 					log_const_source_id(source)) :
 				0U;
 
-	buffer_write(output->func, (uint8_t *)&output_hdr, sizeof(output_hdr),
-		     (void *)output->control_block->ctx);
+	log_output_write(output->func, (uint8_t *)&output_hdr, sizeof(output_hdr),
+			 (void *)output->control_block->ctx);
 
 	size_t len;
 	uint8_t *data = log_msg_get_package(msg, &len);
 
 	if (len > 0U) {
-		buffer_write(output->func, data, len, (void *)output->control_block->ctx);
+		log_output_write(output->func, data, len, (void *)output->control_block->ctx);
 	}
 
 	data = log_msg_get_data(msg, &len);
 	if (len > 0U) {
-		buffer_write(output->func, data, len, (void *)output->control_block->ctx);
+		log_output_write(output->func, data, len, (void *)output->control_block->ctx);
 	}
 
 	log_output_flush(output);
@@ -69,6 +57,6 @@ void log_dict_output_dropped_process(const struct log_output *output, uint32_t c
 	msg.type = MSG_DROPPED_MSG;
 	msg.num_dropped_messages = MIN(cnt, 9999);
 
-	buffer_write(output->func, (uint8_t *)&msg, sizeof(msg),
-		     (void *)output->control_block->ctx);
+	log_output_write(output->func, (uint8_t *)&msg, sizeof(msg),
+			 (void *)output->control_block->ctx);
 }


### PR DESCRIPTION
Cherry-picked from https://github.com/zephyrproject-rtos/zephyr/pull/79506