### PR TITLE
[nrf noup] scripts: west_commands: runners: nrf: workarounds for SDFW…

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -273,6 +273,11 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
             if self.erase:
                 self.exec_op('erase', core='NRFDL_DEVICE_CORE_APPLICATION')
                 self.exec_op('erase', core='NRFDL_DEVICE_CORE_NETWORK')
+                # A reset is needed if repartitioning the device memory
+                self.reset_target()
+            else:
+                # Ensure that firmware is not executing while erasing/programming
+                self.exec_op("reset", option="RESET_VIA_SECDOM")
 
             # Manage SUIT artifacts.
             # This logic should be executed only once per build.
@@ -298,16 +303,8 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
                     self.op_program(app_root_envelope_hex_file, 'ERASE_NONE', None, defer=True, core='NRFDL_DEVICE_CORE_APPLICATION')
 
             if cpuapp:
-                if not self.erase and self.build_conf.getboolean('CONFIG_NRF_REGTOOL_GENERATE_UICR'):
-                    self.exec_op('erase', core='NRFDL_DEVICE_CORE_APPLICATION',
-                                 option={'chip_erase_mode': 'ERASE_UICR',
-                                         'qspi_erase_mode': 'ERASE_NONE'})
                 core = 'NRFDL_DEVICE_CORE_APPLICATION'
             elif cpurad:
-                if not self.erase and self.build_conf.getboolean('CONFIG_NRF_REGTOOL_GENERATE_UICR'):
-                    self.exec_op('erase', core='NRFDL_DEVICE_CORE_NETWORK',
-                                 option={'chip_erase_mode': 'ERASE_UICR',
-                                         'qspi_erase_mode': 'ERASE_NONE'})
                 core = 'NRFDL_DEVICE_CORE_NETWORK'
         else:
             if self.erase:


### PR DESCRIPTION
… v8.0.0

SDFW v8.0.0 introduces certain changes that require matching changes in nrfutil device to ensure that west flash works properly on nrf54h20dk and nrf9280pdk.

This commit adds a few temporary workarounds to ensure that west flash works with an older nrfutil device version as well:

1. Don't erase UICR, as this tries to erase the extended UICR regions as well, and those regions no longer exist (resulting in an error).

2. Reset after erasing domains with west flash --erase. This is needed for the memory owned by the different domains to be freely accessible and able to be allocated to different domains.

2. Unless doing a west flash --erase, do a RESET_VIA_SECDOM reset before programming firmware. This ensures that all the cores are stopped before writing firmware. Removing the UICR erase step seemed to cause some instability when programming, which is suspected to be caused by the firmware running while programming.