### PR TITLE
[nrf fromtree] modules: hal_nordic: Adding SWEXT service

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -193,7 +193,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 35bf3ca665122ddfe8c0c38cec8f19deef2ff62d
+      revision: 1e1048562ff98563d492c8dcab1ee85775547abc
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Adding support for SWEXT (SWitch EXTernal) peripheral.