### PR TITLE
Add radio core image to usb-hid sample

### DIFF
--- a/samples/subsys/usb/hid-keyboard/Kconfig.sysbuild
+++ b/samples/subsys/usb/hid-keyboard/Kconfig.sysbuild
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+source "${ZEPHYR_BASE}/share/sysbuild/Kconfig"
+
+config REMOTE_BOARD
+	string "The board used for remote target"

--- a/samples/subsys/usb/hid-keyboard/sample.yaml
+++ b/samples/subsys/usb/hid-keyboard/sample.yaml
@@ -1,6 +1,7 @@
 sample:
   name: USB HID keyboard sample
 common:
+  sysbuild: true
   harness: button
   filter: dt_alias_exists("sw0") and dt_alias_exists("led0")
   depends_on:
@@ -17,6 +18,8 @@ common:
 tests:
   sample.usbd.hid-keyboard:
     tags: usb
+    extra_args:
+      - SB_CONF_FILE=sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
   sample.usbd.hid-keyboard.out-report:
     tags: usb
     extra_args:

--- a/samples/subsys/usb/hid-keyboard/sysbuild.cmake
+++ b/samples/subsys/usb/hid-keyboard/sysbuild.cmake
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+
+if("${SB_CONFIG_REMOTE_BOARD}" STREQUAL "")
+  message(FATAL_ERROR "REMOTE_BOARD must be set to a valid board name")
+endif()
+
+# Add remote project
+ExternalZephyrProject_Add(
+    APPLICATION remote
+    SOURCE_DIR ${SYSBUILD_NRF_MODULE_DIR}/tests/benchmarks/power_consumption/common/remote_sleep_forever
+    BOARD ${SB_CONFIG_REMOTE_BOARD}
+    BOARD_REVISION ${BOARD_REVISION}
+  )
+
+# Add a dependency so that the remote image will be built and flashed first
+add_dependencies(hid-keyboard remote)
+# Add dependency so that the remote image is flashed first.
+sysbuild_add_dependencies(FLASH hid-keyboard remote)

--- a/samples/subsys/usb/hid-keyboard/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/samples/subsys/usb/hid-keyboard/sysbuild/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,1 @@
+SB_CONFIG_REMOTE_BOARD="nrf54h20dk/nrf54h20/cpurad"


### PR DESCRIPTION
Debugging USB sample power consumption, enable empty radio image for the usb-hid sample