### PR TITLE
[Backport v3.7.99-ncs3-branch] [nrf fromtree] kernel: timeout: ensure next timeout is set when abort…

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -147,8 +147,13 @@ int z_abort_timeout(struct _timeout *to)
 
 	K_SPINLOCK(&timeout_lock) {
 		if (sys_dnode_is_linked(&to->node)) {
+			bool is_first = (to == first());
+
 			remove_timeout(to);
 			ret = 0;
+			if (is_first) {
+				sys_clock_set_timeout(next_timeout(), false);
+			}
 		}
 	}
 


### PR DESCRIPTION
Backport 76a46cb2baf310a06bbdb0b1d7d99394ec04a671 from #2430.