### PR TITLE
[nrf fromtree] logging: frontends: stmesp: alternate message output o…

### DIFF
--- a/subsys/logging/frontends/Kconfig
+++ b/subsys/logging/frontends/Kconfig
@@ -73,6 +73,14 @@ config LOG_FRONTEND_STMESP_GUARANTEED_ACCESS
 	  When enabled, accessing STMESP registers will stall if write cannot be
 	  performed (e.g. ETR buffer is full).
 
+config LOG_FRONTEND_STMESP_MSG_END_TIMESTAMP
+	bool "Generate timestamp and marker at message end"
+	help
+	  Generate a zero data byte with timestamp and marker at message end,
+	  instead of generating a timestamp and marker at message start and
+	  a flag at end. This can be used to maintain compatibility with
+	  certain decoders.
+
 endif # LOG_FRONTEND_STMESP
 
 config LOG_FRONTEND_STMESP_DEMUX

--- a/subsys/logging/frontends/log_frontend_stmesp.c
+++ b/subsys/logging/frontends/log_frontend_stmesp.c
@@ -314,7 +314,11 @@ static inline int16_t get_source_id(const void *source)
 
 static void packet_end(STMESP_Type *stm_esp)
 {
-	STM_FLAG(stm_esp);
+	if (IS_ENABLED(CONFIG_LOG_FRONTEND_STMESP_MSG_END_TIMESTAMP)) {
+		STM_D8(stm_esp, 0, true, true);
+	} else {
+		STM_FLAG(stm_esp);
+	}
 	atomic_set(&new_data, 1);
 }
 
@@ -365,7 +369,11 @@ void log_frontend_msg(const void *source, const struct log_msg_desc desc, uint8_
 			return;
 		}
 
-		STM_D32(stm_esp, hdr.raw, use_timestamp, true);
+		if (IS_ENABLED(CONFIG_LOG_FRONTEND_STMESP_MSG_END_TIMESTAMP)) {
+			STM_D32(stm_esp, hdr.raw, false, false);
+		} else {
+			STM_D32(stm_esp, hdr.raw, use_timestamp, true);
+		}
 		(void)cbprintf_package_convert(package, desc.package_len, package_cb, stm_esp,
 					       flags, strl, ARRAY_SIZE(strl));
 		write_data(sname, sname_len, stm_esp);
@@ -414,7 +422,11 @@ void log_frontend_msg(const void *source, const struct log_msg_desc desc, uint8_
 			return;
 		}
 
-		STM_D32(stm_esp, dict_desc.raw, true, true);
+		if (IS_ENABLED(CONFIG_LOG_FRONTEND_STMESP_MSG_END_TIMESTAMP)) {
+			STM_D32(stm_esp, dict_desc.raw, false, false);
+		} else {
+			STM_D32(stm_esp, dict_desc.raw, true, true);
+		}
 		(void)cbprintf_package_convert(package, desc.package_len, package_cb, stm_esp,
 					       flags, NULL, 0);
 		if (data) {
@@ -462,7 +474,11 @@ static inline void msg_start(STMESP_Type *stm_esp, uint32_t level, const void *s
 {
 	union stm_log_dict_hdr dict_desc = DICT_HDR_INITIALIZER(level, get_source_id(source), 0);
 
-	STM_D32(stm_esp, dict_desc.raw, true, true);
+	if (IS_ENABLED(CONFIG_LOG_FRONTEND_STMESP_MSG_END_TIMESTAMP)) {
+		STM_D32(stm_esp, dict_desc.raw, false, false);
+	} else {
+		STM_D32(stm_esp, dict_desc.raw, true, true);
+	}
 	STM_D32(stm_esp, package_hdr, false, false);
 	STM_D32(stm_esp, (uint32_t)fmt, false, false);
 }
@@ -611,8 +627,12 @@ int log_frontend_stmesp_etr_ready(void)
 	early_buf_read_mode();
 
 	while ((len = early_buf_get_data((void **)&buf)) > 0) {
-		/* Write first word with Marked and timestamp. */
-		STM_D32(stm_esp, *buf, true, true);
+		if (IS_ENABLED(CONFIG_LOG_FRONTEND_STMESP_MSG_END_TIMESTAMP)) {
+			STM_D32(stm_esp, *buf, false, false);
+		} else {
+			/* Write first word with Marked and timestamp. */
+			STM_D32(stm_esp, *buf, true, true);
+		}
 		buf++;
 		len -= sizeof(uint32_t);
 


### PR DESCRIPTION
Add an alternate message output option in which messages are ended with an additional zero data byte with marker and timestamp. Can be used to maintain compatibility with certain decoders.
