### PR TITLE
[nrf fromtree] cmake: use the warnings_as_errors flag for cpp files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,
 # Extra warnings options for twister run
 if (CONFIG_COMPILER_WARNINGS_AS_ERRORS)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler,warnings_as_errors>>)
   zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:asm,warnings_as_errors>>)
   zephyr_link_libraries($<TARGET_PROPERTY:linker,warnings_as_errors>)
 endif()


### PR DESCRIPTION
C++ file compilation is actually missing the warning-as-error handling, causing warnings in build files to be unnoticed in CI. Add a flag to handle them as well.

Signed-off-by: Fabio Baltieri <fabiobaltieri@google.com>
(cherry picked from commit 56dcafece8e3282c492c6004b948fde032bd61d7)