### PR TITLE
[Backport v3.7.99-ncs1-branch] [nrf fromlist] drivers: nrfwifi: Fix recovery for SAP

### DIFF
--- a/drivers/wifi/nrfwifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrfwifi/Kconfig.nrfwifi
@@ -656,7 +656,9 @@ config NRF_WIFI_AP_DEAD_DETECT_TIMEOUT
 
 config NRF_WIFI_RPU_RECOVERY
 	bool "RPU recovery mechanism"
+	# Relies on power-save mode, so, LPM is needed and AP mode is not supported
 	depends on NRF_WIFI_LOW_POWER
+	depends on !NRF70_AP_MODE
 	default y
 	select EXPERIMENTAL
 	help


### PR DESCRIPTION
Backport 5a391483191e8720b7556107337c8adf0ae655e0 from #2247.