### PR TITLE
[nrf noup] drivers: spi: dw: disable pin retention after enabling

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -45,6 +45,10 @@ LOG_MODULE_REGISTER(spi_dw);
 #include <nrfx.h>
 #endif
 
+#ifdef CONFIG_SOC_NRF54H20_GPD
+#include <nrf/gpd.h>
+#endif
+
 static inline bool spi_dw_is_slave(struct spi_dw_data *spi)
 {
 	return (IS_ENABLED(CONFIG_SPI_SLAVE) &&
@@ -553,6 +557,9 @@ int spi_dw_init(const struct device *dev)
 
 #ifdef CONFIG_PINCTRL
 	pinctrl_apply_state(info->pcfg, PINCTRL_STATE_DEFAULT);
+#ifdef CONFIG_SOC_NRF54H20_GPD
+	nrf_gpd_retain_pins_set(info->pcfg, false);
+#endif
 #endif
 
 	DEVICE_MMIO_MAP(dev, K_MEM_CACHE_NONE);


### PR DESCRIPTION
This is required so that device stays functional while enabled.