### PR TITLE
[nrf fromlist] include: drivers: nrf_clock_control: make nrf_clock inclusion stricter

### DIFF
--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NRF_CLOCK_CONTROL_H_
 
 #include <zephyr/device.h>
-#ifdef NRF_CLOCK
+#if defined(NRF_CLOCK) && !defined(NRF_LFRC)
 #include <hal/nrf_clock.h>
 #endif
 #include <zephyr/sys/onoff.h>


### PR DESCRIPTION
Some devices do not support nrf_clock HAL.

Upstream PR #: 83115 : https://github.com/zephyrproject-rtos/zephyr/pull/83115