### PR TITLE
[nrf fromlist] soc: nordic: nrf54h: Change PM_DEVICE_RUNTIME default

### DIFF
--- a/soc/nordic/nrf54h/Kconfig.defconfig
+++ b/soc/nordic/nrf54h/Kconfig.defconfig
@@ -42,4 +42,7 @@ config SPI_DW_ACCESS_WORD_ONLY
 config PM_DEVICE_POWER_DOMAIN
 	default n if PM_DEVICE
 
+config PM_DEVICE_RUNTIME
+	default y if PM_DEVICE
+
 endif # SOC_SERIES_NRF54HX


### PR DESCRIPTION
nrf54h20 device requires device runtime PM to be enabled when device PM is in use.

Upstream PR #: 87807