### PR TITLE
[nrf fromlist] soc: nordic: nrf54l: remove configuration of DCDC regulator

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -44,10 +44,12 @@ zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUPPR     NRF54H20_XXAA
                                                                 NRF_PPR)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54H20_CPUFLPR    NRF54H20_XXAA
                                                                 NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05            NRF54L05_XXAA)
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05            NRF54L05_XXAA
+                                                                DEVELOP_IN_NRF54L15)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05_CPUAPP     NRF_APPLICATION)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L05_CPUFLPR    NRF_FLPR)
-zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10            NRF54L10_XXAA)
+zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10            NRF54L10_XXAA
+                                                                DEVELOP_IN_NRF54L15)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10_CPUAPP     NRF_APPLICATION)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L10_CPUFLPR    NRF_FLPR)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54L15            NRF54L15_XXAA)

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -154,11 +154,6 @@ static inline void power_and_clock_configuration(void)
 	}
 
 #if (DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
-#if defined(__CORTEX_M) && !defined(NRF_TRUSTZONE_NONSECURE) && defined(__ARM_FEATURE_CMSE)
-	if (*(uint32_t volatile *)0x00FFC334 <= 0x180A1D00) {
-		*(uint32_t volatile *)0x50120640 = 0x1EA9E040;
-	}
-#endif
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
 #endif
 

--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -38,6 +38,7 @@
 #endif
 #include <soc/nrfx_coredep.h>
 
+#include <nrf_erratas.h>
 #include <system_nrf54l.h>
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
@@ -154,6 +155,13 @@ static inline void power_and_clock_configuration(void)
 	}
 
 #if (DT_PROP(DT_NODELABEL(vregmain), regulator_initial_mode) == NRF5X_REG_MODE_DCDC)
+#if NRF54L_ERRATA_31_ENABLE_WORKAROUND
+	/* Workaround for Errata 31 */
+	if (nrf54l_errata_31()) {
+		*((volatile uint32_t *)0x50120624ul) = 20 | 1<<5;
+		*((volatile uint32_t *)0x5012063Cul) &= ~(1<<19);
+	}
+#endif
 	nrf_regulators_vreg_enable_set(NRF_REGULATORS, NRF_REGULATORS_VREG_MAIN, true);
 #endif
 


### PR DESCRIPTION
Since nrfx 3.9 integration, configuration is executed in MDK SystemInit().

Additionally, add workaround for nRF54L anomaly 31.

Upstream PR #: 82268

Link: https://github.com/zephyrproject-rtos/zephyr/pull/82268