### PR TITLE
[Backport v3.7.99-ncs3-branch] [nrf fromtree] tests: drivers: uart: async_api: Add nrf54h20 cpuppr and UARTE120 test

### DIFF
--- a/tests/drivers/uart/uart_async_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "nrf54h20dk_nrf54h20_common.dtsi"

--- a/tests/drivers/uart/uart_async_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/uart/uart_async_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+#include "../../../boards/nrf54h20dk_nrf54h20_common.dtsi"
+
+&dut {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};

--- a/tests/drivers/uart/uart_async_api/sysbuild/vpr_launcher/prj.conf
+++ b/tests/drivers/uart/uart_async_api/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,1 @@
+# nothing here


### PR DESCRIPTION
Backport 09b87e9262d6bc87206114dc14d1d10c585fbc0f from #2187.