### PR TITLE
[nrf fromtree] drivers: nrf_wifi: Set default stack size of net_mgmt …

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -160,6 +160,7 @@ config NRF70_REG_DOMAIN
 # stack requirements.
 config NET_MGMT_EVENT_STACK_SIZE
 	default 2048 if !WIFI_NM_WPA_SUPPLICANT
+	default 4600
 
 config NRF70_LOG_VERBOSE
 	bool "Maintains the verbosity of information in logs"


### PR DESCRIPTION
…thread

Fixes overflow issue in the net_mgmt thread
during network interface state changes.

Signed-off-by: Triveni Danda <triveni.danda@nordicsemi.no>
(cherry picked from commit 3a3f4ab3ea3ffb0c617ac75f5ac5fa15cea55abe)