### PR TITLE
[nrf noup] soc: nordic: nrf54l Fix for wait lasting half expected time

### DIFF
--- a/soc/nordic/nrf54l/soc.c
+++ b/soc/nordic/nrf54l/soc.c
@@ -48,6 +48,13 @@ LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 #define HFXO_NODE DT_NODELABEL(hfxo)
 #endif
 
+/* Building for cpuflpr with ns uses cpu_1 instead of cpu_0 */
+#if DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
+#define DEVICE_DT_CLOCK_FREQ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)
+#elif DT_PROP(DT_PATH(cpus, cpu_1), clock_frequency)
+#define DEVICE_DT_CLOCK_FREQ DT_PROP(DT_PATH(cpus, cpu_1), clock_frequency)
+#endif
+
 #if defined(NRF_APPLICATION)
 static inline void power_and_clock_configuration(void)
 {
@@ -176,16 +183,18 @@ int nordicsemi_nrf54l_init(void)
 	/* Update the SystemCoreClock global variable with current core clock
 	 * retrieved from hardware state.
 	 */
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(__NRF_TFM__)
-	/* Currently not supported for non-secure */
-	SystemCoreClockUpdate();
-#endif
 
 #ifdef __NRF_TFM__
 	/* TF-M enables the instruction cache from target_cfg.c, so we
 	 * don't need to enable it here.
 	 */
 #else
+
+	/* Update SystemCoreClock in Zephyr based on device tree to avoid SystemCoreClock
+	 * being overwritten with default value when initializing with TF-M
+	 */
+	SystemCoreClock = DEVICE_DT_CLOCK_FREQ;
+
 	/* Enable ICACHE */
 	sys_cache_instr_enable();
 #endif


### PR DESCRIPTION
Noup as it patches code that does not exist in zephyr. arch_busy_wait and k_busy_wait waited half the expected time due to SystemCoreClock being set back to the default value when ns builds. Changed to rely on device tree as to avoid hardcoded clock frequencies