### PR TITLE
[Backport v3.7.99-ncs1-branch] [nrf fromtree] soc: nordic: nrf53: SOC_NRF53_CPUNET_ENABLE should not…

### DIFF
--- a/soc/nordic/nrf53/Kconfig
+++ b/soc/nordic/nrf53/Kconfig
@@ -197,7 +197,6 @@ config SOC_NRF53_CPUNET_MGMT
 
 config SOC_NRF53_CPUNET_ENABLE
 	bool "NRF53 Network MCU is enabled at boot time"
-	depends on !BT
 	default y if NRF_802154_SER_HOST
 	select SOC_NRF53_CPUNET_MGMT
 	help
@@ -215,7 +214,6 @@ config BOARD_ENABLE_CPUNET
 	bool "[DEPRECATED] NRF53 Network MCU is enabled at boot time"
 	select SOC_NRF53_CPUNET_ENABLE
 	select DEPRECATED
-	depends on !BT
 	help
 	  Use SOC_NRF53_CPUNET_ENABLE instead.
 


### PR DESCRIPTION
Backport 91e394a6321c8dae05131e704b7c8c0fd570f31f from #2116.