### PR TITLE
[nrf noup] soc: nrf54l: Non XIP KMU reserved memory fix

### DIFF
--- a/soc/nordic/nrf54l/CMakeLists.txt
+++ b/soc/nordic/nrf54l/CMakeLists.txt
@@ -10,7 +10,7 @@ zephyr_include_directories(.)
 # We need a buffer in memory in a static location which can be used by
 # the KMU peripheral. The KMU has a static destination address, we chose
 # this address to be 0x20000000, which is the first address in the SRAM.
-if(NOT CONFIG_BUILD_WITH_TFM AND CONFIG_PSA_NEED_CRACEN_KMU_DRIVER)
+if(NOT CONFIG_BUILD_WITH_TFM AND CONFIG_PSA_NEED_CRACEN_KMU_DRIVER AND CONFIG_XIP)
 # Exclamation mark is printable character with the lowest number in ASCII table.
 # We are sure that this file will be included first.
 zephyr_linker_sources(RAM_SECTIONS SORT_KEY ! kmu_push_area_section.ld)


### PR DESCRIPTION
The linker script inclusion which places the KMU reserved buffer on the top of RAM doesn't work for non XIP builds. The Zephyr linker script will firstly load the code for an non XIP build in RAM and then include this KMU related linker script which results in an unpredictable placement of the KMU reserved area and a failed build.

In order to support non XIP builds the linker file is not included and the a DTS reserved-memory entry should be used.

To limit the scope, the DTS reserved memory region is currently only supported for non XIP builds.

This is a noup since the KMU is not supported upstream.