### PR TITLE
Revert "[nrf fromlist] soc: nordic: nrf54l15: fix APPROTECT handling"

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -75,14 +75,11 @@ zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF9230_ENGB_CPUPPR NRF9230_ENGB_XXA
 zephyr_compile_definitions_ifdef(CONFIG_NRF_APPROTECT_LOCK
                                  ENABLE_APPROTECT)
 zephyr_compile_definitions_ifdef(CONFIG_NRF_APPROTECT_USER_HANDLING
-                                 ENABLE_APPROTECT_USER_HANDLING
-                                 ENABLE_AUTHENTICATED_APPROTECT)
+                                 ENABLE_APPROTECT_USER_HANDLING)
 zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_LOCK
-                                 ENABLE_SECURE_APPROTECT
-                                 ENABLE_SECUREAPPROTECT)
+                                 ENABLE_SECURE_APPROTECT)
 zephyr_compile_definitions_ifdef(CONFIG_NRF_SECURE_APPROTECT_USER_HANDLING
-                                 ENABLE_SECURE_APPROTECT_USER_HANDLING
-                                 ENABLE_AUTHENTICATED_SECUREAPPROTECT)
+                                 ENABLE_SECURE_APPROTECT_USER_HANDLING)
 zephyr_library_compile_definitions_ifdef(CONFIG_NRF_TRACE_PORT
                                  ENABLE_TRACE)
 

--- a/soc/nordic/Kconfig
+++ b/soc/nordic/Kconfig
@@ -98,24 +98,15 @@ config NFCT_PINS_AS_GPIOS
 
 choice NRF_APPROTECT_HANDLING
 	bool "APPROTECT handling"
-	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF53X || SOC_NRF54L15_CPUAPP || \
-		   SOC_SERIES_NRF91X
-	default NRF_APPROTECT_DISABLE if SOC_NRF54L15_CPUAPP
+	depends on SOC_SERIES_NRF52X || SOC_NRF5340_CPUNET || \
+		   SOC_NRF5340_CPUAPP || SOC_SERIES_NRF91X
 	default NRF_APPROTECT_USE_UICR
 	help
 	  Specifies how the SystemInit() function should handle the APPROTECT
 	  mechanism.
 
-config NRF_APPROTECT_DISABLE
-	bool "Disable"
-	depends on SOC_NRF54L15_CPUAPP
-	help
-	  When this option is selected, the SystemInit() disables
-	  the APPROTECT mechanism.
-
 config NRF_APPROTECT_USE_UICR
 	bool "Use UICR"
-	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF53X || SOC_SERIES_NRF91X
 	help
 	  When this option is selected, the SystemInit() function loads the
 	  firmware branch state of the APPROTECT mechanism from UICR, so if
@@ -140,23 +131,14 @@ endchoice
 
 choice NRF_SECURE_APPROTECT_HANDLING
 	bool "Secure APPROTECT handling"
-	depends on SOC_NRF5340_CPUAPP || SOC_NRF54L15_CPUAPP || SOC_SERIES_NRF91X
-	default NRF_SECURE_APPROTECT_DISABLE if SOC_NRF54L15_CPUAPP
+	depends on SOC_NRF5340_CPUAPP || SOC_SERIES_NRF91X
 	default NRF_SECURE_APPROTECT_USE_UICR
 	help
 	  Specifies how the SystemInit() function should handle the secure
 	  APPROTECT mechanism.
 
-config NRF_SECURE_APPROTECT_DISABLE
-	bool "Disable"
-	depends on SOC_NRF54L15_CPUAPP
-	help
-	  When this option is selected, the SystemInit() disables
-	  the secure APPROTECT mechanism.
-
 config NRF_SECURE_APPROTECT_USE_UICR
 	bool "Use UICR"
-	depends on SOC_NRF5340_CPUAPP || SOC_SERIES_NRF91X
 	help
 	  When this option is selected, the SystemInit() function loads the
 	  firmware branch state of the secure APPROTECT mechanism from UICR,


### PR DESCRIPTION
This reverts commit e49e65b4b052d6e1406c73add257fcbc377126db.

Revert the change until TFM is fixed.