### PR TITLE
[nrf fromtree] manifest: Update nRF hw models to latest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -300,7 +300,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: bf8e45bd1f870e49cc15392e045c28d54ea12285
+      revision: eeed2591d38e5e9bf89658df67555f2777249fc0
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: b735edbc739ad59156eb55bb8ce2583d74537719


### PR DESCRIPTION
Update the HW models module to:
eeed2591d38e5e9bf89658df67555f2777249fc0

eeed259 RADIO: Do not warn about TASK_RSSISTART during RXIDLE
565220e 54L15.mk: Fix flipper hal target name
bb8c6fd Makefile: Let's install libraries by default
6dbb843 RADIO: Implement immediate RSSI measurement when needed
3a5d567 RADIO: Allow triggering TASK_RSSISTART from register writes

Signed-off-by: Alberto Escolar Piedras <alberto.escolar.piedras@nordicsemi.no>
(cherry picked from commit fb010719ed5a1682bc946dd2153ef964b87ff2cc)