### PR TITLE
[nrf fromlist] drivers: serial: uart_async_to_irq: Fix uart_irq_tx_co…

### DIFF
--- a/drivers/serial/uart_async_to_irq.c
+++ b/drivers/serial/uart_async_to_irq.c
@@ -284,7 +284,7 @@ void z_uart_async_to_irq_irq_rx_disable(const struct device *dev)
 /** Interrupt driven transfer complete function */
 int z_uart_async_to_irq_irq_tx_complete(const struct device *dev)
 {
-	return z_uart_async_to_irq_irq_tx_ready(dev);
+	return z_uart_async_to_irq_irq_tx_ready(dev) > 0 ? 1 : 0;
 }
 
 /** Interrupt driven receiver ready function */


### PR DESCRIPTION
…mplete

uart_irq_tx_complete is implemented by z_uart_async_to_irq_irq_tx_ready which changed recently (5bd53b6e2) to return positive value that may be bigger than 1. uart_irq_tx_complete shall not return value bigger than 1.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/issues/80355