### PR TITLE
[nrf noup] include: net: socket_ncs: reduce NCS_BASE

### DIFF
--- a/include/zephyr/net/socket_ncs.h
+++ b/include/zephyr/net/socket_ncs.h
@@ -27,7 +27,7 @@ extern "C" {
 
 /** Define a base for NCS specific socket options to prevent overlaps with Zephyr's socket options.
  */
-#define NET_SOCKET_NCS_BASE 1000000000
+#define NET_SOCKET_NCS_BASE 1000
 
 /* NCS specific TLS level socket options */
 


### PR DESCRIPTION
Reduces the NCS_BASE to a lower number to simplify
those use cases where certain applications would let
the user input the socket option name by number.
The base is still high enough to prevent collisions
with Zephyr's own socket options for many years.