### PR TITLE
[nrf noup] boards: nordic: Enable PSA RNG for secdom devices

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -27,7 +27,7 @@
 		zephyr,bt-hci = &bt_hci_ipc0;
 		nordic,802154-spinel-ipc = &ipc0;
 		zephyr,canbus = &can120;
-		zephyr,entropy = &prng;
+		zephyr,entropy = &psa_rng;
 	};
 
 	aliases {
@@ -109,8 +109,8 @@
 		};
 	};
 
-	prng: prng {
-		compatible = "nordic,entropy-prng";
+	psa_rng: psa-rng {
+		compatible = "zephyr,psa-crypto-rng";
 		status = "okay";
 	};
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad.dts
@@ -27,15 +27,16 @@
 		zephyr,ieee802154 = &cpurad_ieee802154;
 		zephyr,bt-hci-ipc = &ipc0;
 		nordic,802154-spinel-ipc = &ipc0;
-		zephyr,entropy = &prng;
-	};
-	prng: prng {
-		compatible = "nordic,entropy-prng";
-		status = "okay";
+		zephyr,entropy = &psa_rng;
 	};
 	aliases {
 		ipc-to-cpusys = &cpurad_cpusys_ipc;
 		resetinfo = &cpurad_resetinfo;
+	};
+
+	psa_rng: psa-rng {
+		compatible = "zephyr,psa-crypto-rng";
+		status = "okay";
 	};
 };
 

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp.dts
@@ -28,7 +28,7 @@
 		zephyr,bt-hci = &bt_hci_ipc0;
 		nordic,802154-spinel-ipc = &ipc0;
 		zephyr,canbus = &can120;
-		zephyr,entropy = &prng;
+		zephyr,entropy = &psa_rng;
 	};
 
 	aliases {
@@ -110,8 +110,8 @@
 		};
 	};
 
-	prng: prng {
-		compatible = "nordic,entropy-prng";
+	psa_rng: psa-rng {
+		compatible = "zephyr,psa-crypto-rng";
 		status = "okay";
 	};
 };


### PR DESCRIPTION
Noup since secdom is not available upstream.
This enables the PSA RNG as the default Zephyr entropy provider for the following secdom enabled targets:
nrf54h20_cpuapp and cpurad
nrf9280_cpuapp