### PR TITLE
[Backport v3.7.99-ncs1-branch] [nrf fromlist] soc: nordic: nrf54l: tune configuration of DCDC regulator

### DIFF
--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -155,8 +155,8 @@ static inline void power_and_clock_configuration(void)
 
 #if (DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
 #if defined(__CORTEX_M) && !defined(NRF_TRUSTZONE_NONSECURE) && defined(__ARM_FEATURE_CMSE)
-	if (*(uint32_t *)0x00FFC334 <= 0x180A1D00) {
-		*(uint32_t *)0x50120640 = 0x1FAAE85C;
+	if (*(uint32_t volatile *)0x00FFC334 <= 0x180A1D00) {
+		*(uint32_t volatile *)0x50120640 = 0x1EA9E040;
 	}
 #endif
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);


### PR DESCRIPTION
Backport 9ee72ff9751e3ef0183c9f9e9896bd4b474fa350 from #2217.