### PR TITLE
[nrf noup] dts: Select SoftDevice Controller on nRF54L09

### DIFF
--- a/boards/nordic/nrf54l09pdk/nrf54l09_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l09pdk/nrf54l09_cpuapp_common.dtsi
@@ -18,7 +18,7 @@
 		zephyr,bt-c2h-uart = &uart20;
 		zephyr,flash-controller = &rram_controller;
 		zephyr,flash = &cpuapp_rram;
-		zephyr,bt-hci = &bt_hci_controller;
+		zephyr,bt-hci = &bt_hci_sdc;
 		zephyr,ieee802154 = &ieee802154;
 	};
 };
@@ -108,7 +108,7 @@
 	status = "okay";
 };
 
-&bt_hci_controller {
+&bt_hci_sdc {
 	status = "okay";
 };
 

--- a/dts/arm/nordic/nrf54l09_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l09_enga_cpuapp.dtsi
@@ -17,7 +17,7 @@ nvic: &cpuapp_nvic {};
 
 / {
 	chosen {
-		zephyr,bt-hci = &bt_hci_controller;
+		zephyr,bt-hci = &bt_hci_sdc;
 		zephyr,entropy = &prng;
 	};
 
@@ -38,7 +38,7 @@ nvic: &cpuapp_nvic {};
 	};
 };
 
-&bt_hci_controller {
+&bt_hci_sdc {
 	status = "okay";
 };
 

--- a/dts/common/nordic/nrf54l09.dtsi
+++ b/dts/common/nordic/nrf54l09.dtsi
@@ -212,9 +212,11 @@
 					status = "disabled";
 				};
 
-				/* Note: In the nRF Connect SDK the SoftDevice Controller
-				 * is added and set as the default Bluetooth Controller.
-				 */
+				bt_hci_sdc: bt_hci_sdc {
+					compatible = "nordic,bt-hci-sdc";
+					status = "disabled";
+				};
+
 				bt_hci_controller: bt_hci_controller {
 					compatible = "zephyr,bt-hci-ll-sw-split";
 					status = "disabled";


### PR DESCRIPTION
The SDC HCI controller is defined as a device tree node. A node representing the SDC controller is added and selected as the default over the open source link layer. This is consistent with other SoCs.