### PR TITLE
Workaround for mltpan18

### DIFF
--- a/soc/nordic/common/vpr/Kconfig
+++ b/soc/nordic/common/vpr/Kconfig
@@ -1,6 +1,10 @@
 # Copyright (c) 2024 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+config RISCV_CORE_NORDIC_VPR_USE_MLTPAN_18
+	bool "Apply MLTPAN workaround"
+	default y if SOC_SERIES_NRF54HX || SOC_SERIES_NRF54LX
+
 config RISCV_CORE_NORDIC_VPR
 	bool
 	select ATOMIC_OPERATIONS_C

--- a/soc/nordic/common/vpr/soc_idle.c
+++ b/soc/nordic/common/vpr/soc_idle.c
@@ -6,7 +6,7 @@
 #include <zephyr/irq.h>
 #include <zephyr/sys/barrier.h>
 #include <zephyr/tracing/tracing.h>
-
+#include "hal/nrf_vpr.h"
 /*
  * Due to a HW issue, VPR requires MSTATUS.MIE to be enabled when entering sleep.
  * Otherwise it would not wake up.
@@ -17,6 +17,11 @@ void arch_cpu_idle(void)
 	barrier_dsync_fence_full();
 	irq_unlock(MSTATUS_IEN);
 	__asm__ volatile("wfi");
+
+	/* MLTPAN-18 workaround */
+#if defined(CONFIG_RISCV_CORE_NORDIC_VPR_USE_MLTPAN_18)
+	nrf_vpr_cpurun_set(NRF_VPR, true);
+#endif
 }
 
 void arch_cpu_atomic_idle(unsigned int key)
@@ -25,6 +30,11 @@ void arch_cpu_atomic_idle(unsigned int key)
 	barrier_dsync_fence_full();
 	irq_unlock(MSTATUS_IEN);
 	__asm__ volatile("wfi");
+
+	/* MLTPAN-18 workaround */
+#if defined(CONFIG_RISCV_CORE_NORDIC_VPR_USE_MLTPAN_18)
+	nrf_vpr_cpurun_set(NRF_VPR, true);
+#endif
 
 	/* Disable interrupts if needed. */
 	__asm__ volatile ("csrc mstatus, %0"


### PR DESCRIPTION
Going to hibernate sleep (sleep mode 0xF) multiple times without powering down (or writing to any of the VPR's APB registers) in between will cause GPR x1 (ra) to not be saved