### PR TITLE
[nrf fromlist] drivers: spi_nrfx_spim: Add clock requests for fast SPIM instances

### DIFF
--- a/drivers/clock_control/clock_control_nrf2_common.c
+++ b/drivers/clock_control/clock_control_nrf2_common.c
@@ -198,6 +198,7 @@ int nrf_clock_control_request_sync(const struct device *dev,
 
 	err = k_sem_take(&req.sem, timeout);
 	if (err < 0) {
+		nrf_clock_control_cancel_or_release(dev, spec, &req.cli);
 		return err;
 	}
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -9,6 +9,7 @@
 #include <zephyr/cache.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
+#include <zephyr/drivers/clock_control/nrf_clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/mem_mgmt/mem_attr.h>
 #include <soc.h>
@@ -42,6 +43,16 @@ LOG_MODULE_REGISTER(spi_nrfx_spim, CONFIG_SPI_LOG_LEVEL);
 #define SPI_BUFFER_IN_RAM 1
 #endif
 
+#if defined(CONFIG_CLOCK_CONTROL_NRF2_GLOBAL_HSFLL) && \
+	(defined(CONFIG_HAS_HW_NRF_SPIM120) || \
+	 defined(CONFIG_HAS_HW_NRF_SPIM121))
+#define SPIM_REQUESTS_CLOCK(idx) UTIL_OR(IS_EQ(idx, 120), \
+					 IS_EQ(idx, 121))
+#define USE_CLOCK_REQUESTS 1
+#else
+#define SPIM_REQUESTS_CLOCK(idx) 0
+#endif
+
 struct spi_nrfx_data {
 	struct spi_context ctx;
 	const struct device *dev;
@@ -56,6 +67,9 @@ struct spi_nrfx_data {
 	bool    anomaly_58_workaround_active;
 	uint8_t ppi_ch;
 	uint8_t gpiote_ch;
+#endif
+#ifdef USE_CLOCK_REQUESTS
+	bool clock_requested;
 #endif
 };
 
@@ -74,9 +88,54 @@ struct spi_nrfx_config {
 #ifdef CONFIG_DCACHE
 	uint32_t mem_attr;
 #endif
+#ifdef USE_CLOCK_REQUESTS
+	const struct device *clk_dev;
+	struct nrf_clock_spec clk_spec;
+#endif
 };
 
 static void event_handler(const nrfx_spim_evt_t *p_event, void *p_context);
+
+static inline int request_clock(const struct device *dev)
+{
+#ifdef USE_CLOCK_REQUESTS
+	struct spi_nrfx_data *dev_data = dev->data;
+	const struct spi_nrfx_config *dev_config = dev->config;
+	int error;
+
+	if (!dev_config->clk_dev) {
+		return 0;
+	}
+
+	error = nrf_clock_control_request_sync(
+			dev_config->clk_dev, &dev_config->clk_spec,
+			K_MSEC(CONFIG_SPI_COMPLETION_TIMEOUT_TOLERANCE));
+	if (error < 0) {
+		LOG_ERR("Failed to request clock: %d", error);
+		return error;
+	}
+
+	dev_data->clock_requested = true;
+#endif
+
+	return 0;
+}
+
+static inline void release_clock(const struct device *dev)
+{
+#ifdef USE_CLOCK_REQUESTS
+	struct spi_nrfx_data *dev_data = dev->data;
+	const struct spi_nrfx_config *dev_config = dev->config;
+
+	if (!dev_data->clock_requested) {
+		return;
+	}
+
+	dev_data->clock_requested = false;
+
+	nrf_clock_control_release(dev_config->clk_dev, &dev_config->clk_spec);
+#endif
+}
 
 static inline void finalize_spi_transaction(const struct device *dev, bool deactivate_cs)
 {
@@ -90,6 +149,10 @@ static inline void finalize_spi_transaction(const struct device *dev, bool deact
 
 	if (NRF_SPIM_IS_320MHZ_SPIM(reg) && !(dev_data->ctx.config->operation & SPI_HOLD_ON_CS)) {
 		nrfy_spim_disable(reg);
+	}
+
+	if (!IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+		release_clock(dev);
 	}
 
 	pm_device_runtime_put_async(dev, K_NO_WAIT);
@@ -467,6 +530,11 @@ static int transceive(const struct device *dev,
 	spi_context_lock(&dev_data->ctx, asynchronous, cb, userdata, spi_cfg);
 
 	error = configure(dev, spi_cfg);
+
+	if (error == 0 && !IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+		error = request_clock(dev);
+	}
+
 	if (error == 0) {
 		dev_data->busy = true;
 
@@ -518,6 +586,8 @@ static int transceive(const struct device *dev,
 		} else if (error) {
 			finalize_spi_transaction(dev, true);
 		}
+	} else {
+		pm_device_runtime_put(dev);
 	}
 
 	spi_context_release(&dev_data->ctx, error);
@@ -575,7 +645,7 @@ static const struct spi_driver_api spi_nrfx_driver_api = {
 	.release = spi_nrfx_release,
 };
 
-static void spim_resume(const struct device *dev)
+static int spim_resume(const struct device *dev)
 {
 	const struct spi_nrfx_config *dev_config = dev->config;
 
@@ -587,6 +657,8 @@ static void spim_resume(const struct device *dev)
 #ifdef CONFIG_SOC_NRF54H20_GPD
 	nrf_gpd_retain_pins_set(dev_config->pcfg, false);
 #endif
+
+	return IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) ? request_clock(dev) : 0;
 }
 
 static void spim_suspend(const struct device *dev)
@@ -599,6 +671,10 @@ static void spim_suspend(const struct device *dev)
 		dev_data->initialized = false;
 	}
 
+	if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+		release_clock(dev);
+	}
+
 #ifdef CONFIG_SOC_NRF54H20_GPD
 	nrf_gpd_retain_pins_set(dev_config->pcfg, true);
 #endif
@@ -609,7 +685,11 @@ static void spim_suspend(const struct device *dev)
 static int spim_nrfx_pm_action(const struct device *dev, enum pm_device_action action)
 {
 	if (action == PM_DEVICE_ACTION_RESUME) {
-		spim_resume(dev);
+		int error = spim_resume(dev);
+
+		if (error < 0) {
+			return error;
+		}
 	} else if (IS_ENABLED(CONFIG_PM_DEVICE) && (action == PM_DEVICE_ACTION_SUSPEND)) {
 		spim_suspend(dev);
 	} else {
@@ -685,6 +765,14 @@ static int spi_nrfx_init(const struct device *dev)
 			(0))),								 \
 		(0))
 
+#define SPIM_INIT_LEVEL(idx) \
+	COND_CODE_1(SPIM_REQUESTS_CLOCK(idx), (POST_KERNEL), (PRE_KERNEL_1))
+
+#define SPIM_INIT_PRIO(idx) \
+	COND_CODE_1(SPIM_REQUESTS_CLOCK(idx), \
+		(UTIL_INC(CONFIG_CLOCK_CONTROL_NRF2_GLOBAL_HSFLL_INIT_PRIORITY)), \
+		(CONFIG_SPI_INIT_PRIORITY))
+
 #define SPI_NRFX_SPIM_DEFINE(idx)					       \
 	NRF_DT_CHECK_NODE_HAS_PINCTRL_SLEEP(SPIM(idx));			       \
 	static void irq_connect##idx(void)				       \
@@ -735,6 +823,13 @@ static int spi_nrfx_init(const struct device *dev)
 		.wake_gpiote = WAKE_GPIOTE_INSTANCE(SPIM(idx)),		       \
 		IF_ENABLED(CONFIG_DCACHE,				       \
 			(.mem_attr = SPIM_GET_MEM_ATTR(idx),))		       \
+		IF_ENABLED(USE_CLOCK_REQUESTS,			       \
+			(.clk_dev = SPIM_REQUESTS_CLOCK(idx)		       \
+				  ? DEVICE_DT_GET(DT_CLOCKS_CTLR(SPIM(idx)))   \
+				  : NULL,				       \
+			 .clk_spec = {					       \
+				.frequency = NRF_CLOCK_CONTROL_FREQUENCY_MAX,  \
+			 },))						       \
 	};								       \
 	BUILD_ASSERT(!SPIM_HAS_PROP(idx, wake_gpios) ||			       \
 		     !(DT_GPIO_FLAGS(SPIM(idx), wake_gpios) & GPIO_ACTIVE_LOW),\
@@ -745,7 +840,7 @@ static int spi_nrfx_init(const struct device *dev)
 		      PM_DEVICE_DT_GET(SPIM(idx)),			       \
 		      &spi_##idx##_data,				       \
 		      &spi_##idx##z_config,				       \
-		      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		       \
+		      SPIM_INIT_LEVEL(idx), SPIM_INIT_PRIO(idx),	       \
 		      &spi_nrfx_driver_api)
 
 #define SPIM_MEMORY_SECTION(idx)					       \

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -657,6 +657,7 @@
 				power-domains = <&gpd NRF_GPD_FAST_ACTIVE1>;
 				easydma-maxcnt-bits = <15>;
 				interrupts = <230 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hsfll120>;
 				max-frequency = <DT_FREQ_M(32)>;
 				#address-cells = <1>;
 				#size-cells = <0>;
@@ -683,6 +684,7 @@
 				status = "disabled";
 				easydma-maxcnt-bits = <15>;
 				interrupts = <231 NRF_DEFAULT_IRQ_PRIORITY>;
+				clocks = <&hsfll120>;
 				power-domains = <&gpd NRF_GPD_FAST_ACTIVE1>;
 				max-frequency = <DT_FREQ_M(32)>;
 				#address-cells = <1>;


### PR DESCRIPTION
*drivers: clock_control_nrf2: Add missing cancelation of request*

This is a follow-up to commit https://github.com/zephyrproject-rtos/zephyr/commit/fe0e2dbc6044ffa74b27bfcba335980bc5a6ae64.

If `nrf_clock_control_request_sync()` ends up with a timeout, before returning it must cancel the request that was not fulfilled on time. Otherwise, the request may actually finish succesfully a bit later, but the caller will not be aware that the clock needs to be released (since the call resulted in an error).

*dts: nrf54h20: Add clocks property in fast SPIM nodes*

Fast SPIM instances in nRF54H20 (SPIM120 and SPIM121) are driven by the global HSFLL (HSFLL120). Add `clocks` property in these nodes to reflect this.

*drivers: spi_nrfx_spim: Add clock requests for fast SPIM instances*

Fast SPIM instances (SPIM120 and SPIM121) for correct operation require the highest frequency from the global HSFLL. This commit adds needed clock controller requests to the driver. When the runtime device power management is enabled, the frequency is requested as long as the SPIM is resumed, otherwise it is requested for the duration of transfers.