### PR TITLE
[nrf fromlist] Bluetooth: Host: Use `memset` to initialize `psa_mac_o…

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -717,7 +717,7 @@ static int db_hash_setup(struct gen_hash_state *state, uint8_t *key)
 		LOG_ERR("Unable to import the key for AES CMAC %d", ret);
 		return -EIO;
 	}
-	state->operation = psa_mac_operation_init();
+	memset(&state->operation, 0, sizeof(state->operation));
 
 	ret = psa_mac_sign_setup(&(state->operation), state->key, PSA_ALG_CMAC);
 	if (ret != PSA_SUCCESS) {


### PR DESCRIPTION
…peration_t`

In `db_hash_setup()` the state object for MAC operations was initialized using `psa_mac_operation_init()`. This function was not always optimized or inlined.

A way to reduce stack usage is to use `memset()` and set the object to 0. This is one of the option documented to initialize `psa_mac_operation_t` object.

Upstream PR #: 86094