### PR TITLE
[nrf fromtree] tests: drivers: pwm: add support for nRF54H20 cpuppr PWM

### DIFF
--- a/samples/basic/blinky_pwm/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/samples/basic/blinky_pwm/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,21 @@
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led2;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led2: pwm_led_2 {
+			pwms = <&pwm130 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+};
+
+&pwm130 {
+	status = "okay";
+	pinctrl-0 = <&pwm130_default>;
+	pinctrl-1 = <&pwm130_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/samples/basic/blinky_pwm/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/basic/blinky_pwm/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,4 @@
+&pwm130 {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};

--- a/samples/basic/blinky_pwm/sysbuild/vpr_launcher/prj.conf
+++ b/samples/basic/blinky_pwm/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/samples/basic/fade_led/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/samples/basic/fade_led/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,21 @@
+#include <zephyr/dt-bindings/pwm/pwm.h>
+
+/ {
+	aliases {
+		pwm-led0 = &pwm_led2;
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		pwm_led2: pwm_led_2 {
+			pwms = <&pwm130 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		};
+	};
+};
+
+&pwm130 {
+	status = "okay";
+	pinctrl-0 = <&pwm130_default>;
+	pinctrl-1 = <&pwm130_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/samples/basic/fade_led/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/basic/fade_led/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,4 @@
+&pwm130 {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+};

--- a/samples/basic/fade_led/sysbuild/vpr_launcher/prj.conf
+++ b/samples/basic/fade_led/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,1 @@
+# nothing here

--- a/tests/drivers/pwm/pwm_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
+++ b/tests/drivers/pwm/pwm_api/boards/nrf54h20dk_nrf54h20_cpuppr.overlay
@@ -1,0 +1,20 @@
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+			low-power-enable;
+		};
+	};
+};
+
+&pwm130 {
+	status = "okay";
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/tests/drivers/pwm/pwm_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/pwm/pwm_api/sysbuild/vpr_launcher/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,21 @@
+&pinctrl {
+	pwm_default: pwm_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+		};
+	};
+	pwm_sleep: pwm_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 0)>;
+			low-power-enable;
+		};
+	};
+};
+
+&pwm130 {
+	status = "reserved";
+	interrupt-parent = <&cpuppr_clic>;
+	pinctrl-0 = <&pwm_default>;
+	pinctrl-1 = <&pwm_sleep>;
+	pinctrl-names = "default", "sleep";
+};

--- a/tests/drivers/pwm/pwm_api/sysbuild/vpr_launcher/prj.conf
+++ b/tests/drivers/pwm/pwm_api/sysbuild/vpr_launcher/prj.conf
@@ -1,0 +1,1 @@
+# nothing here


### PR DESCRIPTION
Added overlays for nrf54h20_cpuppr to PWM samples and tests.