### PR TITLE
[nrf noup] drivers: entropy: Switch entropy driver in nRF54L20

### DIFF
--- a/drivers/entropy/Kconfig.nrf_prng
+++ b/drivers/entropy/Kconfig.nrf_prng
@@ -9,7 +9,7 @@ config FAKE_ENTROPY_NRF_PRNG
 	bool "A fake nRF entropy driver"
 	default y
 	depends on DT_HAS_NORDIC_ENTROPY_PRNG_ENABLED
-	depends on (SOC_SERIES_NRF54HX || SOC_SERIES_NRF92X)
+	depends on (SOC_SERIES_NRF54HX || SOC_SERIES_NRF92X || SOC_SERIES_NRF54LX)
 	select ENTROPY_HAS_DRIVER
 	help
 	  This is a super simple PRNG driver that can be used on nRF platforms that

--- a/dts/arm/nordic/nrf54l20_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l20_enga_cpuapp.dtsi
@@ -11,6 +11,10 @@ systick: &cpuapp_systick {};
 nvic: &cpuapp_nvic {};
 
 / {
+	chosen {
+		zephyr,entropy = &prng;
+	};
+
 	soc {
 		compatible = "simple-bus";
 		interrupt-parent = <&cpuapp_nvic>;
@@ -20,6 +24,11 @@ nvic: &cpuapp_nvic {};
 	psa_rng: psa-rng {
 		compatible = "zephyr,psa-crypto-rng";
 		status = "disabled";
+	};
+
+	prng: prng {
+		compatible = "nordic,entropy-prng";
+		status = "okay";
 	};
 };
 


### PR DESCRIPTION
nrf-squash! [nrf noup] entropy: Add fake entropy nRF PRNG driver

Change psa driver to nordic entropy. nRF54L20 needs it as well as nRF54H20.