### PR TITLE
Cherry-pick USB fixes for NCS 2.9.0

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1387,11 +1387,12 @@ static void udc_dwc2_ep_disable(const struct device *dev,
 	uint8_t ep_idx = USB_EP_GET_IDX(cfg->addr);
 	mem_addr_t dxepctl_reg;
 	uint32_t dxepctl;
+	const bool is_iso = dwc2_ep_is_iso(cfg);
 
 	dxepctl_reg = dwc2_get_dxepctl_reg(dev, cfg->addr);
 	dxepctl = sys_read32(dxepctl_reg);
 
-	if (dxepctl & USB_DWC2_DEPCTL_NAKSTS) {
+	if (!is_iso && (dxepctl & USB_DWC2_DEPCTL_NAKSTS)) {
 		/* Endpoint already sends forced NAKs. STALL if necessary. */
 		if (stall) {
 			dxepctl |= USB_DWC2_DEPCTL_STALL;

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2572,7 +2572,11 @@ static void dwc2_handle_incompisoin(const struct device *dev)
 
 				buf = udc_buf_get(dev, cfg->addr);
 				if (buf) {
+					/* Data is no longer relevant */
 					udc_submit_ep_event(dev, buf, 0);
+
+					/* Try to queue next packet before SOF */
+					dwc2_handle_xfer_next(dev, cfg);
 				}
 			}
 		}

--- a/drivers/usb/udc/udc_dwc2_vendor_quirks.h
+++ b/drivers/usb/udc/udc_dwc2_vendor_quirks.h
@@ -201,6 +201,9 @@ static inline int usbhs_enable_core(const struct device *dev)
 	wrapper->ENABLE = USBHS_ENABLE_PHY_Msk | USBHS_ENABLE_CORE_Msk;
 	wrapper->TASKS_START = 1UL;
 
+	/* Wait for clock to start to avoid hang on too early register read */
+	k_busy_wait(1);
+
 	/* Enable interrupts */
 	wrapper->INTENSET = 1UL;
 

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -858,7 +858,13 @@ static int sreq_get_interface(struct usbd_context *const uds_ctx,
 		return 0;
 	}
 
+	/* Treat as error in default (not specified) and addressed states. */
 	cfg_nd = usbd_config_get_current(uds_ctx);
+	if (cfg_nd == NULL) {
+		errno = -EPERM;
+		return 0;
+	}
+
 	cfg_desc = cfg_nd->desc;
 
 	if (setup->wIndex > UINT8_MAX ||


### PR DESCRIPTION
Prevent nRF52/nRF53 USBD DMA transfer in Low Power mode (because it won't work).

Fixes for UAC2 High-Speed support on nRF54H20.