### PR TITLE
nrf54h20 flpr fixes

### DIFF
--- a/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
+++ b/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
@@ -7,6 +7,7 @@
 
 #include <string.h>
 
+#include <zephyr/cache.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
@@ -38,6 +39,11 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 		LOG_DBG("Loading VPR (%p) from %p to %p (%zu bytes)", config->vpr,
 			(void *)config->src_addr, (void *)config->exec_addr, config->size);
 		memcpy((void *)config->exec_addr, (void *)config->src_addr, config->size);
+#if defined(CONFIG_DCACHE)
+		LOG_DBG("Writing back cache with loaded VPR (from %p %zu bytes)",
+			(void *)config->exec_addr, config->size);
+		sys_cache_data_flush_range((void *)config->exec_addr, config->size);
+#endif
 	}
 #endif
 

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -84,7 +84,7 @@
 			device_type = "cpu";
 			clock-frequency = <DT_FREQ_M(320)>;
 			riscv,isa = "rv32emc";
-			nordic,bus-width = <64>;
+			nordic,bus-width = <32>;
 
 			cpuflpr_vevif_rx: mailbox {
 				compatible = "nordic,nrf-vevif-task-rx";


### PR DESCRIPTION
Write-back cache after copying VPR's code and data to the destination memory. It allows VPRs to run from RAM regions cacheable by its host.

It allows to use FLPR in nRF54H20.

Upstream PR #: 84104