### PR TITLE
[nrf noup] lib: net_buf: buf: Revert alloc DBG to WRN change

### DIFF
--- a/lib/net_buf/buf.c
+++ b/lib/net_buf/buf.c
@@ -273,7 +273,7 @@ struct net_buf *net_buf_alloc_len(struct net_buf_pool *pool, size_t size,
 
 	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT) &&
 	    k_current_get() == k_work_queue_thread_get(&k_sys_work_q)) {
-		LOG_WRN("Timeout discarded. No blocking in syswq");
+		LOG_DBG("Timeout discarded. No blocking in syswq");
 		timeout = K_NO_WAIT;
 	}
 


### PR DESCRIPTION
This warning is raised in many places when using bluetooth. However, it is not very useful for the user to see.

This is a noup PR as there is currently more changes coming in around this code and how to handle deadlocks in zephyr.