### PR TITLE
[nrf noup] mgmt: mcumgr: bootutil_hooks: nrf53_hooks: Handle sysbuild…

### DIFF
--- a/subsys/mgmt/mcumgr/bootutil_hooks/nrf53_hooks.c
+++ b/subsys/mgmt/mcumgr/bootutil_hooks/nrf53_hooks.c
@@ -8,10 +8,18 @@
 #include <zephyr/device.h>
 #include "bootutil/bootutil_public.h"
 
+#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
+/* Sysbuild */
+#define NET_CORE_IMAGE CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER
+#else
+/* Legacy child/parent */
+#define NET_CORE_IMAGE 1
+#endif
+
 int boot_read_swap_state_primary_slot_hook(int image_index,
 		struct boot_swap_state *state)
 {
-	if (image_index == 1) {
+	if (image_index == NET_CORE_IMAGE) {
 		/* Pretend that primary slot of image 1 unpopulated */
 		state->magic = BOOT_MAGIC_UNSET;
 		state->swap_type = BOOT_SWAP_TYPE_NONE;


### PR DESCRIPTION
… image ID

fixup! [nrf noup] mgmt/mcumgr: Bootutil hooks to handle image-1

Adds support for sysbuild assigned image IDs

manifest-pr-skip