### PR TITLE
[nrf fromlist] logging: frontends: stmesp: Fix sending string location

### DIFF
--- a/subsys/logging/frontends/log_frontend_stmesp.c
+++ b/subsys/logging/frontends/log_frontend_stmesp.c
@@ -581,7 +581,8 @@ void log_frontend_panic(void)
 
 void log_frontend_init(void)
 {
-#if defined(CONFIG_LOG_FRONTEND_STPESP_TURBO_SOURCE_PORT_ID) && !defined(CONFIG_NRF_ETR)
+#if	defined(CONFIG_LOG_FRONTEND_STPESP_TURBO_SOURCE_PORT_ID) && !defined(CONFIG_NRF_ETR) && \
+	!defined(CONFIG_LOG_MSG_APPEND_RO_STRING_LOC)
 	/* Send location of section with constant source data. It is used by the
 	 * application core to retrieve source names of log messages coming from
 	 * coprocessors (FLPR and PPR).


### PR DESCRIPTION
String location information should only be sent for core which do not append strings to the log message (PPR, FLPR). Without this, cpurad was also sending that information and that was redundant.

Upstream PR #: 86242