### PR TITLE
include: common: sys_bitops: Specify sign when bitshifting

### DIFF
--- a/include/zephyr/arch/common/sys_bitops.h
+++ b/include/zephyr/arch/common/sys_bitops.h
@@ -25,21 +25,21 @@ static ALWAYS_INLINE void sys_set_bit(mem_addr_t addr, unsigned int bit)
 {
 	uint32_t temp = *(volatile uint32_t *)addr;
 
-	*(volatile uint32_t *)addr = temp | (1 << bit);
+	*(volatile uint32_t *)addr = temp | (1U << bit);
 }
 
 static ALWAYS_INLINE void sys_clear_bit(mem_addr_t addr, unsigned int bit)
 {
 	uint32_t temp = *(volatile uint32_t *)addr;
 
-	*(volatile uint32_t *)addr = temp & ~(1 << bit);
+	*(volatile uint32_t *)addr = temp & ~(1U << bit);
 }
 
 static ALWAYS_INLINE int sys_test_bit(mem_addr_t addr, unsigned int bit)
 {
 	uint32_t temp = *(volatile uint32_t *)addr;
 
-	return temp & (1 << bit);
+	return temp & (1U << bit);
 }
 
 static ALWAYS_INLINE void sys_set_bits(mem_addr_t addr, unsigned int mask)
@@ -62,19 +62,19 @@ static ALWAYS_INLINE
 	/* Doing memory offsets in terms of 32-bit values to prevent
 	 * alignment issues
 	 */
-	sys_set_bit(addr + ((bit >> 5) << 2), bit & 0x1F);
+	sys_set_bit(addr + ((bit >> 5) << 2U), bit & 0x1F);
 }
 
 static ALWAYS_INLINE
 	void sys_bitfield_clear_bit(mem_addr_t addr, unsigned int bit)
 {
-	sys_clear_bit(addr + ((bit >> 5) << 2), bit & 0x1F);
+	sys_clear_bit(addr + ((bit >> 5U) << 2U), bit & 0x1F);
 }
 
 static ALWAYS_INLINE
 	int sys_bitfield_test_bit(mem_addr_t addr, unsigned int bit)
 {
-	return sys_test_bit(addr + ((bit >> 5) << 2), bit & 0x1F);
+	return sys_test_bit(addr + ((bit >> 5U) << 2U), bit & 0x1F);
 }
 
 static ALWAYS_INLINE


### PR DESCRIPTION
When left-shifting '1' by 31, the result is undefined. This is something ASAN detects.

Solve this by explicitly defining that the integer is unsigned.

Upstream PR #: 86624