### PR TITLE
[Backport v3.7.99-ncs1-branch] Pull in sys nrf event

### DIFF
--- a/dts/common/nordic/nrf54l15.dtsi
+++ b/dts/common/nordic/nrf54l15.dtsi
@@ -606,6 +606,32 @@
 				status = "disabled";
 			};
 
+			power: power@10e000 {
+				compatible = "nordic,nrf-power";
+				reg = <0x10e000 0x1000>;
+				ranges = <0x0 0x10e000 0x1000>;
+				interrupts = <270 NRF_DEFAULT_IRQ_PRIORITY>;
+				status = "disabled";
+				#address-cells = <1>;
+				#size-cells = <1>;
+
+				gpregret1: gpregret1@51c {
+					#address-cells = <1>;
+					#size-cells = <1>;
+					compatible = "nordic,nrf-gpregret";
+					reg = <0x51c 0x1>;
+					status = "disabled";
+				};
+
+				gpregret2: gpregret2@520 {
+					#address-cells = <1>;
+					#size-cells = <1>;
+					compatible = "nordic,nrf-gpregret";
+					reg = <0x520 0x1>;
+					status = "disabled";
+				};
+			};
+
 			regulators: regulator@120000 {
 				compatible = "nordic,nrf54l-regulators";
 				reg = <0x120000 0x1000>;

--- a/samples/boards/nordic/nrf_sys_event/CMakeLists.txt
+++ b/samples/boards/nordic/nrf_sys_event/CMakeLists.txt
@@ -1,0 +1,9 @@
+# Copyright 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(soc_sys_event)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/samples/boards/nordic/nrf_sys_event/prj.conf
+++ b/samples/boards/nordic/nrf_sys_event/prj.conf
@@ -1,0 +1,4 @@
+# Copyright 2024 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_NRF_SYS_EVENT=y

--- a/samples/boards/nordic/nrf_sys_event/sample.yaml
+++ b/samples/boards/nordic/nrf_sys_event/sample.yaml
@@ -1,0 +1,28 @@
+sample:
+  name: nRF System events
+tests:
+  sample.boards.nordic.nrf_sys_event:
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "constant latency mode disabled"
+    platform_allow:
+      - nrf52dk/nrf52810
+      - nrf52dk/nrf52832
+      - nrf52833dk/nrf52820
+      - nrf52833dk/nrf52833
+      - nrf52840dk/nrf52811
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpunet
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+      - nrf54l15dk/nrf54l15/cpuapp
+    integration_platforms:
+      - nrf52840dk/nrf52840
+      - nrf5340dk/nrf5340/cpuapp
+      - nrf5340dk/nrf5340/cpunet
+      - nrf54h20dk/nrf54h20/cpuapp
+      - nrf54h20dk/nrf54h20/cpurad
+      - nrf54l15dk/nrf54l15/cpuapp

--- a/samples/boards/nordic/nrf_sys_event/src/main.c
+++ b/samples/boards/nordic/nrf_sys_event/src/main.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nrf_sys_event.h>
+#include <stdio.h>
+
+int main(void)
+{
+	printf("request global constant latency mode\n");
+	if (nrf_sys_event_request_global_constlat()) {
+		printf("failed to request global constant latency mode\n");
+		return 0;
+	}
+	printf("constant latency mode enabled\n");
+
+	printf("request global constant latency mode again\n");
+	if (nrf_sys_event_request_global_constlat()) {
+		printf("failed to request global constant latency mode\n");
+		return 0;
+	}
+
+	printf("release global constant latency mode\n");
+	printf("constant latency mode will remain enabled\n");
+	if (nrf_sys_event_release_global_constlat()) {
+		printf("failed to release global constant latency mode\n");
+		return 0;
+	}
+
+	printf("release global constant latency mode again\n");
+	printf("constant latency mode will be disabled\n");
+	if (nrf_sys_event_release_global_constlat()) {
+		printf("failed to release global constant latency mode\n");
+		return 0;
+	}
+
+	printf("constant latency mode disabled\n");
+	return 0;
+}

--- a/soc/nordic/common/CMakeLists.txt
+++ b/soc/nordic/common/CMakeLists.txt
@@ -32,3 +32,5 @@ if(CONFIG_TFM_PARTITION_PLATFORM)
     $<TARGET_PROPERTY:tfm,TFM_BINARY_DIR>/api_ns/interface/include
   )
 endif()
+
+zephyr_library_sources_ifdef(CONFIG_NRF_SYS_EVENT nrf_sys_event.c)

--- a/soc/nordic/common/Kconfig
+++ b/soc/nordic/common/Kconfig
@@ -4,4 +4,8 @@
 config HAS_NORDIC_DMM
 	bool
 
+config NRF_SYS_EVENT
+	bool "nRF system event support"
+	select NRFX_POWER if !NRF_PLATFORM_HALTIUM
+
 rsource "vpr/Kconfig"

--- a/soc/nordic/common/nrf_sys_event.c
+++ b/soc/nordic/common/nrf_sys_event.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <nrf_sys_event.h>
+
+#if CONFIG_SOC_SERIES_NRF54HX
+
+/*
+ * The 54HX is not yet supported by an nrfx driver nor the system controller so
+ * we implement an ISR and concurrent access safe reference counting implementation
+ * here using the nrfx hal.
+ */
+
+#include <hal/nrf_lrcconf.h>
+
+static struct k_spinlock global_constlat_lock;
+static uint16_t global_constlat_count;
+
+int nrf_sys_event_request_global_constlat(void)
+{
+	K_SPINLOCK(&global_constlat_lock) {
+		if (global_constlat_count == 0) {
+#if CONFIG_SOC_NRF54H20_CPUAPP
+			nrf_lrcconf_task_trigger(NRF_LRCCONF010,
+						 NRF_LRCCONF_TASK_CONSTLAT_ENABLE);
+#elif CONFIG_SOC_NRF54H20_CPURAD
+			nrf_lrcconf_task_trigger(NRF_LRCCONF000,
+						 NRF_LRCCONF_TASK_CONSTLAT_ENABLE);
+			nrf_lrcconf_task_trigger(NRF_LRCCONF020,
+						 NRF_LRCCONF_TASK_CONSTLAT_ENABLE);
+#else
+#error "unsupported"
+#endif
+		}
+
+		global_constlat_count++;
+	}
+
+	return 0;
+}
+
+int nrf_sys_event_release_global_constlat(void)
+{
+	K_SPINLOCK(&global_constlat_lock) {
+		if (global_constlat_count == 1) {
+#if CONFIG_SOC_NRF54H20_CPUAPP
+			nrf_lrcconf_task_trigger(NRF_LRCCONF010,
+						 NRF_LRCCONF_TASK_CONSTLAT_DISABLE);
+#elif CONFIG_SOC_NRF54H20_CPURAD
+			nrf_lrcconf_task_trigger(NRF_LRCCONF000,
+						 NRF_LRCCONF_TASK_CONSTLAT_DISABLE);
+			nrf_lrcconf_task_trigger(NRF_LRCCONF020,
+						 NRF_LRCCONF_TASK_CONSTLAT_DISABLE);
+#else
+#error "unsupported"
+#endif
+		}
+
+		global_constlat_count--;
+	}
+
+	return 0;
+}
+
+#else
+
+/*
+ * The nrfx power driver already contains an ISR and concurrent access safe reference
+ * counting API so we just use it directly when available.
+ */
+
+#include <nrfx_power.h>
+
+int nrf_sys_event_request_global_constlat(void)
+{
+	nrfx_err_t err;
+
+	err = nrfx_power_constlat_mode_request();
+
+	return (err == NRFX_SUCCESS || err == NRFX_ERROR_ALREADY) ? 0 : -EAGAIN;
+}
+
+int nrf_sys_event_release_global_constlat(void)
+{
+	nrfx_err_t err;
+
+	err = nrfx_power_constlat_mode_free();
+
+	return (err == NRFX_SUCCESS || err == NRFX_ERROR_BUSY) ? 0 : -EAGAIN;
+}
+
+#endif

--- a/soc/nordic/common/nrf_sys_event.h
+++ b/soc/nordic/common/nrf_sys_event.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+
+/**
+ * @brief Request lowest latency for system events
+ *
+ * @details System will be configured for lowest latency after first
+ * call to nrf_sys_event_request_global_constlat() and will remain
+ * configured for lowest latency until matching number of calls to
+ * nrf_sys_event_release_global_constlat() occur.
+ *
+ * @retval 0 if successful
+ * @retval -errno code otherwise
+ */
+int nrf_sys_event_request_global_constlat(void);
+
+/**
+ * @brief Release low latency request
+ *
+ * @see nrf_sys_event_request_global_constlat()
+ *
+ * @retval 0 if successful
+ * @retval -errno code otherwise
+ */
+int nrf_sys_event_release_global_constlat(void);


### PR DESCRIPTION
Backport 4c7f4d4219899a497853e432636a0344e064c0f4~3..4c7f4d4219899a497853e432636a0344e064c0f4 from #2177.