### PR TITLE
[nrf fromlist] boards: nordic: Fix the label for nRF70 SR co-existence

### DIFF
--- a/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
+++ b/boards/nordic/nrf7002dk/nrf7002dk_nrf5340_cpunet.dts
@@ -82,7 +82,7 @@
 			   <21 0 &gpio1 3 0>;	/* D15 */
 	};
 
-	nrf70: coex {
+	nrf_radio_coex: coex {
 		status = "okay";
 		compatible = "nordic,nrf7002-coex";
 


### PR DESCRIPTION
The co-existence modules expect a common and fixed name, so, rename it to avoid churn.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/80474