### PR TITLE
[nrf fromlist] susbys/dfu/img_util: refined ERASE PROGRESSIVELY imple…

### DIFF
--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -68,8 +68,7 @@ config IMG_BLOCK_BUF_SIZE
 
 config IMG_ERASE_PROGRESSIVELY
 	bool "Erase flash progressively when receiving new firmware"
-	select STREAM_FLASH_ERASE
-	depends on FLASH_HAS_EXPLICIT_ERASE
+	select STREAM_FLASH_ERASE if FLASH_HAS_EXPLICIT_ERASE
 	help
 	  If enabled, flash is erased as necessary when receiving new firmware,
 	  instead of erasing the whole image slot at once. This is necessary

--- a/subsys/dfu/img_util/flash_img.c
+++ b/subsys/dfu/img_util/flash_img.c
@@ -56,27 +56,9 @@ int flash_img_buffered_write(struct flash_img_context *ctx, const uint8_t *data,
 #ifdef CONFIG_IMG_ERASE_PROGRESSIVELY
 	ssize_t status_offset = boot_get_trailer_status_offset(
 		ctx->flash_area->fa_size);
-
-#ifdef CONFIG_STREAM_FLASH_ERASE
-	const struct flash_parameters *fparams =
-		flash_get_parameters(flash_area_get_device(ctx->flash_area));
-
-	if ((flash_params_get_erase_cap(fparams) & FLASH_ERASE_C_EXPLICIT)) {
-		/* use pistine-page-erase procedure for a device which needs it */
-		rc = stream_flash_erase_page(&ctx->stream,
-					ctx->flash_area->fa_off +
-					status_offset);
-	} else
-#endif
-	{
-		if (status_offset > stream_flash_bytes_written(&ctx->stream)) {
-			rc = flash_area_flatten(ctx->flash_area, status_offset,
-						ctx->flash_area->fa_off - status_offset);
-		} else {
-			rc = 0;
-		}
-	}
-
+	rc = stream_flash_erase_page(&ctx->stream,
+				ctx->flash_area->fa_off +
+				status_offset);
 	if (rc) {
 		return rc;
 	}


### PR DESCRIPTION
…mentation

Moved MCUboot trailer's status erase ahead any write operation.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/79152