### PR TITLE
Update hci_core.c

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2337,7 +2337,7 @@ static void send_cmd(void)
 
 	/* Wait until ncmd > 0 */
 	BT_DBG("calling sem_take_wait");
-	k_sem_take(&bt_dev.ncmd_sem, K_FOREVER);
+	k_sem_take(&bt_dev.ncmd_sem, K_NO_WAIT);
 
 	/* Clear out any existing sent command */
 	if (bt_dev.sent_cmd) {


### PR DESCRIPTION
Changed K_FOREVER to K_NO_WAIT in k_sem_take(&bt_dev.ncmd_sem, K_NO_WAIT); in static void send_cmd(void)

If I don't do this, then my program hits timeout:

SEGGER J-Link V7.94e - Real time terminal output
SEGGER J-Link (unknown) V1.0, SN=960000685
Process: JLink.exe
[00:00:00.372,467] <dbg> os: setup_thread_stack: stack 0x200199a0 for thread 0x2000e280: obj_size=4096 buf_start=0x200199a0  buf_size 4096 stack_ptr=0x2001a9a0
[00:00:00.388,397] <dbg> lpuart: api_rx_enable: RX: Enabling
[00:00:00.394,927] <dbg> os: setup_thread_stack: stack 0x200136b8 for thread 0x2000d320: obj_size=1304 buf_start=0x200136b8  buf_size 1304 stack_ptr=0x20013bd0
[00:00:00.410,552] <dbg> bt_hci_core: bt_hci_driver_register: Registered H:4
[00:00:00.418,518] <dbg> os: setup_thread_stack: stack 0x20016c60 for thread 0x2000c710: obj_size=1024 buf_start=0x20016c60  buf_size 1024 stack_ptr=0x20017060
[00:00:00.434,173] <dbg> os: z_impl_k_mutex_lock: 0x2000e1c8 took mutex 0x2000c7e8, count: 1, orig prio: 0
[00:00:00.444,854] <dbg> spi_nrfx_spim: spi_context_buffers_setup: tx_bufs 0x20019888 - rx_bufs 0x20019890 - 1
[00:00:00.455,871] <dbg> spi_nrfx_spim: spi_context_buffers_setup: current_tx 0x20019878 (1), current_rx 0x20019880 (1),[00:00:03.182,891] <inf> ble: Initializing Bluetooth..
[00:00:03.188,781] <dbg> os: z_impl_k_mutex_lock: 0x2000d230 took mutex 0x2000d034, count: 1, orig prio: 7
[00:00:03.199,584] <dbg> os: z_impl_k_mutex_lock: 0x2000d230 took mutex 0x2000e4bc, count: 1, orig prio: 7
[00:00:03.210,266] <dbg> fs_nvs: nvs_recover_last_ate: Recovering last ate from sector 0
[00:00:03.224,853] <dbg> os: z_impl_k_mutex_unlock: mutex 0x2000e4bc lock_count: 1
[00:00:03.233,306] <dbg> os: z_impl_k_mutex_unlock: new owner of mutex 0x2000e4bc: 0 (prio: -1000)
[00:00:03.243,194] <inf> fs_nvs: 2 Sectors of 4096 bytes
[00:00:03.249,267] <inf> fs_nvs: alloc wra: 0, fe8
[00:00:03.254,791] <inf> fs_nvs: data wra: 0, 0
[00:00:03.260,040] <dbg> settings: settings_nvs_backend_init: Initialized
[00:00:03.267,669] <dbg> os: z_impl_k_mutex_unlock: mutex 0x2000d034 lock_count: 1
[00:00:03.276,123] <dbg> os: z_impl_k_mutex_unlock: new owner of mutex 0x2000d034: 0 (prio: -1000)
[00:00:03.286,071] <dbg> os: setup_thread_stack: stack 0x20013bd0 for thread 0x2000d3f8: obj_size=4096 buf_start=0x20013bd0  buf_size 4096 stack_ptr=0x20014bd0
[00:00:03.301,940] <dbg> bt_hci_core: hci_tx_thread: Started
[00:00:03.308,380] <dbg> bt_hci_core: hci_tx_thread: Calling k_poll with 2 events
[00:00:03.316,802] <dbg> os: setup_thread_stack: stack 0x20014bd0 for thread 0x2000d4b0: obj_size=4096 buf_start=0x20014bd0  buf_size 4096 stack_ptr=0x20015bd0
[00:00:03.332,733] <dbg> bt_driver: h4_open: 
[00:00:03.337,829] <dbg> os: setup_thread_stack: stack 0x20015c60 for thread 0x2000dea0: obj_size=4096 buf_start=0x20015c60  buf_size 4096 stack_ptr=0x20016c60
[00:00:03.353,698] <dbg> bt_driver: rx_thread: started
[00:00:03.359,588] <dbg> bt_driver: rx_thread: rx.buf 0
[00:00:03.365,600] <dbg> bt_hci_core: bt_hci_cmd_create: opcode 0x0c03 param_len 0
[00:00:03.374,053] <dbg> bt_hci_core: bt_hci_cmd_create: buf 0x2001fc10
[00:00:03.381,500] <dbg> bt_hci_core: bt_hci_cmd_send_sync: buf 0x2001fc10 opcode 0x0c03 len 3
[00:00:03.391,082] <dbg> bt_hci_core: process_events: count 2
[00:00:03.397,613] <dbg> bt_hci_core: process_events: ev->state 4
[00:00:03.404,479] <dbg> bt_hci_core: send_cmd: calling net_buf_get
[00:00:03.411,560] <dbg> bt_hci_core: send_cmd: calling sem_take_wait
[00:00:03.418,823] <inf> main: ble_thread running
[00:00:03.425,140] <dbg> os: z_tick_sleep: thread 0x2000d230 for 327680 ticks
ASSERTION FAIL [err == 0] @ WEST_TOPDIR/zephyr/subsys/bluetooth/host/hci_core.c:333
        command opcode 0x0c03 timeout with err -11
[00:00:13.403,045] <err> os: r0/a1:  0x00000003  r1/a2:  0x20012965  r2/a3:  0x00000000
[00:00:13.412,231] <err> os: r3/a4:  0x00000003 r12/ip:  0x00000000 r14/lr:  0x0000e3c5
[00:00:13.421,386] <err> os:  xpsr:  0x01000000
[00:00:13.426,910] <err> os: Faulting instruction address (r15/pc): 0x0000e3d2
[00:00:13.435,272] <err> os: >>> ZEPHYR FATAL ERROR 3: Kernel oops on CPU 0
[00:00:13.443,359] <err> os: Current thread: 0x2000e280 (sysworkq)
[00:00:13.450,592] <err> os: Halting system
 
 The function "k_sem_take()" also mentions that if it is run from inside a ISR the option should always be  "K_NO_WAIT"
 
![image](https://github.com/user-attachments/assets/3fc09364-afb5-4c88-ad3b-1590c4c93127)
