### PR TITLE
[nrf fromtree] soc: nordic: add option for forcing RAM power on reboot

### DIFF
--- a/soc/nordic/common/CMakeLists.txt
+++ b/soc/nordic/common/CMakeLists.txt
@@ -11,6 +11,11 @@ if(CONFIG_ARM)
   zephyr_linker_sources(SECTIONS arm_platform_init.ld)
 endif()
 
+# TF-M provides its own reboot sequence
+if(NOT CONFIG_TFM_PARTITION_PLATFORM)
+  zephyr_library_sources_ifdef(CONFIG_ARM reboot.c)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_POWEROFF poweroff.c)
 if(CONFIG_ARM)
   zephyr_library_sources_ifdef(CONFIG_NRF_PLATFORM_HALTIUM soc_lrcconf.c)

--- a/soc/nordic/common/Kconfig
+++ b/soc/nordic/common/Kconfig
@@ -7,6 +7,16 @@ config HAS_NORDIC_DMM
 config HAS_NORDIC_RAM_CTRL
 	bool
 
+config NRF_FORCE_RAM_ON_REBOOT
+	bool "Force all RAM blocks to be powered on before rebooting"
+	depends on HAS_NORDIC_RAM_CTRL
+	help
+	  RAM power configuration is preserved through soft reset,
+	  meaning that there is a risk of accessing powered off RAM blocks
+	  when booting in different application (i.e. bootloader).
+	  Force all RAM blocks to be powered on before triggering soft reset
+	  to prevent this from happening.
+
 config NRF_SYS_EVENT
 	bool "nRF system event support"
 	select NRFX_POWER if !NRF_PLATFORM_HALTIUM

--- a/soc/nordic/common/reboot.c
+++ b/soc/nordic/common/reboot.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/sys/reboot.h>
+#if defined(CONFIG_HAS_NORDIC_RAM_CTRL)
+#include <helpers/nrfx_ram_ctrl.h>
+#endif
+
+void sys_arch_reboot(int type)
+{
+	ARG_UNUSED(type);
+
+#ifdef CONFIG_NRF_FORCE_RAM_ON_REBOOT
+	uint8_t *ram_start;
+	size_t ram_size;
+
+#if defined(NRF_MEMORY_RAM_BASE)
+	ram_start = (uint8_t *)NRF_MEMORY_RAM_BASE;
+#else
+	ram_start = (uint8_t *)NRF_MEMORY_RAM0_BASE;
+#endif
+
+	ram_size = 0;
+#if defined(NRF_MEMORY_RAM_SIZE)
+	ram_size += NRF_MEMORY_RAM_SIZE;
+#endif
+#if defined(NRF_MEMORY_RAM0_SIZE)
+	ram_size += NRF_MEMORY_RAM0_SIZE;
+#endif
+#if defined(NRF_MEMORY_RAM1_SIZE)
+	ram_size += NRF_MEMORY_RAM1_SIZE;
+#endif
+#if defined(NRF_MEMORY_RAM2_SIZE)
+	ram_size += NRF_MEMORY_RAM2_SIZE;
+#endif
+
+	/* Power on all RAM blocks */
+	nrfx_ram_ctrl_power_enable_set(ram_start, ram_size, true);
+#endif
+
+	NVIC_SystemReset();
+}


### PR DESCRIPTION
RAM power configuration is preserved through soft reset, meaning that there is a risk of accessing powered off RAM blocks when booting in different application (i.e. bootloader). Add option to force all RAM blocks to be powered on before triggering soft reset to prevent this from happening.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/87814