### PR TITLE
[nrf fromtree] drivers: udc_dwc2: Rework control endpoint feeding

### DIFF
--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -250,6 +250,28 @@ static uint32_t dwc2_get_iept_xfersize(const struct device *dev, const uint32_t 
 	}
 }
 
+static uint32_t dwc2_get_oept_pktctn(const struct device *dev, const uint32_t idx)
+{
+	struct udc_dwc2_data *const priv = udc_get_private(dev);
+
+	if (idx == 0) {
+		return usb_dwc2_get_doeptsiz0_pktcnt(UINT32_MAX);
+	} else {
+		return priv->max_pktcnt;
+	}
+}
+
+static uint32_t dwc2_get_oept_xfersize(const struct device *dev, const uint32_t idx)
+{
+	struct udc_dwc2_data *const priv = udc_get_private(dev);
+
+	if (idx == 0) {
+		return usb_dwc2_get_doeptsiz0_xfersize(UINT32_MAX);
+	} else {
+		return priv->max_xfersize;
+	}
+}
+
 static void dwc2_flush_rx_fifo(const struct device *dev)
 {
 	struct usb_dwc2_reg *const base = dwc2_get_base(dev);
@@ -582,10 +604,15 @@ static void dwc2_prep_rx(const struct device *dev, struct net_buf *buf,
 	uint8_t ep_idx = USB_EP_GET_IDX(cfg->addr);
 	mem_addr_t doeptsiz_reg = (mem_addr_t)&base->out_ep[ep_idx].doeptsiz;
 	mem_addr_t doepctl_reg = dwc2_get_dxepctl_reg(dev, ep_idx);
+	uint32_t max_xfersize, max_pktcnt;
+	const uint32_t addnl = USB_MPS_ADDITIONAL_TRANSACTIONS(cfg->mps);
 	uint32_t pktcnt;
 	uint32_t doeptsiz;
 	uint32_t doepctl;
 	uint32_t xfersize;
+
+	max_xfersize = dwc2_get_oept_xfersize(dev, ep_idx);
+	max_pktcnt = dwc2_get_oept_pktctn(dev, ep_idx);
 
 	/* Clear NAK and set endpoint enable */
 	doepctl = sys_read32(doepctl_reg);
@@ -593,7 +620,7 @@ static void dwc2_prep_rx(const struct device *dev, struct net_buf *buf,
 
 	if (dwc2_ep_is_iso(cfg)) {
 		xfersize = USB_MPS_TO_TPL(cfg->mps);
-		pktcnt = 1 + USB_MPS_ADDITIONAL_TRANSACTIONS(cfg->mps);
+		pktcnt = 1 + addnl;
 
 		if (xfersize > net_buf_tailroom(buf)) {
 			LOG_ERR("ISO RX buffer too small");
@@ -610,14 +637,18 @@ static void dwc2_prep_rx(const struct device *dev, struct net_buf *buf,
 		xfersize = net_buf_tailroom(buf);
 
 		/* Do as many packets in a single transfer as possible */
-		if (xfersize > priv->max_xfersize) {
-			xfersize = ROUND_DOWN(priv->max_xfersize, USB_MPS_TO_TPL(cfg->mps));
+		if (xfersize > max_xfersize) {
+			xfersize = ROUND_DOWN(max_xfersize, USB_MPS_TO_TPL(cfg->mps));
 		}
 
 		pktcnt = DIV_ROUND_UP(xfersize, USB_MPS_EP_SIZE(cfg->mps));
 	}
 
-	pktcnt = DIV_ROUND_UP(xfersize, udc_mps_ep_size(cfg));
+	if (pktcnt > max_pktcnt) {
+		pktcnt = ROUND_DOWN(max_pktcnt, (1 + addnl));
+		xfersize = pktcnt * udc_mps_ep_size(cfg);
+	}
+
 	doeptsiz = usb_dwc2_set_doeptsizn_pktcnt(pktcnt) |
 		   usb_dwc2_set_doeptsizn_xfersize(xfersize);
 	if (cfg->addr == USB_CONTROL_EP_OUT) {

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -2540,7 +2540,7 @@ static inline void dwc2_handle_out_xfercompl(const struct device *dev,
 		net_buf_add(buf, bcnt);
 	}
 
-	if (!is_iso && (bcnt % udc_mps_ep_size(ep_cfg)) == 0 &&
+	if (!is_iso && bcnt && (bcnt % udc_mps_ep_size(ep_cfg)) == 0 &&
 	    net_buf_tailroom(buf)) {
 		dwc2_prep_rx(dev, buf, ep_cfg);
 	} else {

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -203,6 +203,20 @@ static void dwc2_wait_for_bit(const struct device *dev,
 	}
 }
 
+static inline bool dwc2_in_completer_mode(const struct device *dev)
+{
+	struct udc_dwc2_data *const priv = udc_get_private(dev);
+
+	return !IS_ENABLED(CONFIG_UDC_DWC2_DMA) || !priv->bufferdma;
+}
+
+static inline bool dwc2_in_buffer_dma_mode(const struct device *dev)
+{
+	struct udc_dwc2_data *const priv = udc_get_private(dev);
+
+	return IS_ENABLED(CONFIG_UDC_DWC2_DMA) && priv->bufferdma;
+}
+
 /* Get DOEPCTLn or DIEPCTLn register address */
 static mem_addr_t dwc2_get_dxepctl_reg(const struct device *dev, const uint8_t ep)
 {
@@ -422,7 +436,7 @@ static int dwc2_tx_fifo_write(const struct device *dev,
 		len = buf->len;
 	}
 
-	if (!priv->bufferdma) {
+	if (dwc2_in_completer_mode(dev)) {
 		uint32_t spcavail = dwc2_ftx_avail(dev, ep_idx);
 		uint32_t spcperpkt = ROUND_UP(udc_mps_ep_size(cfg), 4);
 		uint32_t max_pkts, max_transfer;
@@ -487,7 +501,7 @@ static int dwc2_tx_fifo_write(const struct device *dev,
 		    usb_dwc2_set_dieptsizn_pktcnt(pktcnt) |
 		    usb_dwc2_set_dieptsizn_xfersize(len), dieptsiz_reg);
 
-	if (priv->bufferdma) {
+	if (dwc2_in_buffer_dma_mode(dev)) {
 		if (!dwc2_dma_buffer_ok_to_use(dev, buf->data, len, cfg->mps)) {
 			/* Cannot continue unless buffer is bounced. Device will
 			 * cease to function. Is fatal error appropriate here?
@@ -530,7 +544,7 @@ static int dwc2_tx_fifo_write(const struct device *dev,
 	/* Clear IN Endpoint NAK Effective interrupt in case it was set */
 	sys_write32(USB_DWC2_DIEPINT_INEPNAKEFF, diepint_reg);
 
-	if (!priv->bufferdma) {
+	if (dwc2_in_completer_mode(dev)) {
 		const uint8_t *src = buf->data;
 
 		while (pktcnt > 0) {
@@ -659,7 +673,7 @@ static void dwc2_prep_rx(const struct device *dev, struct net_buf *buf,
 	priv->rx_siz[ep_idx] = doeptsiz;
 	sys_write32(doeptsiz, doeptsiz_reg);
 
-	if (priv->bufferdma) {
+	if (dwc2_in_buffer_dma_mode(dev)) {
 		void *data = net_buf_tail(buf);
 
 		if (!dwc2_dma_buffer_ok_to_use(dev, data, xfersize, cfg->mps)) {
@@ -1211,7 +1225,7 @@ static int dwc2_set_dedicated_fifo(const struct device *dev,
 	tmp = *diepctl & ~USB_DWC2_DEPCTL_TXFNUM_MASK;
 
 	reqdep = DIV_ROUND_UP(udc_mps_ep_size(cfg), 4U);
-	if (priv->bufferdma) {
+	if (dwc2_in_buffer_dma_mode(dev)) {
 		/* In DMA mode, TxFIFO capable of holding 2 packets is enough */
 		reqdep *= MIN(2, (1 + addnl));
 	} else {
@@ -2292,7 +2306,7 @@ static void dwc2_on_bus_reset(const struct device *dev)
 	}
 
 	doepmsk = USB_DWC2_DOEPINT_SETUP | USB_DWC2_DOEPINT_XFERCOMPL;
-	if (priv->bufferdma) {
+	if (dwc2_in_buffer_dma_mode(dev)) {
 		doepmsk |= USB_DWC2_DOEPINT_STSPHSERCVD;
 	}
 
@@ -2300,7 +2314,7 @@ static void dwc2_on_bus_reset(const struct device *dev)
 	sys_set_bits((mem_addr_t)&base->diepmsk, USB_DWC2_DIEPINT_XFERCOMPL);
 
 	/* Software has to handle RxFLvl interrupt only in Completer mode */
-	if (!priv->bufferdma) {
+	if (dwc2_in_completer_mode(dev)) {
 		sys_set_bits((mem_addr_t)&base->gintmsk,
 			     USB_DWC2_GINTSTS_RXFLVL);
 	}
@@ -2506,7 +2520,7 @@ static inline void dwc2_handle_out_xfercompl(const struct device *dev,
 		}
 
 		if (!valid) {
-			if (!priv->bufferdma) {
+			if (dwc2_in_completer_mode(dev)) {
 				/* RxFlvl added data to net buf, rollback */
 				net_buf_remove_mem(buf, bcnt);
 			}
@@ -2515,7 +2529,7 @@ static inline void dwc2_handle_out_xfercompl(const struct device *dev,
 		}
 	}
 
-	if (priv->bufferdma && bcnt) {
+	if (dwc2_in_buffer_dma_mode(dev) && bcnt) {
 		sys_cache_data_invd_range(net_buf_tail(buf), bcnt);
 		net_buf_add(buf, bcnt);
 	}
@@ -2559,7 +2573,8 @@ static inline void dwc2_handle_oepint(const struct device *dev)
 		/* StupPktRcvd is not enabled for interrupt, but must be checked
 		 * when XferComp hits to determine if SETUP token was received.
 		 */
-		if (priv->bufferdma && (status & USB_DWC2_DOEPINT_XFERCOMPL) &&
+		if (dwc2_in_buffer_dma_mode(dev) &&
+		    (status & USB_DWC2_DOEPINT_XFERCOMPL) &&
 		    (doepint & USB_DWC2_DOEPINT_STUPPKTRCVD)) {
 			uint32_t addr;
 

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1591,6 +1591,9 @@ static int udc_dwc2_ep_set_halt(const struct device *dev,
 	LOG_DBG("Set halt ep 0x%02x", cfg->addr);
 	if (ep_idx != 0) {
 		cfg->stat.halted = true;
+	} else if (!udc_buf_peek(dev, USB_CONTROL_EP_OUT)) {
+		/* Data stage is STALLed, allow receiving next SETUP */
+		dwc2_ctrl_feed_dout(dev, 8);
 	}
 
 	return 0;

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -660,17 +660,19 @@ static void dwc2_prep_rx(const struct device *dev, struct net_buf *buf,
 	sys_write32(doeptsiz, doeptsiz_reg);
 
 	if (priv->bufferdma) {
-		if (!dwc2_dma_buffer_ok_to_use(dev, buf->data, xfersize, cfg->mps)) {
+		void *data = net_buf_tail(buf);
+
+		if (!dwc2_dma_buffer_ok_to_use(dev, data, xfersize, cfg->mps)) {
 			/* Cannot continue unless buffer is bounced. Device will
 			 * cease to function. Is fatal error appropriate here?
 			 */
 			return;
 		}
 
-		sys_write32((uint32_t)buf->data,
+		sys_write32((uint32_t)data,
 			    (mem_addr_t)&base->out_ep[ep_idx].doepdma);
 
-		sys_cache_data_invd_range(buf->data, xfersize);
+		sys_cache_data_invd_range(data, xfersize);
 	}
 
 	sys_write32(doepctl, doepctl_reg);
@@ -2514,7 +2516,7 @@ static inline void dwc2_handle_out_xfercompl(const struct device *dev,
 	}
 
 	if (priv->bufferdma && bcnt) {
-		sys_cache_data_invd_range(buf->data, bcnt);
+		sys_cache_data_invd_range(net_buf_tail(buf), bcnt);
 		net_buf_add(buf, bcnt);
 	}
 


### PR DESCRIPTION
Cherry pick control transfer related fixes.