### PR TITLE
[nrf fromtree] samples: icbmsg: Change regex for no_multithreading test

### DIFF
--- a/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
+++ b/samples/subsys/ipc/ipc_service/icmsg/sample.yaml
@@ -133,12 +133,12 @@ tests:
       type: multi_line
       ordered: false
       regex:
-        - "host: IPC-service HOST demo started"
-        - "host: Ep bounded"
-        - "host: Perform sends for"
-        - "host: Sent"
-        - "host: Received"
-        - "host: IPC-service HOST demo ended"
+        - "I: IPC-service HOST demo started"
+        - "I: Ep bounded"
+        - "I: Perform sends for"
+        - "I: Sent"
+        - "I: Received"
+        - "I: IPC-service HOST demo ended"
 
   sample.ipc.icbmsg.nrf54l15_remote_no_multithreading:
     platform_allow: nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
Change regex for no_multithreading test version for nRF54L15 platform. This needs to be changed because LOG is running in MINIMAL mode.

Signed-off-by: Jakub Zymelka <jakub.zymelka@nordicsemi.no>
(cherry picked from commit df201e4b4bc6b23d7d80b9b2298f4e6dfb87d47b)