### PR TITLE
[nrf fromtree] kernel: timeout: ensure next timeout is set when abort…

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -147,8 +147,13 @@ int z_abort_timeout(struct _timeout *to)
 
 	K_SPINLOCK(&timeout_lock) {
 		if (sys_dnode_is_linked(&to->node)) {
+			bool is_first = (to == first());
+
 			remove_timeout(to);
 			ret = 0;
+			if (is_first) {
+				sys_clock_set_timeout(next_timeout(), false);
+			}
 		}
 	}
 


### PR DESCRIPTION
…ing the first timeout

Ref: NCSDK-31290

This ensures that the system clock is correctly updated when the first timeout is aborted, preventing unexpected early wake-up by the system clock programmed previously.

Signed-off-by: Dong Wang <dong.d.wang@intel.com>
(cherry picked from commit dd5f11cb04b834584a6d851fe55a9673e25a5356)