### PR TITLE
[nrf noup] tests: drivers: mspi: api: nRF54L15 fix device frequency

### DIFF
--- a/tests/drivers/mspi/api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/mspi/api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -18,7 +18,7 @@
 			status = "okay";
 			compatible = "zephyr,mspi-emul-device";
 			reg = <0x0>;
-			mspi-max-frequency = <48000000>;
+			mspi-max-frequency = <DT_FREQ_M(1)>;
 		};
 	};
 };


### PR DESCRIPTION
~Remove definition of dummy device since there is already external flash defined in SDP MSPI snippets.~

Changed to fix device frequency. Due to changes from https://github.com/nrfconnect/sdk-nrf/pull/20209 the device frequency now needs to be one of the specified.