### PR TITLE
Cherry pick GPD yield() to not block if thread is coop

### DIFF
--- a/soc/nordic/nrf54h/gpd/gpd.c
+++ b/soc/nordic/nrf54h/gpd/gpd.c
@@ -139,6 +139,8 @@ static int nrf_gpd_sync(struct gpd_onoff_manager *gpd_mgr)
 		if (atomic_test_bit(&gpd_service_status, GPD_SERVICE_REQ_OK)) {
 			return 0;
 		}
+
+		k_yield();
 	}
 
 	LOG_ERR("nRFs GDPWR request timed out");


### PR DESCRIPTION
The main thread, if configured with coop priority (don't do that :D) breaks gpd since it has a non yielding while loop (also don't do that)

Add an explicit yield() to allow other threads to run if main or other threads use gpd with coop prio.

Upstream PR #: 84598