### PR TITLE
[nrf fromlist] ipc: icmsg: increase stack size of RX work queue thread

### DIFF
--- a/subsys/ipc/ipc_service/lib/Kconfig.icmsg
+++ b/subsys/ipc/ipc_service/lib/Kconfig.icmsg
@@ -51,7 +51,7 @@ if IPC_SERVICE_BACKEND_ICMSG_WQ_ENABLE
 
 config IPC_SERVICE_BACKEND_ICMSG_WQ_STACK_SIZE
 	int "Size of RX work queue stack"
-	default 1024
+	default 1280
 	help
 	  Size of stack used by work queue RX thread. This work queue is
 	  created to prevent notifying service users about received data


### PR DESCRIPTION
Increases default size of stack used by work queue RX thread from 1024 to ~~2048~~ **1280** to avoid memory issues.

After adding the buffer with the default size of 128 that is allocated on the thread's stack (see #77552), there is too little stack left during heavy stress.

I observed the issues on nRF54H. I was stressing the device (doing different 802.15.4 operations in a loop).
I was consistently seeing weird parameter addresses (ending in `z_arm_usage_fault`) in `icmsg_stack ()`.

Changing the stack size to **>1280** solves the issue. I believe that this should be set as default as this scenario applies to a wide range of users who are stressing the device enough.

Edit: The increase to 2048 is problematic due to memory constraints. Let's increase to 1280, which is just enough.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/79557