### PR TITLE
[nrf fromtree] drivers: nrf_qspi_nor: Fix build without multithreading

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -487,7 +487,9 @@ static int qspi_wait_while_writing(const struct device *dev, k_timeout_t poll_pe
 	int rc;
 
 	do {
+#ifdef CONFIG_MULTITHREADING
 		k_sleep(poll_period);
+#endif
 		rc = qspi_rdsr(dev, 1);
 	} while ((rc >= 0)
 		 && ((rc & SPI_NOR_WIP_BIT) != 0U));

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -488,7 +488,9 @@ static int qspi_wait_while_writing(const struct device *dev, k_timeout_t poll_pe
 
 	do {
 #ifdef CONFIG_MULTITHREADING
-		k_sleep(poll_period);
+		if (!K_TIMEOUT_EQ(poll_period, K_NO_WAIT)) {
+			k_sleep(poll_period);
+		}
 #endif
 		rc = qspi_rdsr(dev, 1);
 	} while ((rc >= 0)


### PR DESCRIPTION
Commits cherry-picked from https://github.com/zephyrproject-rtos/zephyr/pull/79414.