### PR TITLE
Pull in PRF-256 Implementation from upstream Hostap

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: 291e1cd0dfad83ec02826adf48dd6db69c3471ca
+      revision: 9896a2ea803ec62e0998c0e569f12af88537d647
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal

--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: f801840e246f47c9e895c540d0784f09726136c4
+      revision: 291e1cd0dfad83ec02826adf48dd6db69c3471ca
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal

--- a/west.yml
+++ b/west.yml
@@ -259,7 +259,7 @@ manifest:
         - hal
     - name: hostap
       path: modules/lib/hostap
-      revision: cbae0170437dbe196d436b2b53d7aefb97044b0c
+      revision: f801840e246f47c9e895c540d0784f09726136c4
     - name: libmetal
       revision: a6851ba6dba8c9e87d00c42f171a822f7a29639b
       path: modules/hal/libmetal


### PR DESCRIPTION
This Pulls in PRF-256 code from upstream hostap. Picking a SHA commit which is 1 level above my commit SHA for upstream as there is a CI build fix in this SHA for my commit.
