### PR TITLE
[nrf fromtree] scripts: runners: nrf: Fix flashing of FLPR/PPR on nRF…

### DIFF
--- a/scripts/west_commands/runners/nrf_common.py
+++ b/scripts/west_commands/runners/nrf_common.py
@@ -307,6 +307,8 @@ class NrfBinaryRunner(ZephyrBinaryRunner):
     def _get_core(self):
         if self.family in ('nrf54h', 'nrf92'):
             if (self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPUAPP') or
+                self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPUFLPR') or
+                self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPUPPR') or
                 self.build_conf.getboolean('CONFIG_SOC_NRF9280_CPUAPP')):
                 return 'Application'
             if (self.build_conf.getboolean('CONFIG_SOC_NRF54H20_CPURAD') or


### PR DESCRIPTION
…54H20

After commit aaefaad, flashing of the FLPR and PPR cores in the nRF54H20 was broken due to those cores missing from the _get_core() function that retrieves the core to program, triggering an exception. Fix it by referencing those cores and mapping them to the application core.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>
(cherry picked from commit 7254a615307d732cf5b4535baf5c6360261c03fa)