### PR TITLE
[nrf fromtree] boards: nordic: nrf54l09pdk: Change pin used for led0

### DIFF
--- a/boards/nordic/nrf54l09pdk/nrf54l09pdk_nrf54l09-common.dtsi
+++ b/boards/nordic/nrf54l09pdk/nrf54l09pdk_nrf54l09-common.dtsi
@@ -10,7 +10,7 @@
 	leds {
 		compatible = "gpio-leds";
 		led0: led_0 {
-			gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 			label = "Green LED 1";
 		};
 		led1: led_1 {


### PR DESCRIPTION
P1.7 used for led 0 was not passing gpio_api_1pin test (probably shortened with another pin in the test setup. Use different pin that passes the gpio_api_1pin test. At current stage this PDK is 'virtual' so this pin is not attached to any LED and it can be changed.

Signed-off-by: Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>
(cherry picked from commit b298faa5e35e48dd6137f260946bc0eff1b1bbd4)