### PR TITLE
[nrf noup] samples: bluetooth: hci_ipc: increase main stack size for Cracen driver on nRF54H20

### DIFF
--- a/samples/bluetooth/hci_ipc/boards/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/samples/bluetooth/hci_ipc/boards/nrf54h20dk_nrf54h20_cpurad.conf
@@ -1,0 +1,2 @@
+# Increase stack size for Cracen driver.
+CONFIG_MAIN_STACK_SIZE=1024


### PR DESCRIPTION
A larger stack is needed to accomodate the Cracen driver.