### PR TITLE
net: l2: Add a config option to allow mismatched L3/L2 address packets

### DIFF
--- a/.github/workflows/commit-tags.yml
+++ b/.github/workflows/commit-tags.yml
@@ -26,6 +26,5 @@ jobs:
     - name: Run the commit tags
       uses: nrfconnect/action-commit-tags@main
       with:
-        target: '.'
-        baserev: origin/${{ github.base_ref }}
-        revrange: 'none'
+        target: .
+        upstream: zephyrproject-rtos/zephyr/main

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -12,13 +12,13 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Checkout the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
 
     - name: cache-pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('.github/workflows/compliance.yml') }}
@@ -61,7 +61,7 @@ jobs:
         -e KconfigBasicNoModules -e ModulesMaintainers -c origin/${BASE_REF}..
 
     - name: upload-results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       continue-on-error: true
       with:
         name: compliance.xml

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -8,7 +8,7 @@ jobs:
     name: Scan code for licenses
     steps:
     - name: Checkout the code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Scan the code
@@ -17,7 +17,7 @@ jobs:
       with:
         directory-to-scan: 'scan/'
     - name: Artifact Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: scancode
         path: ./artifacts

--- a/subsys/net/l2/ethernet/Kconfig
+++ b/subsys/net/l2/ethernet/Kconfig
@@ -24,6 +24,14 @@ config NET_L2_ETHERNET_MGMT
 	  Enable support net_mgmt Ethernet interface which can be used to
 	  configure at run-time Ethernet drivers and L2 settings.
 
+
+config NET_L2_ETHERNET_ACCEPT_MISMATCH_L3_L2_ADDR
+	bool "Accept mismatched L3 and L2 addresses"
+	help
+	  If enabled, then accept packets where the L3 and L2 addresses do not
+	  conform to RFC1122 section 3.3.6. This is useful in dealing with
+	  buggy devices that do not follow the RFC.
+
 config NET_VLAN
 	bool "Virtual lan support"
 	help

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -173,6 +173,10 @@ static inline
 enum net_verdict ethernet_check_ipv4_bcast_addr(struct net_pkt *pkt,
 						struct net_eth_hdr *hdr)
 {
+	if (IS_ENABLED(CONFIG_NET_L2_ETHERNET_ACCEPT_MISMATCH_L3_L2_ADDR)) {
+		return NET_OK;
+	}
+
 	if (net_eth_is_addr_broadcast(&hdr->dst) &&
 	    !(net_ipv4_is_addr_mcast((struct in_addr *)NET_IPV4_HDR(pkt)->dst) ||
 	      net_ipv4_is_addr_bcast(net_pkt_iface(pkt),


### PR DESCRIPTION
The RFC1122 section 3.3.6 says we SHOULD drop the packets if L2 address is brodcast but L3 address is unicast, but we had seen some Wi-Fi access points in the field not conforming to that, and DHCP offer is dropped due to this and causes Wi-Fi connectivity issues.

As the RFC saus it's SHOULD and not a MUST, add a config option to allow such packets, disabled by default.

Signed-off-by: Chaitanya Tata <Chaitanya.Tata@nordicsemi.no>
(cherry picked from commit 4cd6654b2196bf00d62a528707e45c15db8b627d)