### PR TITLE
[nrf fromlist] soc: nordic: nrf54l: fix configuration of DCDC regulator

### DIFF
--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -154,6 +154,11 @@ static inline void power_and_clock_configuration(void)
 	}
 
 #if (DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
+#if defined(__CORTEX_M) && !defined(NRF_TRUSTZONE_NONSECURE) && defined(__ARM_FEATURE_CMSE)
+	if (*(uint32_t *)0x00FFC334 <= 0x180A1D00) {
+		*(uint32_t *)0x50120640 = 0x1FAAE85C;
+	}
+#endif
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
 #endif
 


### PR DESCRIPTION
DCDC regulator on nRF54L may not always works as intended. Apply a fix addressing that.

Upstream PR #: 80635