### PR TITLE
[nrf noup] drivers: clock_control: nrf: skip nrf_clock.h on haltium

### DIFF
--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NRF_CLOCK_CONTROL_H_
 
 #include <zephyr/device.h>
-#ifdef NRF_CLOCK
+#if defined(NRF_CLOCK) && !defined(CONFIG_NRF_PLATFORM_HALTIUM)
 #include <hal/nrf_clock.h>
 #endif
 #include <zephyr/sys/onoff.h>


### PR DESCRIPTION
Don't include hal/nrf_clock.h on Haltium platforms as that HAL currently does not compile for those. Since this issue only affects projects that are downstream of NCS, and should be fixed soon by NRFX-6892, this patch is made as a temporary no-up that can be reverted along with the introduction of the fix.

Ref: NCSDK-31213