### PR TITLE
Limit amount of code copierd by vpr launcher

### DIFF
--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -343,6 +343,10 @@ SECTIONS
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-data-sections.ld>
+/* Tag end location of code+data that shall be copied in non-XIP execution.
+ * It must not include noinit section.
+ */
+    __relocation_region_end = .;
 
 #include <zephyr/linker/common-noinit.ld>
 

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -290,8 +290,6 @@ SECTIONS
 		  __bss_end = ALIGN(4);
 	}  GROUP_DATA_LINK_IN(RAMABLE_REGION, RAMABLE_REGION)
 
-#include <zephyr/linker/common-noinit.ld>
-
     SECTION_DATA_PROLOGUE(_DATA_SECTION_NAME,,)
 	{
 		 . = ALIGN(4);
@@ -345,6 +343,8 @@ SECTIONS
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-data-sections.ld>
+
+#include <zephyr/linker/common-noinit.ld>
 
     __data_region_end = .;
 

--- a/soc/common/riscv-privileged/vector.S
+++ b/soc/common/riscv-privileged/vector.S
@@ -21,6 +21,8 @@ SECTION_FUNC(vectors, __start)
 	/* Initialize global pointer */
 	.option push
 	.option norelax
+	/* Include end address of code+data that shall be copied in non-XIP execution. */
+	la gp, __relocation_region_end
 	la gp, __global_pointer$
 	.option pop
 #endif


### PR DESCRIPTION
I've prepared a hacky solution that adds address of the end of relocation region to the beginning of the vpr binary. Vpr launcher decodes this address and copies only that part to RAM. This approach speeds up boot time and does not overwrite noinit section but it's hacky.

I'm not expecting that it will be merged. Its purpose is rather to trigger the discussion.