### PR TITLE
[nrf fromtree] shell: Set default max argc count when WiFi shell is enabled

### DIFF
--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -108,6 +108,7 @@ config SHELL_DEFAULT_TERMINAL_HEIGHT
 config SHELL_ARGC_MAX
 	int "Maximum arguments in shell command"
 	range 3 $(UINT8_MAX)
+	default 30 if NET_L2_WIFI_SHELL
 	default 20
 	help
 	  Maximum number of arguments that can build a command.


### PR DESCRIPTION
Set the default maximum argument count for the shell to 30 when the Wi-Fi shell is enabled, to ensure all Wi-Fi
commands work without failure.
