### PR TITLE
[nrf fromtree] logging: frontends: stmesp: Fix logging single argumen…

### DIFF
--- a/subsys/logging/frontends/stmesp/zephyr_custom_log.h
+++ b/subsys/logging/frontends/stmesp/zephyr_custom_log.h
@@ -69,7 +69,8 @@ extern "C" {
 		/* Do turbo logging only if argument fits in 32 bit word. */                       \
 		if (!Z_LOG_STMESP_1_ARG_CHECK(__VA_ARGS__)) {                                      \
 			COND_CODE_1(CONFIG_LOG_FRONTEND_STMESP_TURBO_DROP_OTHERS, (),              \
-				(Z_LOG(_level, __VA_ARGS__)));                             \
+				(Z_LOG(_level, __VA_ARGS__)));                                     \
+			break;                                                                     \
 		}                                                                                  \
 		if (!Z_LOG_LEVEL_ALL_CHECK(_level, __log_current_const_data, _source)) {           \
 			break;                                                                     \


### PR DESCRIPTION
…t log twice

Macro was missing a break when single argument with non 32 bit word argument was detect. Because of that, there were two logging messages created for a single log entry.

Signed-off-by: Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>
(cherry picked from commit 9b2532ab431b9d7dd5c67f72ab67b8ea271acec3)