### PR TITLE
[nrf noup] entropy: Add fake entropy nRF PRNG driver

### DIFF
--- a/dts/arm/nordic/nrf54l09_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l09_enga_cpuapp.dtsi
@@ -18,6 +18,7 @@ nvic: &cpuapp_nvic {};
 / {
 	chosen {
 		zephyr,bt-hci = &bt_hci_controller;
+		zephyr,entropy = &prng;
 	};
 
 	soc {
@@ -29,6 +30,11 @@ nvic: &cpuapp_nvic {};
 	psa_rng: psa-rng {
 		compatible = "zephyr,psa-crypto-rng";
 		status = "disabled";
+	};
+
+	prng: prng {
+		compatible = "nordic,entropy-prng";
+		status = "okay";
 	};
 };
 


### PR DESCRIPTION
This adds temporary entropy driver simulation for
nRF54l09 device since final entropy source is not
available yet.

TODO: Remove this commit when proper solution will be available.