### PR TITLE
[Backport v3.7.99-ncs1-branch] [nrf fromlist] drivers: pwm: nrfx: adjust PWM driver to fast PWM120

### DIFF
--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -639,6 +639,7 @@
 				reg = <0x8e4000 0x1000>;
 				status = "disabled";
 				interrupts = <228 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hsfll120>;
 				power-domains = <&gpd NRF_GPD_FAST_ACTIVE1>;
 				#pwm-cells = <3>;
 			};


### PR DESCRIPTION
Backport ada0489ebf78d4f1db1da831a6d886fb819346da~2..ada0489ebf78d4f1db1da831a6d886fb819346da from #2209.