### PR TITLE
[nrf fromtree] drivers: nrf_wifi: Initialize TWT response parameters …

### DIFF
--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt.c
@@ -620,8 +620,8 @@ void nrf_wifi_event_proc_twt_setup_zep(void *vif_ctx,
 				       unsigned int event_len)
 {
 	struct nrf_wifi_vif_ctx_zep *vif_ctx_zep = NULL;
-	struct wifi_twt_params twt_params;
-	struct twt_interval_float twt_interval_fp;
+	struct wifi_twt_params twt_params = { 0 };
+	struct twt_interval_float twt_interval_fp = { 0 };
 
 	if (!vif_ctx || !twt_setup_info) {
 		return;


### PR DESCRIPTION
…to zero

Set TWT response parameters to zero to avoid
uninitialized values and ensure correct behavior.

Upstream PR #: 82909