### PR TITLE
[nrf fromtree] soc: nordic: Default enable Power Management on nRF54H…

### DIFF
--- a/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpurad
+++ b/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpurad
@@ -11,4 +11,7 @@ config NUM_IRQS
 config NRF_REGTOOL_GENERATE_UICR
 	default y
 
+config PM
+	default y
+
 endif # SOC_NRF54H20_CPURAD


### PR DESCRIPTION
…20 radio core

Adds CONFIG_PM=y to Radio core in the nRF54H20 SoC on the nRF54H20 DK soc defconf.


(cherry picked from commit 51957c885801878edfb781954e6d840fb72033f3)