### PR TITLE
[nrf noup] samples: subsys: smp_svr: 54l10 and 54l05 sample.yaml

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -13,6 +13,7 @@ tests:
       - pinnacle_100_dvk
       - mg100
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
     integration_platforms:
       - nrf52dk/nrf52832
       - nrf52840dk/nrf52840
@@ -114,6 +115,8 @@ tests:
       - CONFIG_PM_OVERRIDE_EXTERNAL_DRIVER_CHECK=y
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
   sample.mcumgr.smp_svr.bt.nrf54l15dk.ext_flash.pure_dts:
@@ -125,5 +128,7 @@ tests:
       - SB_CONFIG_PARTITION_MANAGER=n
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l15dk/nrf54l10/cpuapp
+      - nrf54l15dk/nrf54l05/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp


### PR DESCRIPTION
adds nrf54l10 and nrf54l05 to samples.