### PR TITLE
[Backport v3.7.99-ncs1-branch] [nrf fromlist] samples: sensor: qdec: change pins used for qdec nrf54h20dk

### DIFF
--- a/samples/sensor/qdec/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/sensor/qdec/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -13,10 +13,10 @@
 	encoder-emulate {
 		compatible = "gpio-leds";
 		phase_a: phase_a {
-			gpios = <&gpio7 2 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>;
 		};
 		phase_b: phase_b {
-			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio2 11 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };
@@ -24,17 +24,13 @@
 &pinctrl {
 	qdec_pinctrl: qdec_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 1, 0)>,
-				<NRF_PSEL(QDEC_B, 1, 2)>;
+			psels = <NRF_PSEL(QDEC_A, 2, 8)>,
+				<NRF_PSEL(QDEC_B, 2, 10)>;
 		};
 	};
 };
 
-&gpio1 {
-	status = "okay";
-};
-
-&gpio7 {
+&gpio2 {
 	status = "okay";
 };
 

--- a/tests/boards/nrf/qdec/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/boards/nrf/qdec/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -13,10 +13,10 @@
 	encoder-emulate {
 		compatible = "gpio-leds";
 		phase_a: phase_a {
-			gpios = <&gpio7 2 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio2 9 GPIO_ACTIVE_HIGH>;
 		};
 		phase_b: phase_b {
-			gpios = <&gpio1 3 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio2 11 GPIO_ACTIVE_HIGH>;
 		};
 	};
 };
@@ -24,25 +24,21 @@
 &pinctrl {
 	qdec_pinctrl: qdec_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 1, 0)>,
-				<NRF_PSEL(QDEC_B, 1, 2)>;
+			psels = <NRF_PSEL(QDEC_A, 2, 8)>,
+				<NRF_PSEL(QDEC_B, 2, 10)>;
 		};
 	};
 
 	qdec_sleep_pinctrl: qdec_sleep_pinctrl {
 		group1 {
-			psels = <NRF_PSEL(QDEC_A, 1, 0)>,
-				<NRF_PSEL(QDEC_B, 1, 2)>;
+			psels = <NRF_PSEL(QDEC_A, 2, 8)>,
+				<NRF_PSEL(QDEC_B, 2, 10)>;
 			low-power-enable;
 		};
 	};
 };
 
-&gpio1 {
-	status = "okay";
-};
-
-&gpio7 {
+&gpio2 {
 	status = "okay";
 };
 


### PR DESCRIPTION
Backport 06d6b00c41b1ce0cd9e3ffc3d53958e4b5dc052b from #2192.