### PR TITLE
[Backport v3.7.99-ncs2-branch] [nrf noup] dfu: boot: mcuboot: Fix selecting wrong active slot

### DIFF
--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -37,6 +37,22 @@
 #if USE_PARTITION_MANAGER
 #include <pm_config.h>
 
+#if CONFIG_MCUBOOT_APPLICATION_IMAGE_NUMBER != -1
+/* Sysbuild */
+#ifdef CONFIG_MCUBOOT
+/* lib is part of MCUboot -> operate on the primary application slot */
+#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_PRIMARY_ID
+#else
+/* TODO: Add firmware loader support */
+/* lib is part of the app -> operate on active slot */
+#if defined(CONFIG_NCS_IS_VARIANT_IMAGE)
+#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_SECONDARY_ID
+#else
+#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_PRIMARY_ID
+#endif
+#endif /* CONFIG_MCUBOOT */
+#else
+/* Legacy child/parent */
 #if CONFIG_BUILD_WITH_TFM
 	#define PM_ADDRESS_OFFSET (PM_MCUBOOT_PAD_SIZE + PM_TFM_SIZE)
 #else
@@ -44,20 +60,19 @@
 #endif
 
 #ifdef CONFIG_MCUBOOT
-	/* lib is part of MCUboot -> operate on the primart application slot */
-	#define ACTIVE_SLOT_ID		PM_MCUBOOT_PRIMARY_ID
+	/* lib is part of MCUboot -> operate on the primary application slot */
+	#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_PRIMARY_ID
 #else
 	/* lib is part of the App -> operate on active slot */
 #if (PM_ADDRESS - PM_ADDRESS_OFFSET) == PM_MCUBOOT_PRIMARY_ADDRESS
-	#define ACTIVE_SLOT_ID		PM_MCUBOOT_PRIMARY_ID
+	#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_PRIMARY_ID
 #elif (PM_ADDRESS - PM_ADDRESS_OFFSET) == PM_MCUBOOT_SECONDARY_ADDRESS
-	#define ACTIVE_SLOT_ID		PM_MCUBOOT_SECONDARY_ID
+	#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_SECONDARY_ID
 #else
 	#error Missing partition definitions.
 #endif
 #endif /* CONFIG_MCUBOOT */
-
-#define ACTIVE_SLOT_FLASH_AREA_ID ACTIVE_SLOT_ID
+#endif /* CONFIG_MCUBOOT_APPLICATION_IMAGE_NUMBER != -1 */
 #else
 /* Get active partition. zephyr,code-partition chosen node must be defined */
 #define ACTIVE_SLOT_FLASH_AREA_ID DT_FIXED_PARTITION_ID(DT_CHOSEN(zephyr_code_partition))


### PR DESCRIPTION
Backport d99f13efc7fe216de96ab072b353ffdbe3f96ae1 from #2252.