### PR TITLE
[Backport v3.7.99-ncs1-branch] [nrf noup] drivers: spi: dw: turn on FAST_ACTIVE1 domain

### DIFF
--- a/drivers/spi/spi_dw.c
+++ b/drivers/spi/spi_dw.c
@@ -45,6 +45,10 @@ LOG_MODULE_REGISTER(spi_dw);
 #include <nrfx.h>
 #endif
 
+#ifdef CONFIG_SOC_NRF54H20_GPD
+#include <nrf/gpd.h>
+#endif
+
 static inline bool spi_dw_is_slave(struct spi_dw_data *spi)
 {
 	return (IS_ENABLED(CONFIG_SPI_SLAVE) &&
@@ -560,6 +564,13 @@ int spi_dw_init(const struct device *dev)
 #ifdef CONFIG_HAS_NRFX
 	NRF_EXMIF->INTENSET = BIT(0);
 	NRF_EXMIF->TASKS_START = 1;
+
+#ifdef CONFIG_SOC_NRF54H20_GPD
+	err = nrf_gpd_request(NRF_GPD_FAST_ACTIVE1);
+	if (err < 0) {
+		return err;
+	}
+#endif
 #endif
 
 	info->config_func();


### PR DESCRIPTION
Backport b9bc0846b926d339b042c4faa3c43c8276a37009 from #2261.