### PR TITLE
[nrf fromlist] arch: riscv: option to init custom hw stacked esf memb…

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -83,6 +83,11 @@ config RISCV_SOC_HAS_ISR_STACKING
 	    saved on the stack by the hardware, and the registers saved by the
 	    software macros. The structure must be called 'struct arch_esf'.
 
+	  - SOC_ISR_STACKING_ESR_INIT: macro guarded by !_ASMLANGUAGE.
+	    Some hardware stacked registers should be initialized on init
+	    stack with proper values. This prevents from incorrect behavior
+	    on entry context switch when initial stack is restored.
+
 config RISCV_SOC_HAS_CUSTOM_IRQ_HANDLING
 	bool
 	help

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -106,6 +106,10 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	stack_init->soc_context = soc_esf_init;
 #endif
 
+#ifdef CONFIG_RISCV_SOC_HAS_ISR_STACKING
+	SOC_ISR_STACKING_ESR_INIT;
+#endif
+
 	thread->callee_saved.sp = (unsigned long)stack_init;
 
 	/* where to go when returning from z_riscv_switch() */

--- a/soc/nordic/common/vpr/soc_isr_stacking.h
+++ b/soc/nordic/common/vpr/soc_isr_stacking.h
@@ -62,6 +62,13 @@
 
 #endif /* DT_PROP(VPR_CPU, nordic_bus_width) == 64 */
 
+/*
+ * VPR stacked mcause needs to have proper value on initial stack.
+ * Initial mret will restore this value.
+ */
+#define SOC_ISR_STACKING_ESR_INIT                                                                  \
+	stack_init->_mcause = 0;
+
 #else /* _ASMLANGUAGE */
 
 /*


### PR DESCRIPTION
…ers.

When RISCV_SOC_HAS_ISR_STACKING is used, it may
be needed to initialize custom hw stacked esf members. Some initial values may need to be aligned with
hw stacking mechanism to avoid any side effects.

Upstream PR #: 84076