### PR TITLE
drivers: flash: mspi_nor: initial config, high performance and fast read

### DIFF
--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -22,18 +22,206 @@ LOG_MODULE_REGISTER(flash_mspi_nor, CONFIG_FLASH_LOG_LEVEL);
 #define WITH_RESET_GPIO 1
 #endif
 
+#define FLASH_MX25R_LH_MASK BIT(1)
+
+static uint8_t hp_payload[3] = {SPI_NOR_QE_BIT, 0x0, FLASH_MX25R_LH_MASK};
+
 struct flash_mspi_nor_data {
 	struct k_sem acquired;
 	struct mspi_xfer_packet packet;
 	struct mspi_xfer xfer;
 };
 
+struct flash_mspi_nor_cmd {
+	enum mspi_xfer_direction dir;
+	uint32_t cmd;
+	uint16_t tx_dummy;
+	uint16_t rx_dummy;
+	uint8_t cmd_length;
+	uint8_t addr_length;
+	bool force_single;
+};
+
+struct flash_mspi_nor_cmds {
+	struct flash_mspi_nor_cmd id;
+	struct flash_mspi_nor_cmd write_en;
+	struct flash_mspi_nor_cmd read;
+	struct flash_mspi_nor_cmd status;
+	struct flash_mspi_nor_cmd page_program;
+	struct flash_mspi_nor_cmd sector_erase;
+	struct flash_mspi_nor_cmd chip_erase;
+	struct flash_mspi_nor_cmd mode_change;
+	struct flash_mspi_nor_cmd sfdp;
+	uint8_t mode_payload;
+};
+
+static const struct flash_mspi_nor_cmds commands[] = {
+	[MSPI_IO_MODE_SINGLE] = {
+		.id = {
+			.dir = MSPI_RX,
+			.cmd = JESD216_CMD_READ_ID,
+			.cmd_length = 1,
+		},
+		.write_en = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_CMD_WREN,
+			.cmd_length = 1,
+		},
+		.read = {
+			.dir = MSPI_RX,
+			.cmd = SPI_NOR_CMD_READ_FAST,
+			.cmd_length = 1,
+			.addr_length = 3,
+			.rx_dummy = 8,
+		},
+		.status = {
+			.dir = MSPI_RX,
+			.cmd = SPI_NOR_CMD_RDSR,
+			.cmd_length = 1,
+		},
+		.page_program = {
+			.dir  = MSPI_TX,
+			.cmd = SPI_NOR_CMD_PP,
+			.cmd_length = 1,
+			.addr_length = 3,
+		},
+		.sector_erase = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_CMD_SE,
+			.cmd_length = 1,
+			.addr_length = 3,
+		},
+		.chip_erase = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_CMD_CE,
+			.cmd_length = 1,
+		},
+		.mode_change = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_CMD_WRSR,
+			.cmd_length = 1,
+		},
+		.mode_payload = 0,
+	},
+	[MSPI_IO_MODE_QUAD_1_4_4] = {
+		.id = {
+			.dir = MSPI_RX,
+			.cmd = JESD216_CMD_READ_ID,
+			.cmd_length = 1,
+			.force_single = true,
+		},
+		.write_en = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_CMD_WREN,
+			.cmd_length = 1,
+		},
+		.read = {
+			.dir = MSPI_RX,
+			.cmd = SPI_NOR_CMD_4READ,
+			.cmd_length = 1,
+			.addr_length = 3,
+			.rx_dummy = 6,
+		},
+		.status = {
+			.dir = MSPI_RX,
+			.cmd = SPI_NOR_CMD_RDSR,
+			.cmd_length = 1,
+			.force_single = true,
+		},
+		.page_program = {
+			.dir  = MSPI_TX,
+			.cmd = SPI_NOR_CMD_PP_1_4_4,
+			.cmd_length = 1,
+			.addr_length = 3,
+		},
+		.sector_erase = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_CMD_SE,
+			.cmd_length = 1,
+			.addr_length = 3,
+			.force_single = true,
+		},
+		.chip_erase = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_CMD_CE,
+			.cmd_length = 1,
+		},
+		.mode_change = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_CMD_WRSR,
+			.cmd_length = 1,
+			.force_single = true,
+		},
+		.mode_payload = SPI_NOR_QE_BIT,
+	},
+	[MSPI_IO_MODE_OCTAL] = {
+		.id = {
+			.dir = MSPI_RX,
+			.cmd = JESD216_OCMD_READ_ID,
+			.cmd_length = 2,
+			.addr_length = 4,
+			.rx_dummy = 4
+		},
+		.write_en = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_OCMD_WREN,
+			.cmd_length = 2,
+		},
+		.read = {
+			.dir = MSPI_RX,
+			.cmd = SPI_NOR_OCMD_RD,
+			.cmd_length = 2,
+			.addr_length = 4,
+			.rx_dummy = 20,
+		},
+		.status = {
+			.dir = MSPI_RX,
+			.cmd = SPI_NOR_OCMD_RDSR,
+			.cmd_length = 2,
+			.addr_length = 4,
+			.rx_dummy = 4,
+		},
+		.page_program = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_OCMD_PAGE_PRG,
+			.cmd_length = 2,
+			.addr_length = 4,
+		},
+		.sector_erase = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_OCMD_SE,
+			.cmd_length = 2,
+			.addr_length = 4,
+		},
+		.chip_erase = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_OCMD_CE,
+			.cmd_length = 2,
+		},
+		.sfdp = {
+			.dir = MSPI_RX,
+			.cmd = JESD216_OCMD_READ_SFDP,
+			.cmd_length = 2,
+			.addr_length = 4,
+			.rx_dummy = 20,
+		},
+		.mode_change = {
+			.dir = MSPI_TX,
+			.cmd = SPI_NOR_CMD_WR_CFGREG2,
+			.cmd_length = 1,
+			.addr_length = 4,
+		},
+		.mode_payload = 0x01,
+	},
+};
+
 struct flash_mspi_nor_config {
 	const struct device *bus;
 	uint32_t flash_size;
 	struct mspi_dev_id mspi_id;
-	struct mspi_dev_cfg mspi_cfg;
-	enum mspi_dev_cfg_mask mspi_cfg_mask;
+	struct mspi_dev_cfg mspi_nor_cfg;
+	struct mspi_dev_cfg mspi_nor_init_cfg;
+	enum mspi_dev_cfg_mask mspi_nor_cfg_mask;
 #if defined(CONFIG_MSPI_XIP)
 	struct mspi_xip_cfg xip_cfg;
 #endif
@@ -46,9 +234,22 @@ struct flash_mspi_nor_config {
 	struct flash_pages_layout layout;
 #endif
 	uint8_t jedec_id[SPI_NOR_MAX_ID_LEN];
+	const struct flash_mspi_nor_cmds *jedec_cmds;
 };
 
-static int acquire(const struct device *dev)
+static int dev_cfg_apply(const struct device *dev, const struct mspi_dev_cfg *cfg)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+
+	int rc = mspi_dev_config(dev_config->bus, &dev_config->mspi_id,
+				 dev_config->mspi_nor_cfg_mask, cfg);
+	if (rc < 0) {
+		LOG_ERR("Failed to set device config: %p error: %d", cfg, rc);
+	}
+	return rc;
+}
+
+static int acquire(const struct device *dev, const struct mspi_dev_cfg *cfg)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
 	struct flash_mspi_nor_data *dev_data = dev->data;
@@ -63,12 +264,8 @@ static int acquire(const struct device *dev)
 		/* This acquires the MSPI controller and reconfigures it
 		 * if needed for the flash device.
 		 */
-		rc = mspi_dev_config(dev_config->bus, &dev_config->mspi_id,
-				     dev_config->mspi_cfg_mask,
-				     &dev_config->mspi_cfg);
-		if (rc < 0) {
-			LOG_ERR("mspi_dev_config() failed: %d", rc);
-		} else {
+		rc = dev_cfg_apply(dev, cfg);
+		if (rc == 0) {
 			return 0;
 		}
 
@@ -104,6 +301,30 @@ static inline uint16_t dev_page_size(const struct device *dev)
 	return SPI_NOR_PAGE_SIZE;
 }
 
+static void command_set(const struct device *dev, const struct flash_mspi_nor_cmd *cmd)
+{
+	struct flash_mspi_nor_data *dev_data = dev->data;
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+
+	memset(&dev_data->xfer, 0, sizeof(dev_data->xfer));
+	memset(&dev_data->packet, 0, sizeof(dev_data->packet));
+
+	dev_data->xfer.xfer_mode  = MSPI_PIO;
+	dev_data->xfer.packets    = &dev_data->packet;
+	dev_data->xfer.num_packet = 1;
+	dev_data->xfer.timeout    = 10;
+
+	dev_data->xfer.cmd_length = cmd->cmd_length;
+	dev_data->xfer.addr_length = cmd->addr_length;
+	dev_data->xfer.tx_dummy = (cmd->dir == MSPI_TX) ?
+				  cmd->tx_dummy : dev_config->mspi_nor_cfg.tx_dummy;
+	dev_data->xfer.rx_dummy = (cmd->dir == MSPI_RX) ?
+				  cmd->rx_dummy : dev_config->mspi_nor_cfg.rx_dummy;
+
+	dev_data->packet.dir = cmd->dir;
+	dev_data->packet.cmd = cmd->cmd;
+}
+
 static int api_read(const struct device *dev, off_t addr, void *dest,
 		    size_t size)
 {
@@ -120,17 +341,13 @@ static int api_read(const struct device *dev, off_t addr, void *dest,
 		return -EINVAL;
 	}
 
-	rc = acquire(dev);
+	rc = acquire(dev, &dev_config->mspi_nor_cfg);
 	if (rc < 0) {
 		return rc;
 	}
 
 	/* TODO: get rid of all these hard-coded values for MX25Ux chips */
-	dev_data->xfer.cmd_length  = 2;
-	dev_data->xfer.addr_length = 4;
-	dev_data->xfer.rx_dummy    = 20;
-	dev_data->packet.dir       = MSPI_RX;
-	dev_data->packet.cmd       = SPI_NOR_OCMD_RD;
+	command_set(dev, &dev_config->jedec_cmds->read);
 	dev_data->packet.address   = addr;
 	dev_data->packet.data_buf  = dest;
 	dev_data->packet.num_bytes = size;
@@ -140,35 +357,67 @@ static int api_read(const struct device *dev, off_t addr, void *dest,
 	release(dev);
 
 	if (rc < 0) {
-		LOG_ERR("SPI_NOR_OCMD_RD xfer failed: %d", rc);
+		LOG_ERR("Read xfer failed: %d", rc);
 		return rc;
 	}
 
 	return 0;
 }
 
-static int wait_until_ready(const struct device *dev, k_timeout_t poll_period)
+static int status_get(const struct device *dev, const struct mspi_dev_cfg *curr_cfg,
+		      uint8_t *status)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
 	struct flash_mspi_nor_data *dev_data = dev->data;
-	uint8_t status_reg;
 	int rc;
 
-	while (true) {
-		dev_data->xfer.cmd_length  = 2;
-		dev_data->xfer.addr_length = 4;
-		dev_data->xfer.rx_dummy    = 4;
-		dev_data->packet.dir       = MSPI_RX;
-		dev_data->packet.cmd       = SPI_NOR_OCMD_RDSR;
-		dev_data->packet.address   = 0;
-		dev_data->packet.data_buf  = &status_reg;
-		dev_data->packet.num_bytes = sizeof(status_reg);
-		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
-				     &dev_data->xfer);
+	/* Enter command mode */
+	if (curr_cfg != &dev_config->mspi_nor_init_cfg) {
+		rc = dev_cfg_apply(dev, &dev_config->mspi_nor_init_cfg);
+
 		if (rc < 0) {
-			LOG_ERR("SPI_NOR_OCMD_RDSR xfer failed: %d", rc);
+			LOG_ERR("Switching to initial dev_cfg failed: %d", rc);
 			return rc;
 		}
+	}
+
+	command_set(dev, &dev_config->jedec_cmds->status);
+	dev_data->packet.data_buf  = status;
+	dev_data->packet.num_bytes = sizeof(uint8_t);
+
+	rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id, &dev_data->xfer);
+
+	if (rc < 0) {
+		LOG_ERR("Status xfer failed: %d", rc);
+		return rc;
+	}
+
+	/* Exit command mode */
+	if (curr_cfg != &dev_config->mspi_nor_init_cfg) {
+		rc = dev_cfg_apply(dev, &dev_config->mspi_nor_cfg);
+
+		if (rc < 0) {
+			LOG_ERR("Switching to default dev_cfg failed: %d", rc);
+		}
+	}
+
+	return rc;
+}
+
+static int wait_until_ready(const struct device *dev, const struct mspi_dev_cfg *curr_cfg,
+			    k_timeout_t poll_period)
+{
+	int rc;
+	uint8_t status_reg;
+
+	while (true) {
+		rc = status_get(dev, curr_cfg, &status_reg);
+
+		if (rc < 0) {
+			LOG_ERR("Status xfer failed: %d", rc);
+			return rc;
+		}
+
 		if (!(status_reg & SPI_NOR_WIP_BIT)) {
 			break;
 		}
@@ -177,6 +426,15 @@ static int wait_until_ready(const struct device *dev, k_timeout_t poll_period)
 	}
 
 	return 0;
+}
+
+static int write_enable(const struct device *dev)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+
+	command_set(dev, &dev_config->jedec_cmds->write_en);
+	return mspi_transceive(dev_config->bus, &dev_config->mspi_id, &dev_data->xfer);
 }
 
 static int api_write(const struct device *dev, off_t addr, const void *src,
@@ -196,7 +454,7 @@ static int api_write(const struct device *dev, off_t addr, const void *src,
 		return -EINVAL;
 	}
 
-	rc = acquire(dev);
+	rc = acquire(dev, &dev_config->mspi_nor_cfg);
 	if (rc < 0) {
 		return rc;
 	}
@@ -207,29 +465,19 @@ static int api_write(const struct device *dev, off_t addr, const void *src,
 		uint16_t page_left = page_size - page_offset;
 		uint16_t to_write = (uint16_t)MIN(size, page_left);
 
-		dev_data->xfer.cmd_length  = 2;
-		dev_data->xfer.tx_dummy    = 0;
-		dev_data->packet.dir       = MSPI_TX;
-
-		dev_data->xfer.addr_length = 0;
-		dev_data->packet.cmd       = SPI_NOR_OCMD_WREN;
-		dev_data->packet.num_bytes = 0;
-		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
-				     &dev_data->xfer);
-		if (rc < 0) {
-			LOG_ERR("SPI_NOR_OCMD_WREN xfer failed: %d", rc);
+		if (write_enable(dev) < 0) {
+			LOG_ERR("Write enable xfer failed: %d", rc);
 			break;
 		}
 
-		dev_data->xfer.addr_length = 4;
-		dev_data->packet.cmd       = SPI_NOR_OCMD_PAGE_PRG;
+		command_set(dev, &dev_config->jedec_cmds->page_program);
 		dev_data->packet.address   = addr;
 		dev_data->packet.data_buf  = (uint8_t *)src;
 		dev_data->packet.num_bytes = to_write;
 		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
 				     &dev_data->xfer);
 		if (rc < 0) {
-			LOG_ERR("SPI_NOR_OCMD_PAGE_PRG xfer failed: %d", rc);
+			LOG_ERR("Page program xfer failed: %d", rc);
 			break;
 		}
 
@@ -237,7 +485,7 @@ static int api_write(const struct device *dev, off_t addr, const void *src,
 		src   = (const uint8_t *)src + to_write;
 		size -= to_write;
 
-		rc = wait_until_ready(dev, K_MSEC(1));
+		rc = wait_until_ready(dev, &dev_config->mspi_nor_cfg, K_MSEC(1));
 		if (rc < 0) {
 			break;
 		}
@@ -267,38 +515,26 @@ static int api_erase(const struct device *dev, off_t addr, size_t size)
 		return -EINVAL;
 	}
 
-	rc = acquire(dev);
+	rc = acquire(dev, &dev_config->mspi_nor_init_cfg);
 	if (rc < 0) {
 		return rc;
 	}
 
 	while (size > 0) {
-		dev_data->xfer.cmd_length  = 2;
-		dev_data->xfer.tx_dummy    = 0;
-		dev_data->packet.dir       = MSPI_TX;
-		dev_data->packet.num_bytes = 0;
-
-		dev_data->xfer.addr_length = 0;
-		dev_data->packet.cmd       = SPI_NOR_OCMD_WREN;
-		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
-				     &dev_data->xfer);
+		rc = write_enable(dev);
 		if (rc < 0) {
-			LOG_ERR("SPI_NOR_OCMD_WREN xfer failed: %d", rc);
+			LOG_ERR("Write enable failed.");
 			break;
 		}
 
 		if (size == flash_size) {
 			/* Chip erase. */
-			dev_data->xfer.addr_length = 0;
-			dev_data->packet.cmd       = SPI_NOR_OCMD_CE;
-
+			command_set(dev, &dev_config->jedec_cmds->chip_erase);
 			size -= flash_size;
 		} else {
 			/* Sector erase. */
-			dev_data->xfer.addr_length = 4;
-			dev_data->packet.cmd       = SPI_NOR_OCMD_SE;
-			dev_data->packet.address   = addr;
-
+			command_set(dev, &dev_config->jedec_cmds->sector_erase);
+			dev_data->packet.address = addr;
 			addr += SPI_NOR_SECTOR_SIZE;
 			size -= SPI_NOR_SECTOR_SIZE;
 		}
@@ -310,7 +546,7 @@ static int api_erase(const struct device *dev, off_t addr, size_t size)
 			break;
 		}
 
-		rc = wait_until_ready(dev, K_MSEC(1));
+		rc = wait_until_ready(dev, &dev_config->mspi_nor_init_cfg, K_MSEC(1));
 		if (rc < 0) {
 			break;
 		}
@@ -340,19 +576,14 @@ static int read_jedec_id(const struct device *dev, uint8_t *id)
 	struct flash_mspi_nor_data *dev_data = dev->data;
 	int rc;
 
-	dev_data->xfer.cmd_length  = 2;
-	dev_data->xfer.addr_length = 4;
-	dev_data->xfer.rx_dummy    = 4;
-	dev_data->packet.dir       = MSPI_RX;
-	dev_data->packet.cmd       = JESD216_OCMD_READ_ID;
-	dev_data->packet.address   = 0;
+	command_set(dev, &dev_config->jedec_cmds->id);
 	dev_data->packet.data_buf  = id;
 	dev_data->packet.num_bytes = JESD216_READ_ID_LEN;
+
 	rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
 			     &dev_data->xfer);
 	if (rc < 0) {
-		printk("mspi_transceive() failed: %d\n", rc);
-		return rc;
+		LOG_ERR("mspi_transceive() failed: %d\n", rc);
 	}
 
 	return rc;
@@ -382,16 +613,13 @@ static int api_sfdp_read(const struct device *dev, off_t addr, void *dest,
 		return 0;
 	}
 
-	rc = acquire(dev);
+	rc = acquire(dev, dev_config->jedec_cmds->sfdp.force_single ?
+			  &dev_config->mspi_nor_init_cfg : &dev_config->mspi_nor_cfg);
 	if (rc < 0) {
 		return rc;
 	}
 
-	dev_data->xfer.cmd_length  = 2;
-	dev_data->xfer.addr_length = 4;
-	dev_data->xfer.rx_dummy    = 20;
-	dev_data->packet.dir       = MSPI_RX;
-	dev_data->packet.cmd       = JESD216_OCMD_READ_SFDP;
+	command_set(dev, &dev_config->jedec_cmds->sfdp);
 	dev_data->packet.address   = addr;
 	dev_data->packet.data_buf  = dest;
 	dev_data->packet.num_bytes = size;
@@ -409,9 +637,10 @@ static int api_sfdp_read(const struct device *dev, off_t addr, void *dest,
 
 static int api_read_jedec_id(const struct device *dev, uint8_t *id)
 {
-	int rc = 0;
+	const struct flash_mspi_nor_config *dev_config = dev->config;
 
-	rc = acquire(dev);
+	int rc = acquire(dev, dev_config->jedec_cmds->id.force_single ?
+			      &dev_config->mspi_nor_init_cfg : &dev_config->mspi_nor_cfg);
 	if (rc < 0) {
 		return rc;
 	}
@@ -439,77 +668,91 @@ static int dev_pm_action_cb(const struct device *dev,
 	return 0;
 }
 
+static int switch_mode(const struct device *dev, uint8_t *id)
+{
+	const struct flash_mspi_nor_config *dev_config = dev->config;
+	struct flash_mspi_nor_data *dev_data = dev->data;
+
+	/* For octal mode:
+	 * If the read ID does not match the one from DTS, assume the flash
+	 * is already in the Octa I/O mode, so switching it is not needed.
+	 */
+	if ((dev_config->mspi_nor_cfg.io_mode == MSPI_IO_MODE_OCTAL) &&
+	     (memcmp(id, dev_config->jedec_id, JESD216_READ_ID_LEN) != 0)) {
+		return 0;
+	}
+
+	command_set(dev, &commands[MSPI_IO_MODE_SINGLE].write_en);
+	int rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
+			     &dev_data->xfer);
+	if (rc < 0) {
+		LOG_ERR("Failed to set write enable: %d", rc);
+		return rc;
+	}
+
+	command_set(dev, &dev_config->jedec_cmds->mode_change);
+
+	/* MX25R specific:
+	 * For quad io mode above 8 MHz and single io mode above 33 MHz,
+	 * high performance mode needs to be enabled.
+	 */
+	if (((dev_config->mspi_nor_cfg.io_mode == MSPI_IO_MODE_QUAD_1_4_4) &&
+	     (dev_config->mspi_nor_cfg.freq > MHZ(8))) ||
+	    ((dev_config->mspi_nor_cfg.io_mode == MSPI_IO_MODE_SINGLE) &&
+	     (dev_config->mspi_nor_cfg.freq > MHZ(33)))) {
+		dev_data->packet.data_buf  = hp_payload;
+		dev_data->packet.num_bytes = sizeof(hp_payload);
+	} else {
+		dev_data->packet.data_buf  = (uint8_t *)&dev_config->jedec_cmds->mode_payload;
+		dev_data->packet.num_bytes = sizeof(dev_config->jedec_cmds->mode_payload);
+	}
+
+	rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id, &dev_data->xfer);
+
+	if (rc < 0) {
+		LOG_ERR("Failed to change IO mode: %d\n", rc);
+		return rc;
+	}
+
+	return 0;
+}
+
 static int flash_chip_init(const struct device *dev)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
 	struct flash_mspi_nor_data *dev_data = dev->data;
-	struct mspi_dev_cfg init_dev_cfg = dev_config->mspi_cfg;
 	uint8_t id[JESD216_READ_ID_LEN] = {0};
 	int rc;
 
-	init_dev_cfg.freq = MHZ(1);
-	init_dev_cfg.io_mode = MSPI_IO_MODE_SINGLE;
-
 	rc = mspi_dev_config(dev_config->bus, &dev_config->mspi_id,
-			     MSPI_DEVICE_CONFIG_ALL, &init_dev_cfg);
+			     MSPI_DEVICE_CONFIG_ALL, &dev_config->mspi_nor_init_cfg);
 	if (rc < 0) {
 		LOG_ERR("Failed to set initial device config: %d", rc);
 		return rc;
 	}
 
-	dev_data->xfer.xfer_mode  = MSPI_PIO;
-	dev_data->xfer.packets    = &dev_data->packet;
-	dev_data->xfer.num_packet = 1;
-	dev_data->xfer.timeout    = 10;
-
-	dev_data->xfer.cmd_length  = 1;
-	dev_data->xfer.addr_length = 0;
-	dev_data->xfer.tx_dummy    = 0;
-	dev_data->xfer.rx_dummy    = 0;
-
-	dev_data->packet.dir       = MSPI_RX;
-	dev_data->packet.cmd       = JESD216_CMD_READ_ID;
+	command_set(dev, &commands[MSPI_IO_MODE_SINGLE].id);
 	dev_data->packet.data_buf  = id;
 	dev_data->packet.num_bytes = sizeof(id);
+
 	rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
 			     &dev_data->xfer);
 	if (rc < 0) {
-		LOG_ERR("Failed to read JEDEC ID in single line mode: %d", rc);
+		LOG_ERR("Failed to read JEDEC ID in initial line mode: %d", rc);
 		return rc;
 	}
 
-	/*
-	 * If the read ID does not match the one from DTS, assume the flash
-	 * is already in the Octa I/O mode, so switching it is not needed.
-	 */
-	if (memcmp(id, dev_config->jedec_id, sizeof(id)) == 0) {
-		static const uint8_t enable_sopi[] = { 0x01 };
+	rc = switch_mode(dev, id);
 
-		dev_data->packet.dir       = MSPI_TX;
-		dev_data->packet.cmd       = SPI_NOR_CMD_WREN;
-		dev_data->packet.num_bytes = 0;
-		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
-				     &dev_data->xfer);
-		if (rc < 0) {
-			LOG_ERR("SPI_NOR_CMD_WREN xfer failed: %d", rc);
-			return rc;
-		}
-
-		dev_data->xfer.addr_length = 4;
-		dev_data->packet.cmd       = SPI_NOR_CMD_WR_CFGREG2;
-		dev_data->packet.address   = 0;
-		dev_data->packet.data_buf  = (uint8_t *)&enable_sopi;
-		dev_data->packet.num_bytes = sizeof(enable_sopi);
-		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
-				     &dev_data->xfer);
-		if (rc < 0) {
-			printk("SPI_NOR_CMD_WR_CFGREG2 xfer failed: %d\n", rc);
-			return rc;
-		}
+	if (rc < 0) {
+		LOG_ERR("Failed to switch mode: %d", rc);
+		return rc;
 	}
 
 	rc = mspi_dev_config(dev_config->bus, &dev_config->mspi_id,
-			     MSPI_DEVICE_CONFIG_ALL, &dev_config->mspi_cfg);
+			     MSPI_DEVICE_CONFIG_ALL,
+			     dev_config->jedec_cmds->id.force_single ?
+			     &dev_config->mspi_nor_init_cfg : &dev_config->mspi_nor_cfg);
 	if (rc < 0) {
 		LOG_ERR("Failed to set device config: %d", rc);
 		return rc;
@@ -517,6 +760,7 @@ static int flash_chip_init(const struct device *dev)
 
 	rc = read_jedec_id(dev, id);
 	if (rc < 0) {
+		LOG_ERR("Failed to read JEDEC ID in final line mode: %d", rc);
 		return rc;
 	}
 
@@ -624,7 +868,20 @@ static DEVICE_API(flash, drv_api) = {
 #endif
 };
 
+#define FLASH_INITIAL_CONFIG(inst)					\
+{									\
+	.ce_num = DT_INST_PROP_OR(inst, mspi_hardware_ce_num, 0),	\
+	.freq = MIN(DT_INST_PROP(inst, mspi_max_frequency), MHZ(50)),	\
+	.io_mode = MSPI_IO_MODE_SINGLE,					\
+	.data_rate = MSPI_DATA_RATE_SINGLE,				\
+	.cpp = MSPI_CPP_MODE_0,						\
+	.endian = MSPI_XFER_BIG_ENDIAN,					\
+	.ce_polarity = MSPI_CE_ACTIVE_LOW,				\
+	.dqs_enable = false,						\
+}
+
 #define FLASH_SIZE_INST(inst) (DT_INST_PROP(inst, size) / 8)
+#define FLASH_CMDS(inst) &commands[DT_INST_ENUM_IDX(inst, mspi_io_mode)]
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 BUILD_ASSERT((CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE % 4096) == 0,
@@ -651,17 +908,22 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 #endif
 
 #define FLASH_MSPI_NOR_INST(inst)						\
-	BUILD_ASSERT(DT_INST_ENUM_IDX(inst, mspi_io_mode) ==			\
-		     MSPI_IO_MODE_OCTAL,					\
-		"Only Octal I/O mode is supported for now");			\
+	BUILD_ASSERT((DT_INST_ENUM_IDX(inst, mspi_io_mode) ==			\
+		      MSPI_IO_MODE_SINGLE) ||					\
+		     (DT_INST_ENUM_IDX(inst, mspi_io_mode) ==			\
+		      MSPI_IO_MODE_QUAD_1_4_4) ||				\
+		     (DT_INST_ENUM_IDX(inst, mspi_io_mode) ==			\
+		      MSPI_IO_MODE_OCTAL),					\
+		"Only 1x, 1-4-4 and 8x I/O modes are supported for now");	\
 	PM_DEVICE_DT_INST_DEFINE(inst, dev_pm_action_cb);			\
 	static struct flash_mspi_nor_data dev##inst##_data;			\
 	static const struct flash_mspi_nor_config dev##inst##_config = {	\
 		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),			\
 		.flash_size = FLASH_SIZE_INST(inst),				\
 		.mspi_id = MSPI_DEVICE_ID_DT_INST(inst),			\
-		.mspi_cfg = MSPI_DEVICE_CONFIG_DT_INST(inst),			\
-		.mspi_cfg_mask = DT_PROP(DT_INST_BUS(inst),			\
+		.mspi_nor_cfg = MSPI_DEVICE_CONFIG_DT_INST(inst),		\
+		.mspi_nor_init_cfg = FLASH_INITIAL_CONFIG(inst),		\
+		.mspi_nor_cfg_mask = DT_PROP(DT_INST_BUS(inst),			\
 					 software_multiperipheral)		\
 			       ? MSPI_DEVICE_CONFIG_ALL				\
 			       : MSPI_DEVICE_CONFIG_NONE,			\
@@ -675,6 +937,7 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 				   / 1000,))					\
 		FLASH_PAGE_LAYOUT_DEFINE(inst)					\
 		.jedec_id = DT_INST_PROP(inst, jedec_id),			\
+		.jedec_cmds = FLASH_CMDS(inst),					\
 	};									\
 	FLASH_PAGE_LAYOUT_CHECK(inst)						\
 	DEVICE_DT_INST_DEFINE(inst,						\

--- a/drivers/flash/flash_mspi_nor.c
+++ b/drivers/flash/flash_mspi_nor.c
@@ -28,183 +28,6 @@ struct flash_mspi_nor_data {
 	struct mspi_xfer xfer;
 };
 
-struct flash_mspi_nor_cmd {
-	enum mspi_xfer_direction dir;
-	uint32_t cmd;
-	uint16_t tx_dummy;
-	uint16_t rx_dummy;
-	uint8_t cmd_length;
-	uint8_t addr_length;
-};
-
-struct flash_mspi_nor_cmds {
-	struct flash_mspi_nor_cmd id;
-	struct flash_mspi_nor_cmd write_en;
-	struct flash_mspi_nor_cmd read;
-	struct flash_mspi_nor_cmd status;
-	struct flash_mspi_nor_cmd page_program;
-	struct flash_mspi_nor_cmd sector_erase;
-	struct flash_mspi_nor_cmd chip_erase;
-	struct flash_mspi_nor_cmd mode_change;
-	struct flash_mspi_nor_cmd sfdp;
-	uint8_t mode_payload;
-};
-
-static const struct flash_mspi_nor_cmds commands[] = {
-	[MSPI_IO_MODE_SINGLE] = {
-		.id = {
-			.dir = MSPI_RX,
-			.cmd = JESD216_CMD_READ_ID,
-			.cmd_length = 1,
-		},
-		.write_en = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_WREN,
-			.cmd_length = 1,
-		},
-		.read = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_CMD_READ,
-			.cmd_length = 1,
-			.addr_length = 3,
-		},
-		.status = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_CMD_RDSR,
-			.cmd_length = 1,
-		},
-		.page_program = {
-			.dir  = MSPI_TX,
-			.cmd = SPI_NOR_CMD_PP,
-			.cmd_length = 1,
-			.addr_length = 3,
-		},
-		.sector_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_SE,
-			.cmd_length = 1,
-			.addr_length = 3,
-		},
-		.chip_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_CE,
-			.cmd_length = 1,
-		},
-		.mode_change = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_WRSR,
-			.cmd_length = 1,
-		},
-		.mode_payload = 0,
-	},
-	[MSPI_IO_MODE_QUAD_1_4_4] = {
-		.id = {
-			.dir = MSPI_RX,
-			.cmd = JESD216_CMD_READ_ID,
-			.cmd_length = 1,
-		},
-		.write_en = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_WREN,
-			.cmd_length = 1,
-		},
-		.read = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_CMD_4READ,
-			.cmd_length = 1,
-			.addr_length = 3,
-			.rx_dummy = 6,
-		},
-		.status = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_CMD_RDSR,
-			.cmd_length = 1,
-		},
-		.page_program = {
-			.dir  = MSPI_TX,
-			.cmd = SPI_NOR_CMD_PP_1_4_4,
-			.cmd_length = 1,
-			.addr_length = 3,
-		},
-		.sector_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_SE,
-			.cmd_length = 1,
-			.addr_length = 3,
-		},
-		.chip_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_CE,
-			.cmd_length = 1,
-		},
-		.mode_change = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_WRSR,
-			.cmd_length = 1,
-		},
-		.mode_payload = SPI_NOR_QE_BIT,
-	},
-	[MSPI_IO_MODE_OCTAL] = {
-		.id = {
-			.dir = MSPI_RX,
-			.cmd = JESD216_OCMD_READ_ID,
-			.cmd_length = 2,
-			.addr_length = 4,
-			.rx_dummy = 4
-		},
-		.write_en = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_OCMD_WREN,
-			.cmd_length = 2,
-		},
-		.read = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_OCMD_RD,
-			.cmd_length = 2,
-			.addr_length = 4,
-			.rx_dummy = 20,
-		},
-		.status = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_OCMD_RDSR,
-			.cmd_length = 2,
-			.addr_length = 4,
-			.rx_dummy = 4,
-		},
-		.page_program = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_OCMD_PAGE_PRG,
-			.cmd_length = 2,
-			.addr_length = 4,
-		},
-		.sector_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_OCMD_SE,
-			.cmd_length = 2,
-			.addr_length = 4,
-		},
-		.chip_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_OCMD_CE,
-			.cmd_length = 2,
-		},
-		.sfdp = {
-			.dir = MSPI_RX,
-			.cmd = JESD216_OCMD_READ_SFDP,
-			.cmd_length = 2,
-			.addr_length = 4,
-			.rx_dummy = 20,
-		},
-		.mode_change = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_WR_CFGREG2,
-			.cmd_length = 1,
-			.addr_length = 4,
-		},
-		.mode_payload = 0x01,
-	},
-};
-
 struct flash_mspi_nor_config {
 	const struct device *bus;
 	uint32_t flash_size;
@@ -223,7 +46,6 @@ struct flash_mspi_nor_config {
 	struct flash_pages_layout layout;
 #endif
 	uint8_t jedec_id[SPI_NOR_MAX_ID_LEN];
-	const struct flash_mspi_nor_cmds *jedec_cmds;
 };
 
 static int acquire(const struct device *dev)
@@ -282,27 +104,6 @@ static inline uint16_t dev_page_size(const struct device *dev)
 	return SPI_NOR_PAGE_SIZE;
 }
 
-static void command_set(const struct device *dev, const struct flash_mspi_nor_cmd *cmd)
-{
-	struct flash_mspi_nor_data *dev_data = dev->data;
-
-	memset(&dev_data->xfer, 0, sizeof(dev_data->xfer));
-	memset(&dev_data->packet, 0, sizeof(dev_data->packet));
-
-	dev_data->xfer.xfer_mode  = MSPI_PIO;
-	dev_data->xfer.packets    = &dev_data->packet;
-	dev_data->xfer.num_packet = 1;
-	dev_data->xfer.timeout    = 10;
-
-	dev_data->xfer.cmd_length = cmd->cmd_length;
-	dev_data->xfer.addr_length = cmd->addr_length;
-	dev_data->xfer.tx_dummy = cmd->tx_dummy;
-	dev_data->xfer.rx_dummy = cmd->rx_dummy;
-
-	dev_data->packet.dir = cmd->dir;
-	dev_data->packet.cmd = cmd->cmd;
-}
-
 static int api_read(const struct device *dev, off_t addr, void *dest,
 		    size_t size)
 {
@@ -325,7 +126,11 @@ static int api_read(const struct device *dev, off_t addr, void *dest,
 	}
 
 	/* TODO: get rid of all these hard-coded values for MX25Ux chips */
-	command_set(dev, &dev_config->jedec_cmds->read);
+	dev_data->xfer.cmd_length  = 2;
+	dev_data->xfer.addr_length = 4;
+	dev_data->xfer.rx_dummy    = 20;
+	dev_data->packet.dir       = MSPI_RX;
+	dev_data->packet.cmd       = SPI_NOR_OCMD_RD;
 	dev_data->packet.address   = addr;
 	dev_data->packet.data_buf  = dest;
 	dev_data->packet.num_bytes = size;
@@ -335,38 +140,35 @@ static int api_read(const struct device *dev, off_t addr, void *dest,
 	release(dev);
 
 	if (rc < 0) {
-		LOG_ERR("Read xfer failed: %d", rc);
+		LOG_ERR("SPI_NOR_OCMD_RD xfer failed: %d", rc);
 		return rc;
 	}
 
 	return 0;
 }
 
-static int status_get(const struct device *dev, uint8_t *status)
+static int wait_until_ready(const struct device *dev, k_timeout_t poll_period)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
 	struct flash_mspi_nor_data *dev_data = dev->data;
-
-	command_set(dev, &dev_config->jedec_cmds->status);
-	dev_data->packet.data_buf  = status;
-	dev_data->packet.num_bytes = sizeof(uint8_t);
-
-	return mspi_transceive(dev_config->bus, &dev_config->mspi_id, &dev_data->xfer);
-}
-
-static int wait_until_ready(const struct device *dev, k_timeout_t poll_period)
-{
-	int rc;
 	uint8_t status_reg;
+	int rc;
 
 	while (true) {
-		rc = status_get(dev, &status_reg);
-
+		dev_data->xfer.cmd_length  = 2;
+		dev_data->xfer.addr_length = 4;
+		dev_data->xfer.rx_dummy    = 4;
+		dev_data->packet.dir       = MSPI_RX;
+		dev_data->packet.cmd       = SPI_NOR_OCMD_RDSR;
+		dev_data->packet.address   = 0;
+		dev_data->packet.data_buf  = &status_reg;
+		dev_data->packet.num_bytes = sizeof(status_reg);
+		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
+				     &dev_data->xfer);
 		if (rc < 0) {
-			LOG_ERR("Status xfer failed: %d", rc);
+			LOG_ERR("SPI_NOR_OCMD_RDSR xfer failed: %d", rc);
 			return rc;
 		}
-
 		if (!(status_reg & SPI_NOR_WIP_BIT)) {
 			break;
 		}
@@ -375,15 +177,6 @@ static int wait_until_ready(const struct device *dev, k_timeout_t poll_period)
 	}
 
 	return 0;
-}
-
-static int write_enable(const struct device *dev)
-{
-	const struct flash_mspi_nor_config *dev_config = dev->config;
-	struct flash_mspi_nor_data *dev_data = dev->data;
-
-	command_set(dev, &dev_config->jedec_cmds->write_en);
-	return mspi_transceive(dev_config->bus, &dev_config->mspi_id, &dev_data->xfer);
 }
 
 static int api_write(const struct device *dev, off_t addr, const void *src,
@@ -414,19 +207,29 @@ static int api_write(const struct device *dev, off_t addr, const void *src,
 		uint16_t page_left = page_size - page_offset;
 		uint16_t to_write = (uint16_t)MIN(size, page_left);
 
-		if (write_enable(dev) < 0) {
-			LOG_ERR("Write enable xfer failed: %d", rc);
+		dev_data->xfer.cmd_length  = 2;
+		dev_data->xfer.tx_dummy    = 0;
+		dev_data->packet.dir       = MSPI_TX;
+
+		dev_data->xfer.addr_length = 0;
+		dev_data->packet.cmd       = SPI_NOR_OCMD_WREN;
+		dev_data->packet.num_bytes = 0;
+		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
+				     &dev_data->xfer);
+		if (rc < 0) {
+			LOG_ERR("SPI_NOR_OCMD_WREN xfer failed: %d", rc);
 			break;
 		}
 
-		command_set(dev, &dev_config->jedec_cmds->page_program);
+		dev_data->xfer.addr_length = 4;
+		dev_data->packet.cmd       = SPI_NOR_OCMD_PAGE_PRG;
 		dev_data->packet.address   = addr;
 		dev_data->packet.data_buf  = (uint8_t *)src;
 		dev_data->packet.num_bytes = to_write;
 		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
 				     &dev_data->xfer);
 		if (rc < 0) {
-			LOG_ERR("Page program xfer failed: %d", rc);
+			LOG_ERR("SPI_NOR_OCMD_PAGE_PRG xfer failed: %d", rc);
 			break;
 		}
 
@@ -470,20 +273,32 @@ static int api_erase(const struct device *dev, off_t addr, size_t size)
 	}
 
 	while (size > 0) {
-		rc = write_enable(dev);
+		dev_data->xfer.cmd_length  = 2;
+		dev_data->xfer.tx_dummy    = 0;
+		dev_data->packet.dir       = MSPI_TX;
+		dev_data->packet.num_bytes = 0;
+
+		dev_data->xfer.addr_length = 0;
+		dev_data->packet.cmd       = SPI_NOR_OCMD_WREN;
+		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
+				     &dev_data->xfer);
 		if (rc < 0) {
-			LOG_ERR("Write enable failed.");
+			LOG_ERR("SPI_NOR_OCMD_WREN xfer failed: %d", rc);
 			break;
 		}
 
 		if (size == flash_size) {
 			/* Chip erase. */
-			command_set(dev, &dev_config->jedec_cmds->chip_erase);
+			dev_data->xfer.addr_length = 0;
+			dev_data->packet.cmd       = SPI_NOR_OCMD_CE;
+
 			size -= flash_size;
 		} else {
 			/* Sector erase. */
-			command_set(dev, &dev_config->jedec_cmds->sector_erase);
-			dev_data->packet.address = addr;
+			dev_data->xfer.addr_length = 4;
+			dev_data->packet.cmd       = SPI_NOR_OCMD_SE;
+			dev_data->packet.address   = addr;
+
 			addr += SPI_NOR_SECTOR_SIZE;
 			size -= SPI_NOR_SECTOR_SIZE;
 		}
@@ -525,14 +340,19 @@ static int read_jedec_id(const struct device *dev, uint8_t *id)
 	struct flash_mspi_nor_data *dev_data = dev->data;
 	int rc;
 
-	command_set(dev, &dev_config->jedec_cmds->id);
+	dev_data->xfer.cmd_length  = 2;
+	dev_data->xfer.addr_length = 4;
+	dev_data->xfer.rx_dummy    = 4;
+	dev_data->packet.dir       = MSPI_RX;
+	dev_data->packet.cmd       = JESD216_OCMD_READ_ID;
+	dev_data->packet.address   = 0;
 	dev_data->packet.data_buf  = id;
 	dev_data->packet.num_bytes = JESD216_READ_ID_LEN;
-
 	rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
 			     &dev_data->xfer);
 	if (rc < 0) {
-		LOG_ERR("mspi_transceive() failed: %d\n", rc);
+		printk("mspi_transceive() failed: %d\n", rc);
+		return rc;
 	}
 
 	return rc;
@@ -567,8 +387,11 @@ static int api_sfdp_read(const struct device *dev, off_t addr, void *dest,
 		return rc;
 	}
 
-
-	command_set(dev, &dev_config->jedec_cmds->sfdp);
+	dev_data->xfer.cmd_length  = 2;
+	dev_data->xfer.addr_length = 4;
+	dev_data->xfer.rx_dummy    = 20;
+	dev_data->packet.dir       = MSPI_RX;
+	dev_data->packet.cmd       = JESD216_OCMD_READ_SFDP;
 	dev_data->packet.address   = addr;
 	dev_data->packet.data_buf  = dest;
 	dev_data->packet.num_bytes = size;
@@ -616,41 +439,6 @@ static int dev_pm_action_cb(const struct device *dev,
 	return 0;
 }
 
-static int switch_mode(const struct device *dev, uint8_t *id)
-{
-	const struct flash_mspi_nor_config *dev_config = dev->config;
-	struct flash_mspi_nor_data *dev_data = dev->data;
-
-	/* For octal mode:
-	 * If the read ID does not match the one from DTS, assume the flash
-	 * is already in the Octa I/O mode, so switching it is not needed.
-	 */
-	if ((dev_config->mspi_cfg.io_mode == MSPI_IO_MODE_OCTAL) &&
-	     (memcmp(id, dev_config->jedec_id, JESD216_READ_ID_LEN) != 0)) {
-		return 0;
-	}
-
-	command_set(dev, &commands[MSPI_IO_MODE_SINGLE].write_en);
-	int rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
-			     &dev_data->xfer);
-	if (rc < 0) {
-		LOG_ERR("Failed to set write enable: %d", rc);
-		return rc;
-	}
-
-	command_set(dev, &dev_config->jedec_cmds->mode_change);
-	dev_data->packet.data_buf  = (uint8_t *)&dev_config->jedec_cmds->mode_payload;
-	dev_data->packet.num_bytes = sizeof(dev_config->jedec_cmds->mode_payload);
-	rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
-			     &dev_data->xfer);
-	if (rc < 0) {
-		LOG_ERR("Failed to change IO mode: %d\n", rc);
-		return rc;
-	}
-
-	return 0;
-}
-
 static int flash_chip_init(const struct device *dev)
 {
 	const struct flash_mspi_nor_config *dev_config = dev->config;
@@ -669,21 +457,55 @@ static int flash_chip_init(const struct device *dev)
 		return rc;
 	}
 
-	command_set(dev, &commands[MSPI_IO_MODE_SINGLE].id);
+	dev_data->xfer.xfer_mode  = MSPI_PIO;
+	dev_data->xfer.packets    = &dev_data->packet;
+	dev_data->xfer.num_packet = 1;
+	dev_data->xfer.timeout    = 10;
+
+	dev_data->xfer.cmd_length  = 1;
+	dev_data->xfer.addr_length = 0;
+	dev_data->xfer.tx_dummy    = 0;
+	dev_data->xfer.rx_dummy    = 0;
+
+	dev_data->packet.dir       = MSPI_RX;
+	dev_data->packet.cmd       = JESD216_CMD_READ_ID;
 	dev_data->packet.data_buf  = id;
 	dev_data->packet.num_bytes = sizeof(id);
-
 	rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
 			     &dev_data->xfer);
 	if (rc < 0) {
-		LOG_ERR("Failed to read JEDEC ID in initial line mode: %d", rc);
+		LOG_ERR("Failed to read JEDEC ID in single line mode: %d", rc);
 		return rc;
 	}
 
-	rc = switch_mode(dev, id);
+	/*
+	 * If the read ID does not match the one from DTS, assume the flash
+	 * is already in the Octa I/O mode, so switching it is not needed.
+	 */
+	if (memcmp(id, dev_config->jedec_id, sizeof(id)) == 0) {
+		static const uint8_t enable_sopi[] = { 0x01 };
 
-	if (rc < 0) {
-		LOG_ERR("Failed to switch mode: %d", rc);
+		dev_data->packet.dir       = MSPI_TX;
+		dev_data->packet.cmd       = SPI_NOR_CMD_WREN;
+		dev_data->packet.num_bytes = 0;
+		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
+				     &dev_data->xfer);
+		if (rc < 0) {
+			LOG_ERR("SPI_NOR_CMD_WREN xfer failed: %d", rc);
+			return rc;
+		}
+
+		dev_data->xfer.addr_length = 4;
+		dev_data->packet.cmd       = SPI_NOR_CMD_WR_CFGREG2;
+		dev_data->packet.address   = 0;
+		dev_data->packet.data_buf  = (uint8_t *)&enable_sopi;
+		dev_data->packet.num_bytes = sizeof(enable_sopi);
+		rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
+				     &dev_data->xfer);
+		if (rc < 0) {
+			printk("SPI_NOR_CMD_WR_CFGREG2 xfer failed: %d\n", rc);
+			return rc;
+		}
 	}
 
 	rc = mspi_dev_config(dev_config->bus, &dev_config->mspi_id,
@@ -803,7 +625,6 @@ static DEVICE_API(flash, drv_api) = {
 };
 
 #define FLASH_SIZE_INST(inst) (DT_INST_PROP(inst, size) / 8)
-#define FLASH_CMDS(inst) &commands[DT_INST_ENUM_IDX(inst, mspi_io_mode)]
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 BUILD_ASSERT((CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE % 4096) == 0,
@@ -830,13 +651,9 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 #endif
 
 #define FLASH_MSPI_NOR_INST(inst)						\
-	BUILD_ASSERT((DT_INST_ENUM_IDX(inst, mspi_io_mode) ==			\
-		      MSPI_IO_MODE_SINGLE) ||					\
-		     (DT_INST_ENUM_IDX(inst, mspi_io_mode) ==			\
-		      MSPI_IO_MODE_QUAD_1_4_4) ||				\
-		     (DT_INST_ENUM_IDX(inst, mspi_io_mode) ==			\
-		      MSPI_IO_MODE_OCTAL),					\
-		"Only 1x, 1-4-4 and 8x I/O modes are supported for now");	\
+	BUILD_ASSERT(DT_INST_ENUM_IDX(inst, mspi_io_mode) ==			\
+		     MSPI_IO_MODE_OCTAL,					\
+		"Only Octal I/O mode is supported for now");			\
 	PM_DEVICE_DT_INST_DEFINE(inst, dev_pm_action_cb);			\
 	static struct flash_mspi_nor_data dev##inst##_data;			\
 	static const struct flash_mspi_nor_config dev##inst##_config = {	\
@@ -858,7 +675,6 @@ BUILD_ASSERT((FLASH_SIZE_INST(inst) % CONFIG_FLASH_MSPI_NOR_LAYOUT_PAGE_SIZE) ==
 				   / 1000,))					\
 		FLASH_PAGE_LAYOUT_DEFINE(inst)					\
 		.jedec_id = DT_INST_PROP(inst, jedec_id),			\
-		.jedec_cmds = FLASH_CMDS(inst),					\
 	};									\
 	FLASH_PAGE_LAYOUT_CHECK(inst)						\
 	DEVICE_DT_INST_DEFINE(inst,						\


### PR DESCRIPTION
Pull in changes from upstream that switch to single lane when required, enable high performance bit when needed and use fast read in single.