### PR TITLE
[nrf fromtree] dts: common: nordic: nrf54l20: Adjust RAM size to 511k

### DIFF
--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -64,10 +64,10 @@
 
 		cpuapp_sram: memory@20000000 {
 			compatible = "mmio-sram";
-			reg = <0x20000000 DT_SIZE_K(512)>;
+			reg = <0x20000000 DT_SIZE_K(511)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x20000000 0x2f000>;
+			ranges = <0x0 0x20000000 0x7fc00>;
 		};
 
 		global_peripherals: peripheral@50000000 {


### PR DESCRIPTION
Last 1k is used for saving VPR context and shall not be exposed. Limiting RAM to 511k.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/79795