### PR TITLE
[nrf fromlist] samples: boards: nordic: system_off: Add GRTC wakeup

### DIFF
--- a/samples/boards/nordic/system_off/Kconfig
+++ b/samples/boards/nordic/system_off/Kconfig
@@ -21,4 +21,10 @@ config APP_USE_RETAINED_MEM
 
 endchoice
 
+config GRTC_WAKEUP_ENABLE
+	bool "Use GRTC to wake up device from system off"
+	default n
+	help
+	  Switch wake up source from pressing sw0 button to GRTC
+
 source "Kconfig.zephyr"

--- a/samples/boards/nordic/system_off/sample.yaml
+++ b/samples/boards/nordic/system_off/sample.yaml
@@ -29,3 +29,9 @@ tests:
     extra_configs:
       - CONFIG_APP_USE_RETAINED_MEM=y
       - CONFIG_RETAINED_MEM=y
+  sample.boards.nrf.system_off.grtc_wakeup:
+    build_only: true
+    platform_allow:
+      - nrf54l15dk/nrf54l15/cpuapp
+    extra_configs:
+      - CONFIG_GRTC_WAKEUP_ENABLE=y


### PR DESCRIPTION
Extend system_off sample to use GRTC timer as a wake up source.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/79095