### PR TITLE
[nrf fromtree] bluetooth: host: Allow for ECDH operations through sys…

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -1002,10 +1002,11 @@ config BT_ECC
 	select PSA_WANT_KEY_TYPE_ECC_KEY_PAIR_EXPORT
 	select PSA_WANT_ECC_SECP_R1_256
 	imply MBEDTLS_PSA_P256M_DRIVER_ENABLED if MBEDTLS_PSA_CRYPTO_C
-	select BT_LONG_WQ
+	imply BT_LONG_WQ
 	help
-	  If this option is set, internal APIs will be available to perform ECDH operations
-	  through the long work queue. operations needed e.g. by LE Secure Connections.
+	  If this option is set, internal APIs will be available to perform ECDH operations through
+	  the long work queue (or system work queue). The operations are used e.g. by LE Secure
+	  Connections.
 
 endif # BT_HCI_HOST
 

--- a/subsys/bluetooth/host/ecc.c
+++ b/subsys/bluetooth/host/ecc.c
@@ -279,7 +279,11 @@ int bt_pub_key_gen(struct bt_pub_key_cb *new_cb)
 
 	atomic_clear_bit(bt_dev.flags, BT_DEV_HAS_PUB_KEY);
 
-	bt_long_wq_submit(&pub_key_work);
+	if (IS_ENABLED(CONFIG_BT_LONG_WQ)) {
+		bt_long_wq_submit(&pub_key_work);
+	} else {
+		k_work_submit(&pub_key_work);
+	}
 
 	return 0;
 }
@@ -338,7 +342,11 @@ int bt_dh_key_gen(const uint8_t remote_pk[BT_PUB_KEY_LEN], bt_dh_key_cb_t cb)
 	sys_memcpy_swap(&ecc.public_key_be[BT_PUB_KEY_COORD_LEN],
 			&remote_pk[BT_PUB_KEY_COORD_LEN], BT_PUB_KEY_COORD_LEN);
 
-	bt_long_wq_submit(&dh_key_work);
+	if (IS_ENABLED(CONFIG_BT_LONG_WQ)) {
+		bt_long_wq_submit(&dh_key_work);
+	} else {
+		k_work_submit(&dh_key_work);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
…tem workq

Change allows performing ECDH operations through system workq. This is done to allow reducing memory consumption by disabling the long workq on small SoCs.

Signed-off-by: Marek Pieta <Marek.Pieta@nordicsemi.no>
(cherry picked from commit c7f3ad6307a034beb486077899440cb6a2eeeca5)