### PR TITLE
 [nrf fromtree] scripts: logging: dictionary: Add uart support

### DIFF
--- a/scripts/logging/dictionary/log_parser.py
+++ b/scripts/logging/dictionary/log_parser.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright (c) 2021 Intel Corporation
+# Copyright (c) 2024 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -17,8 +18,7 @@ import logging
 import sys
 
 import dictionary_parser
-from dictionary_parser.log_database import LogDatabase
-
+import parserlib
 
 LOGGER_FORMAT = "%(message)s"
 logger = logging.getLogger("parser")
@@ -47,6 +47,7 @@ def read_log_file(args):
     Read the log from file
     """
     logdata = None
+    hexdata = ''
 
     # Open log data file for reading
     if args.hex:
@@ -100,7 +101,6 @@ def read_log_file(args):
 
     return logdata
 
-
 def main():
     """Main function of log parser"""
     args = parse_args()
@@ -112,36 +112,12 @@ def main():
     else:
         logger.setLevel(logging.INFO)
 
-    # Read from database file
-    database = LogDatabase.read_json_database(args.dbfile)
-    if database is None:
-        logger.error("ERROR: Cannot open database file: %s, exiting...", args.dbfile)
-        sys.exit(1)
-
     logdata = read_log_file(args)
     if logdata is None:
         logger.error("ERROR: cannot read log from file: %s, exiting...", args.logfile)
         sys.exit(1)
 
-    log_parser = dictionary_parser.get_parser(database)
-    if log_parser is not None:
-        logger.debug("# Build ID: %s", database.get_build_id())
-        logger.debug("# Target: %s, %d-bit", database.get_arch(), database.get_tgt_bits())
-        if database.is_tgt_little_endian():
-            logger.debug("# Endianness: Little")
-        else:
-            logger.debug("# Endianness: Big")
-
-        logger.debug("# Database version: %d", database.get_version())
-
-        ret = log_parser.parse_log_data(logdata, debug=args.debug)
-        if not ret:
-            logger.error("ERROR: there were error(s) parsing log data")
-            sys.exit(1)
-    else:
-        logger.error("ERROR: Cannot find a suitable parser matching database version!")
-        sys.exit(1)
-
+    parserlib.parser(logdata, args.dbfile, logger)
 
 if __name__ == "__main__":
     main()

--- a/scripts/logging/dictionary/log_parser_uart.py
+++ b/scripts/logging/dictionary/log_parser_uart.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Log Parser for Dictionary-based Logging
+
+This uses the JSON database file to decode the binary
+log data taken directly from input serialport and print
+the log messages.
+"""
+
+import serial
+import time
+import argparse
+import logging
+import sys
+
+import parserlib
+
+LOGGER_FORMAT = "%(message)s"
+logger = logging.getLogger("parser")
+
+def parse_args():
+    """Parse command line arguments"""
+    argparser = argparse.ArgumentParser(allow_abbrev=False)
+
+    argparser.add_argument("dbfile", help="Dictionary Logging Database file")
+    argparser.add_argument("serialPort", help="Port where the logs are generated")
+    argparser.add_argument("baudrate", help="Serial Port baud rate")
+    argparser.add_argument("--debug", action="store_true",
+                           help="Print extra debugging information")
+
+    return argparser.parse_args()
+
+def main():
+    """function of serial parser"""
+    args = parse_args()
+
+    if args.dbfile is None or '.json' not in args.dbfile:
+        logger.error("ERROR: invalid log database path: %s, exiting...", args.dbfile)
+        sys.exit(1)
+
+    logging.basicConfig(format=LOGGER_FORMAT)
+
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
+
+    # Parse the log every second from serial port
+    with serial.Serial(args.serialPort, args.baudrate) as ser:
+        ser.timeout = 2
+        while True:
+            size = ser.inWaiting()
+            if size:
+                data = ser.read(size)
+                parserlib.parser(data, args.dbfile, logger)
+            time.sleep(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/logging/dictionary/parserlib.py
+++ b/scripts/logging/dictionary/parserlib.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2021 Intel Corporation
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Parser library for Dictionary-based Logging
+
+This library along with dictionary_parser converts the
+input binary data to the log using log database.
+"""
+import sys
+import logging
+
+import dictionary_parser
+from dictionary_parser.log_database import LogDatabase
+
+def parser(logdata, dbfile, logger):
+    """function of serial parser"""
+    # Read from database file
+    database = LogDatabase.read_json_database(dbfile)
+
+    if not isinstance(logger, logging.Logger):
+        raise ValueError("Invalid logger instance. Please configure the logger!")
+
+    if database is None:
+        logger.error("ERROR: Cannot open database file:  exiting...")
+        sys.exit(1)
+
+    if logdata is None:
+        logger.error("ERROR: cannot read log from file:  exiting...")
+        sys.exit(1)
+
+    log_parser = dictionary_parser.get_parser(database)
+    if log_parser is not None:
+        logger.debug("# Build ID: %s", database.get_build_id())
+        logger.debug("# Target: %s, %d-bit", database.get_arch(), database.get_tgt_bits())
+        if database.is_tgt_little_endian():
+            logger.debug("# Endianness: Little")
+        else:
+            logger.debug("# Endianness: Big")
+
+        ret = log_parser.parse_log_data(logdata)
+        if not ret:
+            logger.error("ERROR: there were error(s) parsing log data")
+            sys.exit(1)
+    else:
+        logger.error("ERROR: Cannot find a suitable parser matching database version!")


### PR DESCRIPTION
This commit adds support to dictionary logging to parse binary data directly from input serial and generate the ascii logs.

Signed-off-by: Kumar Siddaramayya <harish.kumar@nordicsemi.no>
(cherry picked from commit a899deda2b0f53802cd232e0cb0f537167571f28)