### PR TITLE
Nrfx 6832 enable sensor tests on nrf54l20pdk

### DIFF
--- a/samples/sensor/qdec/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
+++ b/samples/sensor/qdec/boards/nrf54l20pdk_nrf54l20_cpuapp.overlay
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		qdec0 = &qdec20;
+		qenca = &phase_a;
+		qencb = &phase_b;
+	};
+
+	encoder-emulate {
+		compatible = "gpio-leds";
+		phase_a: phase_a {
+			gpios = <&gpio1 0 GPIO_ACTIVE_HIGH>;
+		};
+		phase_b: phase_b {
+			gpios = <&gpio1 2 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&pinctrl {
+	qdec_pinctrl: qdec_pinctrl {
+		group1 {
+			psels = <NRF_PSEL(QDEC_A, 1, 1)>,
+				<NRF_PSEL(QDEC_B, 1, 3)>;
+		};
+	};
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&qdec20 {
+	status = "okay";
+	pinctrl-0 = <&qdec_pinctrl>;
+	pinctrl-names = "default";
+	steps = <120>;
+	led-pre = <500>;
+};

--- a/samples/sensor/qdec/sample.yaml
+++ b/samples/sensor/qdec/sample.yaml
@@ -42,11 +42,13 @@ tests:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     integration_platforms:
       - nrf52840dk/nrf52840
       - nrf5340dk/nrf5340/cpuapp
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54l20pdk/nrf54l20/cpuapp
       - nrf54h20dk/nrf54h20/cpuapp
     harness_config:
       fixture: gpio_loopback


### PR DESCRIPTION
Enable sensor tests on nRF54L20pdk:
- zephyr/tests/drivers/sensor/temp_sensor
- zephyr/samples/sensor/qdec
- zephyr/tests/boards/nrf/qdec

manifest-pr-skip