### PR TITLE
[Backport v3.7.99-ncs3-branch] Bump nrf regtool v8.1.2 ncs

### DIFF
--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -15,7 +15,7 @@ if(CONFIG_NRF_REGTOOL_GENERATE_BICR)
   list(APPEND nrf_regtool_components GENERATE:BICR)
 endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 8.0.0 REQUIRED
+  find_package(nrf-regtool 8.0.0
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH

--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -15,7 +15,7 @@ if(CONFIG_NRF_REGTOOL_GENERATE_BICR)
   list(APPEND nrf_regtool_components GENERATE:BICR)
 endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 8.1.2
+  find_package(nrf-regtool 8.1.2 REQUIRED
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH

--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -15,7 +15,7 @@ if(CONFIG_NRF_REGTOOL_GENERATE_BICR)
   list(APPEND nrf_regtool_components GENERATE:BICR)
 endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 8.0.0
+  find_package(nrf-regtool 8.1.2
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH


### PR DESCRIPTION
Backport c8aea90f09265465244b6881a5c4a93486c5eef0~3..c8aea90f09265465244b6881a5c4a93486c5eef0 from #2467.