### PR TITLE
[nrf fromtree] modules: hal_nordic: use CLOCK_CONTROL_NRF2 for HFCLK …

### DIFF
--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -23,6 +23,7 @@ menuconfig NRF_802154_RADIO_DRIVER
 	depends on HAS_HW_NRF_RADIO_IEEE802154
 	select DYNAMIC_INTERRUPTS
 	select ENTROPY_GENERATOR
+	select CLOCK_CONTROL
 	depends on !$(dt_nodelabel_enabled,timer1)
 	help
 	  This option enables nRF IEEE 802.15.4 radio driver in Zephyr. Note,

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
@@ -11,12 +11,7 @@
 
 #include <compiler_abstraction.h>
 #include <zephyr/kernel.h>
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
 #include <zephyr/drivers/clock_control/nrf_clock_control.h>
-#include <zephyr/drivers/clock_control.h>
-#elif !defined(NRF54H_SERIES)
-#error No implementation to start or stop HFCLK due to missing clock_control.
-#endif
 
 static bool hfclk_is_running;
 
@@ -35,7 +30,6 @@ bool nrf_802154_clock_hfclk_is_running(void)
 	return hfclk_is_running;
 }
 
-#if defined(CONFIG_CLOCK_CONTROL_NRF)
 
 static struct onoff_client hfclk_cli;
 
@@ -48,6 +42,7 @@ static void hfclk_on_callback(struct onoff_manager *mgr,
 	nrf_802154_clock_hfclk_ready();
 }
 
+#if defined(CONFIG_CLOCK_CONTROL_NRF)
 void nrf_802154_clock_hfclk_start(void)
 {
 	int ret;
@@ -75,40 +70,22 @@ void nrf_802154_clock_hfclk_stop(void)
 	hfclk_is_running = false;
 }
 
-#elif defined(NRF54H_SERIES)
-
-#define NRF_LRCCONF_RADIO_PD NRF_LRCCONF010
-/* HF clock time to ramp-up. */
-#define MAX_HFXO_RAMP_UP_TIME_US 550
-
-static void hfclk_started_timer_handler(struct k_timer *dummy)
-{
-	hfclk_is_running = true;
-	nrf_802154_clock_hfclk_ready();
-}
-
-K_TIMER_DEFINE(hfclk_started_timer, hfclk_started_timer_handler, NULL);
+#elif defined(CONFIG_CLOCK_CONTROL_NRF2)
 
 void nrf_802154_clock_hfclk_start(void)
 {
-	/* Use register directly, there is no support for that task in nrf_lrcconf_task_trigger.
-	 * This code might cause troubles if there are other HFXO users in this CPU.
-	 */
-	NRF_LRCCONF_RADIO_PD->EVENTS_HFXOSTARTED = 0x0;
-	NRF_LRCCONF_RADIO_PD->TASKS_REQHFXO = 0x1;
+	sys_notify_init_callback(&hfclk_cli.notify, hfclk_on_callback);
+	int ret = nrf_clock_control_request(DEVICE_DT_GET(DT_NODELABEL(hfxo)), NULL, &hfclk_cli);
 
-	k_timer_start(&hfclk_started_timer, K_USEC(MAX_HFXO_RAMP_UP_TIME_US), K_NO_WAIT);
+	__ASSERT_NO_MSG(ret >= 0);
 }
 
 void nrf_802154_clock_hfclk_stop(void)
 {
-	/* Use register directly, there is no support for that task in nrf_lrcconf_task_trigger.
-	 * This code might cause troubles if there are other HFXO users in this CPU.
-	 */
-	NRF_LRCCONF_RADIO_PD->TASKS_STOPREQHFXO = 0x1;
-	NRF_LRCCONF_RADIO_PD->EVENTS_HFXOSTARTED = 0x0;
+	int ret = nrf_clock_control_cancel_or_release(DEVICE_DT_GET(DT_NODELABEL(hfxo)),
+						      NULL, &hfclk_cli);
 
-	hfclk_is_running = false;
+	__ASSERT_NO_MSG(ret >= 0);
 }
 
 #endif


### PR DESCRIPTION
…request/release

Makes 802.15.4 use the API under CONFIG_CLOCK_CONTROL_NRF2 in nrf_clock_control.h to request/release HFCLK.

Previous HFCLK requesting/releasing on nRF54H20 was more of a workaround and could produce issues when
comes to sharing the resources.

Signed-off-by: Piotr Koziar <piotr.koziar@nordicsemi.no>
(cherry picked from commit b6ca9dbc713bffd80ad6a5d5b4cb4564fd192042)