### PR TITLE
[nrf fromlist] drivers: pwm: nrfx: adjust PWM driver to fast PWM120

### DIFF
--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -639,6 +639,7 @@
 				reg = <0x8e4000 0x1000>;
 				status = "disabled";
 				interrupts = <228 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hsfll120>;
 				power-domains = <&gpd NRF_GPD_FAST_ACTIVE1>;
 				#pwm-cells = <3>;
 			};


### PR DESCRIPTION
Fast PWM120 instance works with 320MHz clock, thus `pwm_nrfx_get_cycles_per_sec` needs to be adjusted.
Also, it uses cachable RAM, thus sys_cache function needs to be added to flush the cached sequence.

Upstream PR : https://github.com/zephyrproject-rtos/zephyr/pull/80672