### PR TITLE
[Backport v3.7.99-ncs1-branch] [nrf fromlist] drivers: pwm: nrfx: add pin retention

### DIFF
--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -13,6 +13,9 @@
 #include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/cache.h>
 #include <zephyr/mem_mgmt/mem_attr.h>
+#ifdef CONFIG_SOC_NRF54H20_GPD
+#include <nrf/gpd.h>
+#endif
 
 #include <zephyr/logging/log.h>
 
@@ -274,6 +277,10 @@ static void pwm_resume(const struct device *dev)
 
 	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 
+#ifdef CONFIG_SOC_NRF54H20_GPD
+	nrf_gpd_retain_pins_set(config->pcfg, false);
+#endif
+
 	for (size_t i = 0; i < NRF_PWM_CHANNEL_COUNT; i++) {
 		uint32_t psel;
 
@@ -301,6 +308,10 @@ static void pwm_suspend(const struct device *dev)
 	nrfx_pwm_stop(&config->pwm, false);
 	while (!nrfx_pwm_stopped_check(&config->pwm)) {
 	}
+
+#ifdef CONFIG_SOC_NRF54H20_GPD
+	nrf_gpd_retain_pins_set(config->pcfg, true);
+#endif
 
 	memset(dev->data, 0, sizeof(struct pwm_nrfx_data));
 	(void)pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);


### PR DESCRIPTION
Backport b524b0e61990b415fe3b011611d031b28c29d279 from #2263.