### PR TITLE
[Backport v3.7.99-ncs1-branch] [nrf fromlist] drivers: serial: nrfx_uarte: Fix RX path without low p…

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -1516,7 +1516,7 @@ static void rxto_isr(const struct device *dev)
 			async_rx->total_user_byte_cnt += rx_flush(dev);
 		}
 #endif
-	} else {
+	} else if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || LOW_POWER_ENABLED(config)) {
 		async_rx->flush_cnt = rx_flush(dev);
 	}
 


### PR DESCRIPTION
Backport b27ed6f1c4b1833d2479068581fcc0f8f3213392 from #2230.