### PR TITLE
[nrf fromlist] tests: drivers: i2s: Add overlay to support nRF54L15 DK

### DIFF
--- a/tests/drivers/i2s/i2s_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/i2s/i2s_api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* i2s-node0 is the transmitter/receiver */
+
+/ {
+	aliases {
+		i2s-node0 = &i2s20;
+	};
+};
+
+&pinctrl {
+	i2s20_default_alt: i2s20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(I2S_SCK_M, 1, 11)>,
+				<NRF_PSEL(I2S_LRCK_M, 1, 12)>,
+				<NRF_PSEL(I2S_SDOUT, 1, 8)>,
+				<NRF_PSEL(I2S_SDIN, 1, 9)>;
+		};
+	};
+};
+
+&i2s20 {
+	status = "okay";
+	pinctrl-0 = <&i2s20_default_alt>;
+	pinctrl-names = "default";
+};

--- a/tests/drivers/i2s/i2s_speed/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* i2s-node0 is the transmitter/receiver */
+
+/ {
+	aliases {
+		i2s-node0 = &i2s20;
+	};
+};
+
+&pinctrl {
+	i2s20_default_alt: i2s20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(I2S_SCK_M, 1, 11)>,
+				<NRF_PSEL(I2S_LRCK_M, 1, 12)>,
+				<NRF_PSEL(I2S_SDOUT, 1, 8)>,
+				<NRF_PSEL(I2S_SDIN, 1, 9)>;
+		};
+	};
+};
+
+&i2s20 {
+	status = "okay";
+	pinctrl-0 = <&i2s20_default_alt>;
+	pinctrl-names = "default";
+};


### PR DESCRIPTION
Add overlay to support nRF54L15 DK.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/79930/