### PR TITLE
[nrf fromlist] Bluetooth: Host: Fix Advertising Coding Selection as p…

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3684,6 +3684,7 @@ static int le_init(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_EXT_ADV_CODING_SELECTION) &&
+	    IS_ENABLED(CONFIG_BT_OBSERVER) &&
 	    BT_FEAT_LE_ADV_CODING_SEL(bt_dev.le.features)) {
 		err = le_set_host_feature(BT_LE_FEAT_BIT_ADV_CODING_SEL_HOST, 1);
 		if (err) {


### PR DESCRIPTION
…eripheral

Fix mistake in host implementation of Advertising Coding Selection.

The host should only try set the BT_LE_FEAT_BIT_ADV_CODING_SEL_HOST when the observer role is enabled. If a broadcaster enables the CONFIG_BT_EXT_ADV_CODING_SELECTION Kconfig option bluetooth will fail to initialise.

Upstream PR #: 86731