### PR TITLE
[nrf fromtree] boards: nordic: nrf54l20pdk: Add SPI to the supported …

### DIFF
--- a/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
+++ b/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
@@ -19,4 +19,5 @@ supported:
   - gpio
   - i2c
   - pwm
+  - spi
   - watchdog

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -9,6 +9,7 @@ common:
   platform_allow:
     - nrf52840dk/nrf52840
     - nrf54l15dk/nrf54l15/cpuapp
+    - nrf54l20pdk/nrf54l20/cpuapp
     - nrf54h20dk/nrf54h20/cpuapp
     - nrf54h20dk/nrf54h20/cpurad
     - nrf54h20dk/nrf54h20/cpuppr


### PR DESCRIPTION
…peripherals

Enable Twister tests of SPI peripheral on nRF54L20pdk.

Upstream PR #: 85928