### PR TITLE
[nrf fromtree] net: lib: tls_credentials: return size required

### DIFF
--- a/include/zephyr/net/tls_credentials.h
+++ b/include/zephyr/net/tls_credentials.h
@@ -107,6 +107,7 @@ int tls_credential_add(sec_tag_t tag, enum tls_credential_type type,
  * @retval -EACCES Access to the TLS credential subsystem was denied.
  * @retval -ENOENT Requested TLS credential was not found.
  * @retval -EFBIG Requested TLS credential does not fit in the buffer provided.
+ *                Check *credlen for size required.
  */
 int tls_credential_get(sec_tag_t tag, enum tls_credential_type type,
 		       void *cred, size_t *credlen);


### PR DESCRIPTION
If either no buffer is provided or the size of it is too small, return the required length.

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>
(cherry picked from commit 6ec5729a3dd80ef8bd4b2aa02263e6d4b75e5e72)