### PR TITLE
[nrf noup] dts: Select SoftDevice Controller DTS binding as default

### DIFF
--- a/boards/nordic/nrf54l20pdk/nrf54l20_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l20pdk/nrf54l20_cpuapp_common.dtsi
@@ -18,7 +18,7 @@
 		zephyr,bt-c2h-uart = &uart20;
 		zephyr,flash-controller = &rram_controller;
 		zephyr,flash = &cpuapp_rram;
-		zephyr,bt-hci = &bt_hci_controller;
+		zephyr,bt-hci = &bt_hci_sdc;
 		zephyr,ieee802154 = &ieee802154;
 	};
 };
@@ -108,7 +108,7 @@
 	status = "okay";
 };
 
-&bt_hci_controller {
+&bt_hci_sdc {
 	status = "okay";
 };
 

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -168,9 +168,10 @@
 					status = "disabled";
 				};
 
-				/* Note: In the nRF Connect SDK the SoftDevice Controller
-				 * is added and set as the default Bluetooth Controller.
-				 */
+				bt_hci_sdc: bt_hci_sdc {
+					compatible = "nordic,bt-hci-sdc";
+					status = "disabled";
+				};
 				bt_hci_controller: bt_hci_controller {
 					compatible = "zephyr,bt-hci-ll-sw-split";
 					status = "disabled";


### PR DESCRIPTION
The Softdevice Controller is enabled using the device tree. Added a device tree node that enables the SDC and disables the Zephyr Bluetooth controller on nRF54L20.