### PR TITLE
[nrf fromtree] dp: swdp_bitbang: fix missing reset pin error

### DIFF
--- a/drivers/dp/swdp_bitbang.c
+++ b/drivers/dp/swdp_bitbang.c
@@ -601,9 +601,11 @@ static int sw_port_on(const struct device *dev)
 		return ret;
 	}
 
-	ret = gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT_ACTIVE);
-	if (ret) {
-		return ret;
+	if (config->reset.port) {
+		ret = gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT_ACTIVE);
+		if (ret) {
+			return ret;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
This patch fixes an issue where the reset pin is used even when it's not given.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>
(cherry picked from commit 4f85ce6eda93199946277d09bd5220b5eddd997e)