### PR TITLE
[nrf fromtree]: samples: boards: nordic: system_off: Update README.

### DIFF
--- a/samples/boards/nordic/system_off/README.rst
+++ b/samples/boards/nordic/system_off/README.rst
@@ -22,7 +22,7 @@ RAM is configured to keep the containing section powered while in system-off mod
 Requirements
 ************
 
-This application uses nRF51 DK, nRF52 DK or nRF54L15 PDK board for the demo.
+This application uses nRF51 DK, nRF52 DK or nRF54L15 DK board for the demo.
 
 Sample Output
 =============


### PR DESCRIPTION
Update DK naming - NRF54L15PDK is deprecated.

Signed-off-by: Bartlomiej Buczek <bartlomiej.buczek@nordicsemi.no>i

(cherry picked from commit 8cd361a51a4e7954d58ca7f06ed554bd3a7ef076)