### PR TITLE
[nrf noup] tests: drivers: mspi: api: fix for nRF54L15

### DIFF
--- a/tests/drivers/mspi/api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/mspi/api/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -6,14 +6,23 @@
 
 / {
 	aliases {
-		mspi0 = &sdp_mspi;
+		mspi0 = &sdp_mspi_api;
 	};
 };
 
 &cpuflpr_vpr {
 	status = "okay";
 
-	sdp_mspi: sdp_mspi {
+	sdp_mspi_api: sdp_mspi_api {
+		compatible = "nordic,nrfe-mspi-controller";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		clock-frequency = <DT_FREQ_M(64)>;
+		pinctrl-0 = <&sdp_mspi_default>;
+		pinctrl-1 = <&sdp_mspi_sleep>;
+		pinctrl-names = "default", "sleep";
+		status = "okay";
+
 		mspi_device: mspi_device@0 {
 			status = "okay";
 			compatible = "zephyr,mspi-emul-device";


### PR DESCRIPTION
nrf-squash! [nrf noup] tests: drivers: mspi: api: Add nRF54L15 overlay file

Fix the test for nRF54L15 after changing definition of external flash in DTS.