### PR TITLE
[nrf fromtree] Run pdm tests on nrf54l20pdk

### DIFF
--- a/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
+++ b/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
@@ -15,6 +15,7 @@ flash: 449
 supported:
   - adc
   - counter
+  - dmic
   - gpio
   - i2c
   - pwm

--- a/samples/drivers/audio/dmic/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/samples/drivers/audio/dmic/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	pdm20_default_alt: pdm20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 10)>,
+				<NRF_PSEL(PDM_DIN, 1, 11)>;
+		};
+	};
+};
+
+dmic_dev: &pdm20 {
+	status = "okay";
+	pinctrl-0 = <&pdm20_default_alt>;
+	pinctrl-names = "default";
+	clock-source = "PCLK32M";
+};

--- a/tests/drivers/audio/dmic_api/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/tests/drivers/audio/dmic_api/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		dmic-dev = &pdm20;
+	};
+};
+
+&pinctrl {
+	pdm20_default_alt: pdm20_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 1, 10)>,
+				<NRF_PSEL(PDM_DIN, 1, 11)>;
+		};
+	};
+};
+
+dmic_dev: &pdm20 {
+	status = "okay";
+	pinctrl-0 = <&pdm20_default_alt>;
+	pinctrl-names = "default";
+	clock-source = "PCLK32M";
+};

--- a/tests/drivers/audio/dmic_api/src/main.c
+++ b/tests/drivers/audio/dmic_api/src/main.c
@@ -21,14 +21,21 @@ static const struct device *dmic_dev = DEVICE_DT_GET(DT_ALIAS(dmic_dev));
 #define BYTES_PER_SAMPLE sizeof(int16_t)
 #define SLAB_ALIGN 4
 #define MAX_SAMPLE_RATE  48000
+#elif DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_pdm)
+#define PDM_CHANNELS 2
+#define SAMPLE_BIT_WIDTH 16
+#define BYTES_PER_SAMPLE sizeof(int16_t)
+#define SLAB_ALIGN 4
+#define MAX_SAMPLE_RATE  48000
+#else
+#error "Unsupported DMIC device"
+#endif
+
 /* Milliseconds to wait for a block to be read. */
 #define READ_TIMEOUT 1000
 /* Size of a block for 100 ms of audio data. */
 #define BLOCK_SIZE(_sample_rate, _number_of_channels) \
 	(BYTES_PER_SAMPLE * (_sample_rate / 10) * _number_of_channels)
-#else
-#error "Unsupported DMIC device"
-#endif
 
 /* Driver will allocate blocks from this slab to receive audio data into them.
  * Application, after getting a given block from the driver and processing its


### PR DESCRIPTION
Enable PDM tests on nRF54L20pdk.

manifest-pr-skip