### PR TITLE
[nrf fromtree] runners: jlink: Fix NoneType object error

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -37,7 +37,7 @@ def is_ip(ip):
     return True
 
 def is_tunnel(tunnel):
-    return tunnel.startswith("tunnel:")
+    return tunnel.startswith("tunnel:") if tunnel else False
 
 class ToggleAction(argparse.Action):
 

--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
@@ -53,6 +53,7 @@
 	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
+		spi-max-frequency = <DT_FREQ_M(8)>;
 		reg = <0>;
 	};
 };


### PR DESCRIPTION
The commit 221199e15b85a070b3d81709eee3d533c9f99967 presents a bug that makes west flash failed with error.

AttributeError: 'NoneType' object has no attribute 'startswith'

In function is_tunnel(), tunnel may contain None and has no attribute "startswith". Fix it.

Signed-off-by: Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>
Signed-off-by: Phi Bang Nguyen <phibang.nguyen@nxp.com>
(cherry picked from commit 829c03bcdca378fa2fa55484d16a190d379f754c)