### PR TITLE
[nrf fromlist] ipc: icbmsg: Reduce block alignment to 32-bits

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-ipc_conf.dtsi
@@ -22,6 +22,7 @@
 
 		cpuapp_cpurad_ipc: ipc-2-3 {
 			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
 			status = "disabled";
 			mboxes = <&cpuapp_bellboard 18>,
 				 <&cpurad_bellboard 12>;

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-ipc_conf.dtsi
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280-ipc_conf.dtsi
@@ -22,6 +22,7 @@
 
 		cpuapp_cpurad_ipc: ipc-2-3 {
 			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
 			status = "disabled";
 			mboxes = <&cpuapp_bellboard 18>,
 				 <&cpurad_bellboard 12>;

--- a/doc/services/ipc/ipc_service/backends/ipc_service_icbmsg.rst
+++ b/doc/services/ipc/ipc_service/backends/ipc_service_icbmsg.rst
@@ -40,11 +40,20 @@ Configuration
 The backend is configured using Kconfig and devicetree.
 When configuring the backend, do the following:
 
+* If at least one of the cores uses data cache on shared memory, set the ``dcache-alignment`` value.
+  This must be the largest value of the invalidation or the write-back size for both sides of the communication.
+  You can skip it if none of the communication sides is using data cache on shared memory.
 * Define two memory regions and assign them to ``tx-region`` and ``rx-region`` of an instance.
   Ensure that the memory regions used for data exchange are unique (not overlapping any other region) and accessible by both domains (or CPUs).
 * Define the number of allocable blocks for each region with ``tx-blocks`` and ``rx-blocks``.
 * Define MBOX devices for sending a signal that informs the other domain (or CPU) of the written data.
   Ensure that the other domain (or CPU) can receive the signal.
+
+.. caution::
+
+    Make sure that you set correct value of the ``dcache-alignment``.
+    At first, wrong value may not show any signs, which may give a false impression that everything works.
+    Unstable behavior will appear sooner or later.
 
 See the following configuration example for one of the instances:
 
@@ -63,6 +72,7 @@ See the following configuration example for one of the instances:
    ipc {
       ipc0: ipc0 {
          compatible = "zephyr,ipc-icbmsg";
+         dcache-alignment = <32>;
          tx-region = <&tx>;
          rx-region = <&rx>;
          tx-blocks = <16>;

--- a/doc/services/ipc/ipc_service/backends/ipc_service_icmsg.rst
+++ b/doc/services/ipc/ipc_service/backends/ipc_service_icmsg.rst
@@ -24,6 +24,9 @@ Configuration
 The  backend is configured via Kconfig and devicetree.
 When configuring the backend, do the following:
 
+* If at least one of the cores uses data cache on shared memory, set the ``dcache-alignment`` value.
+  This must be the largest value of the invalidation or the write-back size for both sides of the communication.
+  You can skip it if none of the communication sides is using data cache on shared memory.
 * Define two memory regions and assign them to ``tx-region`` and ``rx-region``
   of an instance. Ensure that the memory regions used for data exchange are
   unique (not overlapping any other region) and accessible by both domains
@@ -31,6 +34,12 @@ When configuring the backend, do the following:
 * Define MBOX devices which are used to send the signal that informs the other
   domain (or CPU) that data has been written. Ensure that the other domain
   (or CPU) is able to receive the signal.
+
+.. caution::
+
+    Make sure that you set correct value of the ``dcache-alignment``.
+    At first, wrong value may not show any signs, which may give a false impression that everything works.
+    Unstable behavior will appear sooner or later.
 
 See the following configuration example for one of the instances:
 
@@ -49,6 +58,7 @@ See the following configuration example for one of the instances:
       ipc {
          ipc0: ipc0 {
             compatible = "zephyr,ipc-icmsg";
+            dcache-alignment = <32>;
             tx-region = <&tx>;
             rx-region = <&rx>;
             mboxes = <&mbox 0>, <&mbox 1>;

--- a/dts/bindings/ipc/zephyr,ipc-icmsg.yaml
+++ b/dts/bindings/ipc/zephyr,ipc-icmsg.yaml
@@ -32,7 +32,7 @@ properties:
       For example:
         Side A: no data cache
         Side B: 32 Bytes write-back size, 16 Bytes invalidation size
-        dcache-alignment = 32; for both
+        dcache-alignment = <32>; for both
 
   mboxes:
     description: phandle to the MBOX controller (TX and RX are required)

--- a/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -23,6 +23,7 @@
 	ipc {
 		ipc0: ipc0 {
 			compatible = "zephyr,ipc-icmsg";
+			dcache-alignment = <32>;
 			tx-region = <&sram_tx>;
 			rx-region = <&sram_rx>;
 			mboxes = <&cpuapp_vevif_rx 20>, <&cpuapp_vevif_tx 21>;

--- a/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/boards/nrf54l15dk_nrf54l15_cpuapp_icbmsg.overlay
@@ -23,6 +23,7 @@
 	ipc {
 		ipc0: ipc0 {
 			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
 			tx-region = <&sram_tx>;
 			rx-region = <&sram_rx>;
 			tx-blocks = <16>;

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr.overlay
@@ -23,6 +23,7 @@
 	ipc {
 		ipc0: ipc0 {
 			compatible = "zephyr,ipc-icmsg";
+			dcache-alignment = <32>;
 			tx-region = <&sram_tx>;
 			rx-region = <&sram_rx>;
 			mboxes = <&cpuflpr_vevif_rx 21>, <&cpuflpr_vevif_tx 20>;

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf54l15dk_nrf54l15_cpuflpr_icbmsg.overlay
@@ -23,6 +23,7 @@
 	ipc {
 		ipc0: ipc0 {
 			compatible = "zephyr,ipc-icbmsg";
+			dcache-alignment = <32>;
 			tx-region = <&sram_tx>;
 			rx-region = <&sram_rx>;
 			tx-blocks = <18>;

--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -1434,11 +1434,11 @@ const static struct ipc_service_backend backend_ops = {
 	};										\
 	BUILD_ASSERT(IS_POWER_OF_TWO(GET_CACHE_ALIGNMENT(i)),				\
 		     "This module supports only power of two cache alignment");		\
-	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, tx, rx) > GET_CACHE_ALIGNMENT(i)) &&	\
+	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, tx, rx) >= GET_CACHE_ALIGNMENT(i)) &&	\
 		     (GET_BLOCK_SIZE_INST(i, tx, rx) <					\
 		      GET_MEM_SIZE_INST(i, tx)),					\
 		     "TX region is too small for provided number of blocks");		\
-	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, rx, tx) > GET_CACHE_ALIGNMENT(i)) &&	\
+	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, rx, tx) >= GET_CACHE_ALIGNMENT(i)) &&	\
 		     (GET_BLOCK_SIZE_INST(i, rx, tx) <					\
 		      GET_MEM_SIZE_INST(i, rx)),					\
 		     "RX region is too small for provided number of blocks");		\

--- a/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
+++ b/subsys/ipc/ipc_service/backends/ipc_icbmsg.c
@@ -1296,6 +1296,11 @@ const static struct ipc_service_backend backend_ops = {
 };
 
 /**
+ * Required block alignment.
+ */
+#define BLOCK_ALIGNMENT sizeof(uint32_t)
+
+/**
  * Number of bytes per each ICMsg message. It is used to calculate size of ICMsg area.
  */
 #define BYTES_PER_ICMSG_MESSAGE (ROUND_UP(sizeof(struct control_message),		\
@@ -1308,10 +1313,10 @@ const static struct ipc_service_backend backend_ops = {
 	(PBUF_HEADER_OVERHEAD(GET_CACHE_ALIGNMENT(i)) + 2 * BYTES_PER_ICMSG_MESSAGE)
 
 /**
- * Returns required block alignment for instance "i".
+ * Returns required data cache alignment for instance "i".
  */
 #define GET_CACHE_ALIGNMENT(i) \
-	MAX(sizeof(uint32_t), DT_INST_PROP_OR(i, dcache_alignment, 0))
+	MAX(BLOCK_ALIGNMENT, DT_INST_PROP_OR(i, dcache_alignment, 0))
 
 /**
  * Calculates minimum size required for ICMsg region for specific number of local
@@ -1319,9 +1324,9 @@ const static struct ipc_service_backend backend_ops = {
  * because it can hold data message for each local block and release message
  * for each remote block.
  */
-#define GET_ICMSG_MIN_SIZE(i, local_blocks, remote_blocks)				\
+#define GET_ICMSG_MIN_SIZE(i, local_blocks, remote_blocks) ROUND_UP(			\
 	(ICMSG_BUFFER_OVERHEAD(i) + BYTES_PER_ICMSG_MESSAGE *				\
-	 (local_blocks + remote_blocks))
+	 (local_blocks + remote_blocks)), GET_CACHE_ALIGNMENT(i))
 
 /**
  * Calculate aligned block size by evenly dividing remaining space after removing
@@ -1329,7 +1334,7 @@ const static struct ipc_service_backend backend_ops = {
  */
 #define GET_BLOCK_SIZE(i, total_size, local_blocks, remote_blocks) ROUND_DOWN(		\
 	((total_size) - GET_ICMSG_MIN_SIZE(i, (local_blocks), (remote_blocks))) /	\
-	(local_blocks), GET_CACHE_ALIGNMENT(i))
+	(local_blocks), BLOCK_ALIGNMENT)
 
 /**
  * Calculate offset where area for blocks starts which is just after the ICMsg.
@@ -1434,11 +1439,11 @@ const static struct ipc_service_backend backend_ops = {
 	};										\
 	BUILD_ASSERT(IS_POWER_OF_TWO(GET_CACHE_ALIGNMENT(i)),				\
 		     "This module supports only power of two cache alignment");		\
-	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, tx, rx) >= GET_CACHE_ALIGNMENT(i)) &&	\
+	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, tx, rx) >= BLOCK_ALIGNMENT) &&		\
 		     (GET_BLOCK_SIZE_INST(i, tx, rx) <					\
 		      GET_MEM_SIZE_INST(i, tx)),					\
 		     "TX region is too small for provided number of blocks");		\
-	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, rx, tx) >= GET_CACHE_ALIGNMENT(i)) &&	\
+	BUILD_ASSERT((GET_BLOCK_SIZE_INST(i, rx, tx) >= BLOCK_ALIGNMENT) &&		\
 		     (GET_BLOCK_SIZE_INST(i, rx, tx) <					\
 		      GET_MEM_SIZE_INST(i, rx)),					\
 		     "RX region is too small for provided number of blocks");		\


### PR DESCRIPTION
[nrf fromlist] ipc: icbmsg: Reduce block alignment to 32-bits

The ICBMsg backend divides its memory into
blocks. Each block is aligned to data cache
alignment. Is it not required, since adjacent
blocks has the same data flow direction (either
read-only or write-only). This commit changes
it to 32-bits making wasted memory significantly
reduced.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/79604

Depends on: https://github.com/nrfconnect/sdk-zephyr/pull/2154