### PR TITLE
modules: hal_nordic: bump regtool to 9.0.1

### DIFF
--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CONFIG_NRF_REGTOOL_GENERATE_UICR)
   list(APPEND nrf_regtool_components GENERATE:UICR)
 endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 9.0.1
+  find_package(nrf-regtool 9.0.1 REQUIRED
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH

--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CONFIG_NRF_REGTOOL_GENERATE_UICR)
   list(APPEND nrf_regtool_components GENERATE:UICR)
 endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 8.1.3 REQUIRED
+  find_package(nrf-regtool 8.1.3
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH

--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CONFIG_NRF_REGTOOL_GENERATE_UICR)
   list(APPEND nrf_regtool_components GENERATE:UICR)
 endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 9.0.0
+  find_package(nrf-regtool 9.0.1
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH

--- a/modules/hal_nordic/CMakeLists.txt
+++ b/modules/hal_nordic/CMakeLists.txt
@@ -12,7 +12,7 @@ if(CONFIG_NRF_REGTOOL_GENERATE_UICR)
   list(APPEND nrf_regtool_components GENERATE:UICR)
 endif()
 if(DEFINED nrf_regtool_components)
-  find_package(nrf-regtool 8.1.3
+  find_package(nrf-regtool 9.0.0
     COMPONENTS ${nrf_regtool_components}
     PATHS ${CMAKE_CURRENT_LIST_DIR}/nrf-regtool
     NO_CMAKE_PATH


### PR DESCRIPTION
Upstream PR #: 88055

Added support for VPR GPIOs and a more concise output print.