### PR TITLE
[nrf noup] boards: Update non-secure target for nrf54l15

### DIFF
--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp_ns.yaml
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuapp_ns.yaml
@@ -9,6 +9,7 @@ toolchain:
   - gnuarmemb
   - xtools
   - zephyr
+sysbuild: true
 ram: 256
 flash: 1524
 supported:


### PR DESCRIPTION
Enables forcing use of sysbuild to build nrf54l15dk non-secure board target when using twister

It fixes Twister nightly regression, can be tested with comamnd:
`$ZEPHYR_BASE/scripts/twister -vv -p nrf54l15dk/nrf54l15/cpuapp/ns -T $ZEPHYR_BASE/tests/subsys/mgmt/mcumgr`

Similar fix on Upstream: https://github.com/zephyrproject-rtos/zephyr/pull/82907
(however this board is only on NCS, why it is [nrf noap] commit)