### PR TITLE
[nrf fromtree] Bluetooth: monitor: Fix SEGGER RTT compilation error

### DIFF
--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -126,13 +126,12 @@ static void monitor_send(const void *data, size_t len)
 	}
 
 	if (!drop) {
-		if (!panic_mode) {
-			SEGGER_RTT_LOCK();
-		}
-		cnt = SEGGER_RTT_WriteNoLock(CONFIG_BT_DEBUG_MONITOR_RTT_BUFFER,
-					     rtt_buf, rtt_buf_offset);
-		if (!panic_mode) {
-			SEGGER_RTT_UNLOCK();
+		if (panic_mode) {
+			cnt = SEGGER_RTT_WriteNoLock(CONFIG_BT_DEBUG_MONITOR_RTT_BUFFER,
+						     rtt_buf, rtt_buf_offset);
+		} else {
+			cnt = SEGGER_RTT_Write(CONFIG_BT_DEBUG_MONITOR_RTT_BUFFER,
+					       rtt_buf, rtt_buf_offset);
 		}
 	}
 


### PR DESCRIPTION
This fixes out of scope IRQ lock key by using SEGGER_RTT_Write version that locks the IRQ by itself.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>
(cherry picked from commit 27c18adf28a08de4fa04f1dde8afee6ce185dee3)