### PR TITLE
[nrf fromtree] boards: nordic: Do not enable hw-flow-control on console

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -255,7 +255,6 @@ ipc0: &cpuapp_cpurad_ipc {
 	pinctrl-0 = <&uart136_default>;
 	pinctrl-1 = <&uart136_sleep>;
 	pinctrl-names = "default", "sleep";
-	hw-flow-control;
 };
 
 &gpio6 {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuppr.dts
@@ -48,7 +48,6 @@
 	pinctrl-0 = <&uart135_default>;
 	pinctrl-1 = <&uart135_sleep>;
 	pinctrl-names = "default", "sleep";
-	hw-flow-control;
 };
 
 &uart136 {

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -100,7 +100,6 @@ ipc0: &cpuapp_cpurad_ipc {
 	pinctrl-0 = <&uart135_default>;
 	pinctrl-1 = <&uart135_sleep>;
 	pinctrl-names = "default", "sleep";
-	hw-flow-control;
 };
 
 &uart136 {

--- a/boards/nordic/nrf54l15dk/nrf54l15_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l15_cpuapp_common.dtsi
@@ -87,7 +87,6 @@
 
 &uart20 {
 	status = "okay";
-	hw-flow-control;
 };
 
 &gpio0 {

--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
@@ -48,7 +48,6 @@
 
 &uart30 {
 	status = "okay";
-	hw-flow-control;
 };
 
 &gpio0 {

--- a/boards/nordic/nrf54l15pdk/nrf54l15_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l15pdk/nrf54l15_cpuapp_common.dtsi
@@ -87,7 +87,6 @@
 
 &uart20 {
 	status = "okay";
-	hw-flow-control;
 };
 
 &gpio0 {

--- a/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15pdk/nrf54l15pdk_nrf54l15_cpuflpr.dts
@@ -48,7 +48,6 @@
 
 &uart30 {
 	status = "okay";
-	hw-flow-control;
 };
 
 &gpio0 {

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
@@ -246,7 +246,6 @@ ipc0: &cpuapp_cpurad_ipc {
 	pinctrl-0 = <&uart136_default>;
 	pinctrl-1 = <&uart136_sleep>;
 	pinctrl-names = "default", "sleep";
-	hw-flow-control;
 };
 
 &gpio6 {

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuppr.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuppr.dts
@@ -49,7 +49,6 @@
 	pinctrl-0 = <&uart135_default>;
 	pinctrl-1 = <&uart135_sleep>;
 	pinctrl-names = "default", "sleep";
-	hw-flow-control;
 };
 
 &uart136 {

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpurad.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpurad.dts
@@ -105,7 +105,6 @@ ipc0: &cpuapp_cpurad_ipc {
 	pinctrl-0 = <&uart135_default>;
 	pinctrl-1 = <&uart135_sleep>;
 	pinctrl-names = "default", "sleep";
-	hw-flow-control;
 };
 
 &uart136 {


### PR DESCRIPTION
Like in all other legacy boards, hw-flow-control should not be enabled for console UART. With hw-flow-control sample stuck during printing some initial information and sample appears to be not working correctly unless com port is opened.

Signed-off-by: Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>
(cherry picked from commit 01f2740015fec36b1d9b000be95fd88ebb42edf0)