### PR TITLE
[nrf noup] ci: Fix manifest-pr-skip

### DIFF
--- a/.github/workflows/manifest-PR.yml
+++ b/.github/workflows/manifest-PR.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: handle manifest PR
+        if: >
+          !(contains(github.event.pull_request.title, 'manifest-pr-skip') ||
+            contains(github.event.pull_request.body, 'manifest-pr-skip'))
         uses: nrfconnect/action-manifest-pr@main
         with:
           token: ${{ secrets.NCS_GITHUB_TOKEN }}


### PR DESCRIPTION
fixup! [nrf noup] ci: Enable action-manifest-pr

When the PR title or body contains "manifest-pr-skip", this action will cancel itself, which results in a failure status. Use the same condition to skip the whole workflow instead.