### PR TITLE
[nrf noup]: Revert "[nrf fromtree] cmake: use the warnings_as_errors ...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,6 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,
 # Extra warnings options for twister run
 if (CONFIG_COMPILER_WARNINGS_AS_ERRORS)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
-  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:asm,warnings_as_errors>>)
   zephyr_link_libraries($<TARGET_PROPERTY:linker,warnings_as_errors>)
 endif()


### PR DESCRIPTION
flag for cpp files"

Some nRF Connect SDK samples are generating warnings for C++ code. nRF Connect SDK CI treats warnings as errors for code, but this was previous not active for C++ source code.

Therfore revert the upstream warning-as-errors flag for C++ code. Revert this commit when nRF Connect SDK C++ source code is clear from warnings.

This reverts commit f3e3cedba999b1c6364e97f6660490d297d45ea4.