### PR TITLE
[nrf fromlist] boards: nordic: nrf54l20pdk: Increase RAM,Flash on FLPR

### DIFF
--- a/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
+++ b/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuapp.yaml
@@ -10,7 +10,7 @@ toolchain:
   - xtools
   - zephyr
 sysbuild: true
-ram: 512
+ram: 415
 flash: 449
 supported:
   - adc

--- a/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuflpr.dts
+++ b/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuflpr.dts
@@ -33,7 +33,7 @@
 
 		cpuflpr_code_partition: partition@0 {
 			label = "image-0";
-			reg = <0x0 DT_SIZE_K(64)>;
+			reg = <0x0 DT_SIZE_K(96)>;
 		};
 	};
 };

--- a/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuflpr.yaml
+++ b/boards/nordic/nrf54l20pdk/nrf54l20pdk_nrf54l20_cpuflpr.yaml
@@ -8,8 +8,10 @@ arch: riscv
 toolchain:
   - zephyr
 sysbuild: true
-ram: 64
-flash: 64
+ram: 96
+flash: 96
 supported:
   - counter
   - gpio
+  - i2c
+  - spi

--- a/dts/common/nordic/nrf54l20.dtsi
+++ b/dts/common/nordic/nrf54l20.dtsi
@@ -95,19 +95,21 @@
 
 		cpuapp_sram: memory@20000000 {
 			compatible = "mmio-sram";
-			reg = <0x20000000 DT_SIZE_K(447)>;
+			reg = <0x20000000 DT_SIZE_K(415)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x20000000 0x6fc00>;
+			ranges = <0x0 0x20000000 0x67c00>;
 		};
 
-		cpuflpr_sram: memory@2006fc00 {
+		cpuflpr_sram: memory@20067c00 {
 			compatible = "mmio-sram";
-			reg = <0x2006fc00 DT_SIZE_K(64)>;
+			reg = <0x20067c00 DT_SIZE_K(96)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x2006fc00 0x10000>;
+			ranges = <0x0 0x20067c00 0x18000>;
 		};
+
+		/* 0x20067c00 - 0x20080000; size 0x400 (1k): Reserved for VPR context */
 
 		global_peripherals: peripheral@50000000 {
 			ranges = <0x0 0x50000000 0x10000000>;
@@ -805,14 +807,14 @@
 
 			cpuapp_rram: rram@0 {
 				compatible = "soc-nv-flash";
-				reg = <0x0 DT_SIZE_K(1972)>;
+				reg = <0x0 DT_SIZE_K(1940)>;
 				erase-block-size = <4096>;
 				write-block-size = <16>;
 			};
 
-			cpuflpr_rram: rram@1ed000 {
+			cpuflpr_rram: rram@1e5000 {
 				compatible = "soc-nv-flash";
-				reg = <0x1ed000 DT_SIZE_K(64)>;
+				reg = <0x1e5000 DT_SIZE_K(96)>;
 				erase-block-size = <4096>;
 				write-block-size = <16>;
 			};

--- a/snippets/nordic-flpr/soc/nrf54l20_cpuapp.overlay
+++ b/snippets/nordic-flpr/soc/nrf54l20_cpuapp.overlay
@@ -9,18 +9,18 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			cpuflpr_code_partition: image@1ed000 {
+			cpuflpr_code_partition: image@1e5000 {
 				/* FLPR core code partition */
-				reg = <0x1ed000 DT_SIZE_K(64)>;
+				reg = <0x1e5000 DT_SIZE_K(96)>;
 			};
 		};
 
-		cpuflpr_sram_code_data: memory@2006fc00 {
+		cpuflpr_sram_code_data: memory@20067c00 {
 			compatible = "mmio-sram";
-			reg = <0x2006fc00 DT_SIZE_K(64)>;
+			reg = <0x20067c00 DT_SIZE_K(96)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x2006fc00 0x10000>;
+			ranges = <0x0 0x20067c00 0x18000>;
 		};
 	};
 };


### PR DESCRIPTION
Increase SRAM and RRAM available for FLPR core on nRF54L20.
Increase both memories from 64k to 96 as it's on L15.
L20 has more memory than L15.
Currently, some tests/samples doesn't fit.

manifest-pr-skip