### PR TITLE
[nrf noup] ci: remove Sidewalk from test-spec

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -302,19 +302,6 @@
   - "subsys/net/l2/wifi/**/*"
   - "subsys/net/l2/ethernet/**/*"
 
-"CI-sidewalk-test":
-  - "include/dfu/**/*"
-  - "include/mgmt/mcumgr/**/*"
-  - "soc/nordic/**/*"
-  - "subsys/dfu/**/*"
-  - "subsys/settings/**/*"
-  - "subsys/mgmt/mcumgr/**/*"
-  - "samples/bluetooth/hci_ipc/**/*"
-  - any:
-      - "subsys/bluetooth/**/*"
-      - "!subsys/bluetooth/mesh/**/*"
-      - "!subsys/bluetooth/audio/**/*"
-
 "CI-audio-test":
   - "boards/nordic/nrf5340_audio_dk/**/*"
   - "drivers/flash/**/*"


### PR DESCRIPTION
Sidewalk becomes NCS Add-on.
There is no need to trigger Sidewalk tests.