### PR TITLE
[nrf fromlist] drivers: adc: nrfx_saadc: Add support for AIN8-AIN13 o…

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -9,6 +9,7 @@
 #include <haly/nrfy_saadc.h>
 #include <zephyr/dt-bindings/adc/nrf-saadc-v3.h>
 #include <zephyr/dt-bindings/adc/nrf-saadc-nrf54l.h>
+#include <zephyr/dt-bindings/adc/nrf-saadc-nrf54h20.h>
 #include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>
@@ -23,7 +24,7 @@ LOG_MODULE_REGISTER(adc_nrfx_saadc);
 #if (NRF_SAADC_HAS_AIN_AS_PIN)
 
 #if defined(CONFIG_NRF_PLATFORM_HALTIUM)
-static const uint8_t saadc_psels[NRF_SAADC_AIN7 + 1] = {
+static const uint32_t saadc_psels[NRF_SAADC_AIN13 + 1] = {
 	[NRF_SAADC_AIN0] = NRF_PIN_PORT_TO_PIN_NUMBER(0U, 1),
 	[NRF_SAADC_AIN1] = NRF_PIN_PORT_TO_PIN_NUMBER(1U, 1),
 	[NRF_SAADC_AIN2] = NRF_PIN_PORT_TO_PIN_NUMBER(2U, 1),
@@ -32,6 +33,12 @@ static const uint8_t saadc_psels[NRF_SAADC_AIN7 + 1] = {
 	[NRF_SAADC_AIN5] = NRF_PIN_PORT_TO_PIN_NUMBER(5U, 1),
 	[NRF_SAADC_AIN6] = NRF_PIN_PORT_TO_PIN_NUMBER(6U, 1),
 	[NRF_SAADC_AIN7] = NRF_PIN_PORT_TO_PIN_NUMBER(7U, 1),
+	[NRF_SAADC_AIN8] = NRF_PIN_PORT_TO_PIN_NUMBER(0U, 9),
+	[NRF_SAADC_AIN9] = NRF_PIN_PORT_TO_PIN_NUMBER(1U, 9),
+	[NRF_SAADC_AIN10] = NRF_PIN_PORT_TO_PIN_NUMBER(2U, 9),
+	[NRF_SAADC_AIN11] = NRF_PIN_PORT_TO_PIN_NUMBER(3U, 9),
+	[NRF_SAADC_AIN12] = NRF_PIN_PORT_TO_PIN_NUMBER(4U, 9),
+	[NRF_SAADC_AIN13] = NRF_PIN_PORT_TO_PIN_NUMBER(5U, 9),
 };
 #elif defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
 static const uint32_t saadc_psels[NRF_SAADC_DVDD + 1] = {

--- a/dts/common/nordic/nrf54h20.dtsi
+++ b/dts/common/nordic/nrf54h20.dtsi
@@ -7,7 +7,7 @@
 #include <mem.h>
 #include <nordic/nrf_common.dtsi>
 
-#include <zephyr/dt-bindings/adc/nrf-saadc.h>
+#include <zephyr/dt-bindings/adc/nrf-saadc-nrf54h20.h>
 #include <zephyr/dt-bindings/misc/nordic-nrf-ficr-nrf54h20.h>
 #include <zephyr/dt-bindings/misc/nordic-domain-id-nrf54h20.h>
 #include <zephyr/dt-bindings/misc/nordic-owner-id-nrf54h20.h>

--- a/include/zephyr/dt-bindings/adc/nrf-saadc-nrf54h20.h
+++ b/include/zephyr/dt-bindings/adc/nrf-saadc-nrf54h20.h
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2024 Nordic Semiconductor ASA
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_NRF54H_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_NRF54H_H_
+
+#include <zephyr/dt-bindings/adc/nrf-saadc.h>
+
+#define NRF_SAADC_AIN8 9
+#define NRF_SAADC_AIN9 10
+#define NRF_SAADC_AIN10 11
+#define NRF_SAADC_AIN11 12
+#define NRF_SAADC_AIN12 13
+#define NRF_SAADC_AIN13 14
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_SAADC_NRF54H_H_ */


### PR DESCRIPTION
…n nrf54h20

Extend support in dt bindings and in the driver to allow use of AIN8 to AIN13 analog inputs.

Upstream PR #: 85709