### PR TITLE
[nrf fromtree] dfu: boot: mcuboot: fix boot_is_img_confirmed

### DIFF
--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -233,7 +233,7 @@ bool boot_is_img_confirmed(void)
 	const struct flash_area *fa;
 	int rc;
 
-	rc = flash_area_open(FLASH_AREA_IMAGE_PRIMARY, &fa);
+	rc = flash_area_open(ACTIVE_SLOT_FLASH_AREA_ID, &fa);
 	if (rc) {
 		return false;
 	}


### PR DESCRIPTION
Fix image confirmed for Direct XIP.

Signed-off-by: Fin Maaß <f.maass@vogl-electronic.com>
(cherry picked from commit e3f935650b976f098d19ff304344e83103ad0491)