### PR TITLE
[nrf fromtree] boards: nordic: ipc node added dcache alignement

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
@@ -9,6 +9,7 @@
 		cpusec_cpuapp_ipc: ipc-1-2 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpusec_bellboard 12>,
 				 <&cpuapp_bellboard 0>;
 		};
@@ -16,6 +17,7 @@
 		cpusec_cpurad_ipc: ipc-1-3 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpusec_bellboard 18>,
 				 <&cpurad_bellboard 0>;
 		};
@@ -30,6 +32,7 @@
 		cpuapp_cpusys_ipc: ipc-2-12 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpuapp_bellboard 6>,
 				 <&cpusys_vevif 12>;
 		};
@@ -37,6 +40,7 @@
 		cpuapp_cpuppr_ipc: ipc-2-13 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpuapp_bellboard 13>,
 				 <&cpuppr_vevif 12>;
 		};
@@ -44,6 +48,7 @@
 		cpuapp_cpuflpr_ipc: ipc-2-14 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpuapp_bellboard 14>,
 				 <&cpuflpr_vevif 16>;
 		};
@@ -51,6 +56,7 @@
 		cpurad_cpusys_ipc: ipc-3-12 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpurad_bellboard 6>,
 				 <&cpusys_vevif 18>;
 		};

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-ipc_conf.dtsi
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-ipc_conf.dtsi
@@ -9,6 +9,7 @@
 		cpusec_cpuapp_ipc: ipc-1-2 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpusec_bellboard 12>,
 				 <&cpuapp_bellboard 0>;
 		};
@@ -16,6 +17,7 @@
 		cpusec_cpurad_ipc: ipc-1-3 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpusec_bellboard 18>,
 				 <&cpurad_bellboard 0>;
 		};
@@ -30,6 +32,7 @@
 		cpuapp_cpusys_ipc: ipc-2-12 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpuapp_bellboard 6>,
 				 <&cpusys_vevif 12>;
 		};
@@ -37,6 +40,7 @@
 		cpuapp_cpuppr_ipc: ipc-2-13 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpuapp_bellboard 13>,
 				 <&cpuppr_vevif 12>;
 		};
@@ -44,6 +48,7 @@
 		cpurad_cpusys_ipc: ipc-3-12 {
 			compatible = "zephyr,ipc-icmsg";
 			status = "disabled";
+			dcache-alignment = <32>;
 			mboxes = <&cpurad_bellboard 6>,
 				 <&cpusys_vevif 18>;
 		};


### PR DESCRIPTION
dcache-alignement needs to be defined for ipc to have consistent memory organization on both endpoints, when shared memory is cacheable. nrf54h20 and nrf9280 are using cacheable shared memory.
This is applied for ipc with icmsg backend.

Signed-off-by: Lukasz Stepnicki <lukasz.stepnicki@nordicsemi.no>
(cherry picked from commit 022122d659a7c10180b8a91c6a0b49874f2850fa)