### PR TITLE
[nrf fromtree] tests: drivers: spi: Fix nrf52840 overlay

### DIFF
--- a/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/nrf52840dk_nrf52840.overlay
@@ -53,6 +53,7 @@
 	zephyr,pm-device-runtime-auto;
 	dut_spi_dt: test-spi-dev@0 {
 		compatible = "vnd,spi-device";
+		spi-max-frequency = <DT_FREQ_M(8)>;
 		reg = <0>;
 	};
 };


### PR DESCRIPTION
spi-max-frequency was missing in overlay

Now it's set to 8 MHz as per datasheet

Signed-off-by: Jerzy Kasenberg <jerzy.kasenberg@codecoup.pl>
(cherry picked from commit 1d4b1ade4358803e5320d79da1e6d72d8eace0a4)