### PR TITLE
[nrf fromtree] cmake: reports: Add support for JSON prefix

### DIFF
--- a/cmake/reports/CMakeLists.txt
+++ b/cmake/reports/CMakeLists.txt
@@ -29,7 +29,7 @@ foreach(report ram_report rom_report footprint)
     )
 endforeach()
 
-if (CONFIG_BUILD_WITH_TFM)
+if(CONFIG_BUILD_WITH_TFM)
   foreach(report ram_report rom_report footprint)
     add_custom_target(
       tfm_${report}
@@ -40,6 +40,7 @@ if (CONFIG_BUILD_WITH_TFM)
       -o ${CMAKE_BINARY_DIR}
       ${workspace_arg}
       -d ${report_depth}
+      --json tfm_${report}.json
       ${flag_for_${report}}
       DEPENDS tfm
       USES_TERMINAL
@@ -48,22 +49,23 @@ if (CONFIG_BUILD_WITH_TFM)
   endforeach()
 endif()
 
-if (CONFIG_TFM_BL2)
+if(CONFIG_TFM_BL2)
   foreach(report ram_report rom_report footprint)
-  add_custom_target(
-    bl2_${report}
-    ${PYTHON_EXECUTABLE}
-    ${ZEPHYR_BASE}/scripts/footprint/size_report
-    -k $<TARGET_PROPERTY:tfm,BL2_ELF_FILE>
-    -z ${ZEPHYR_BASE}
-    -o ${CMAKE_BINARY_DIR}
-    ${workspace_arg}
-    -d ${report_depth}
-    ${flag_for_${report}}
-    DEPENDS tfm
-    USES_TERMINAL
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    )
+    add_custom_target(
+      bl2_${report}
+      ${PYTHON_EXECUTABLE}
+      ${ZEPHYR_BASE}/scripts/footprint/size_report
+      -k $<TARGET_PROPERTY:tfm,BL2_ELF_FILE>
+      -z ${ZEPHYR_BASE}
+      -o ${CMAKE_BINARY_DIR}
+      ${workspace_arg}
+      -d ${report_depth}
+      --json bl2_${report}.json
+      ${flag_for_${report}}
+      DEPENDS tfm
+      USES_TERMINAL
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+      )
   endforeach()
 endif()
 


### PR DESCRIPTION
Adds support for prefixing files with the target of bl2 or tfm

Signed-off-by: Jamie McCrae <jamie.mccrae@nordicsemi.no>
(cherry picked from commit f80446973a3d2d83037e0413a09b62258649a617)