### PR TITLE
[Backport v3.7.99-ncs1-branch] [nrf fromtree] linker: lto: Remove experimental label

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -536,11 +536,10 @@ config NO_OPTIMIZATIONS
 endchoice
 
 config LTO
-	bool "Link Time Optimization [EXPERIMENTAL]"
+	bool "Link Time Optimization"
 	depends on !(GEN_ISR_TABLES || GEN_IRQ_VECTOR_TABLE) || ISR_TABLES_LOCAL_DECLARATION
 	depends on !NATIVE_LIBRARY
 	depends on !CODE_DATA_RELOCATION
-	select EXPERIMENTAL
 	help
 	  This option enables Link Time Optimization.
 


### PR DESCRIPTION
Backport b6c23193700be7e7744bccf0c3aec159c1aaedfb from #2215.