### PR TITLE
drivers: serial: nrfx_uarte: Add requesting of global hsfll for fast UARTE instance

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54h20dk_nrf54h20_common.dtsi"

--- a/tests/drivers/uart/uart_async_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/uart/uart_async_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "../../../boards/nrf54h20dk_nrf54h20_common.dtsi"
+
+&dut {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};

--- a/tests/drivers/uart/uart_async_api/sysbuild/vpr_launcher/prj.conf
+++ b/tests/drivers/uart/uart_async_api/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,1 @@
+# nothing here


### PR DESCRIPTION
PR fetches latest changes in UARTE shim and extension to `uart_async_api` test to support testing UARTE120.

It's based on #2377. 