### PR TITLE
[nrf fromlist] drivers: mbox: nrf_vevif_event_tx: Fix errata 16 workaround

### DIFF
--- a/drivers/mbox/mbox_nrf_vevif_event_tx.c
+++ b/drivers/mbox/mbox_nrf_vevif_event_tx.c
@@ -40,7 +40,7 @@ static int vevif_event_tx_send(const struct device *dev, uint32_t id, const stru
 	nrf_vpr_csr_vevif_events_trigger(BIT(id));
 
 #if defined(CONFIG_MBOX_NRF_VEVIF_EVENT_USE_54L_ERRATA_16)
-	while (!nrf_vpr_csr_vevif_events_get()) {
+	while (!(nrf_vpr_csr_vevif_events_get() & BIT(id))) {
 		;
 	}
 	nrf_vpr_csr_vevif_events_set(0);


### PR DESCRIPTION
Due to errata 16 VPR is triggering an event and immediately clears that event.
Pend until requested event is set before clearing it. Without that check event could be cleared too early and APP core is not waken up.

Upstream PR #: 86249