### PR TITLE
[Backport v3.7.99-ncs1-branch] soc: nordic: nrf54h: disable IRQ before PM config

### DIFF
--- a/arch/arm/core/cortex_m/pm_s2ram.S
+++ b/arch/arm/core/cortex_m/pm_s2ram.S
@@ -85,6 +85,9 @@ SECTION_FUNC(TEXT, arch_pm_s2ram_suspend)
 	 * not successful (in r0 the return value).
 	 */
 
+	/* Move return value of system_off to callee-saved register. */
+	mov 	r4, r0
+
 	/*
 	 * Reset the marking of suspend to RAM, return is ignored.
 	 */
@@ -92,7 +95,9 @@ SECTION_FUNC(TEXT, arch_pm_s2ram_suspend)
 	bl	pm_s2ram_mark_check_and_clear
 	mov 	lr, r1
 
-	/* Move system_off back to r0 as return value */
+	/* Move the stored return value of system_off back to r0,
+	 * setting it as return value for this function.
+	 */
 	mov	r0, r4
 
 	pop	{r4-r12, lr}

--- a/soc/nordic/nrf54h/pm_s2ram.c
+++ b/soc/nordic/nrf54h/pm_s2ram.c
@@ -111,18 +111,15 @@ int soc_s2ram_suspend(pm_s2ram_system_off_fn_t system_off)
 {
 	int ret;
 
-	__disable_irq();
 	nvic_suspend(&backup_data.nvic_context);
 	mpu_suspend(&backup_data.mpu_context);
 	ret = arch_pm_s2ram_suspend(system_off);
 	if (ret < 0) {
-		__enable_irq();
 		return ret;
 	}
 
 	mpu_resume(&backup_data.mpu_context);
 	nvic_resume(&backup_data.nvic_context);
-	__enable_irq();
 
 	return ret;
 }

--- a/soc/nordic/nrf54h/power.c
+++ b/soc/nordic/nrf54h/power.c
@@ -188,15 +188,19 @@ static void s2ram_enter(void)
 void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
 	if (state == PM_STATE_SUSPEND_TO_IDLE) {
+		__disable_irq();
 		s2idle_enter(substate_id);
 		/* Resume here. */
 		s2idle_exit(substate_id);
+		__enable_irq();
 	}
 #if defined(CONFIG_PM_S2RAM)
 	else if (state == PM_STATE_SUSPEND_TO_RAM) {
+		__disable_irq();
 		s2ram_enter();
 		/* On resuming or error we return exactly *HERE* */
 		s2ram_exit();
+		__enable_irq();
 	}
 #endif
 	else {


### PR DESCRIPTION
Backport dab9c11bdcc80f1e0670ef686e6066ee3304ac47~2..dab9c11bdcc80f1e0670ef686e6066ee3304ac47 from #2258.