### PR TITLE
[nrf fromlist] drivers: serial: nrfx_uarte: Fix RX path without low p…

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1516,7 +1516,7 @@ static void rxto_isr(const struct device *dev)
 			async_rx->total_user_byte_cnt += rx_flush(dev);
 		}
 #endif
-	} else {
+	} else if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || LOW_POWER_ENABLED(config)) {
 		async_rx->flush_cnt = rx_flush(dev);
 	}
 


### PR DESCRIPTION
…ower modes

RX FIFO flushing on RXTO event should only be performed when UARTE peripheral might be disable during inactivity and that happens when low power modes is enabled or when device runtime PM is used. Flushing was incrementing flush_cnt which was not used (flushed data is not copied to the next buffer) which was causing data loss and invalid RX data length reporting.

Upstream PR #: 80968