### PR TITLE
drivers: serial: uart_nrfx_uarte: Avoid incorrect UARTE disable when using runtime PM

### DIFF
--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -622,6 +622,11 @@ static void clock_event_handler(nrfx_clock_evt_type_t event)
 			__ASSERT_NO_MSG(false);
 		}
 		break;
+	case NRFX_CLOCK_EVT_PLL_STARTED:
+	{
+		/* unhandled event */
+		break;
+	}
 	default:
 		__ASSERT_NO_MSG(0);
 		break;

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -48,6 +48,14 @@ LOG_MODULE_REGISTER(clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 #define INF(dev, subsys, ...) CLOCK_LOG(INF, dev, subsys, __VA_ARGS__)
 #define DBG(dev, subsys, ...) CLOCK_LOG(DBG, dev, subsys, __VA_ARGS__)
 
+#if defined(NRF54L05_XXAA) || defined(NRF54L10_XXAA) || defined(NRF54L15_XXAA)
+#if NRFX_RELEASE_VER_AT_LEAST(3, 11, 0)
+#error "Remove workaround for XOSTART as it is already done in the nrfx clock"
+#endif
+
+#define USE_WORKAROUND_FOR_CLOCK_XOSTART_ANOMALY 1
+#endif
+
 /* Clock subsys structure */
 struct nrf_clock_control_sub_data {
 	clock_control_cb_t cb;
@@ -220,6 +228,9 @@ static void hfclk_start(void)
 		hf_start_tstamp = k_uptime_get();
 	}
 
+#ifdef USE_WORKAROUND_FOR_CLOCK_XOSTART_ANOMALY
+	nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_PLLSTART);
+#endif
 	nrfx_clock_hfclk_start();
 }
 
@@ -230,6 +241,9 @@ static void hfclk_stop(void)
 	}
 
 	nrfx_clock_hfclk_stop();
+#ifdef USE_WORKAROUND_FOR_CLOCK_XOSTART_ANOMALY
+	nrf_clock_task_trigger(NRF_CLOCK, NRF_CLOCK_TASK_PLLSTOP);
+#endif
 }
 
 #if NRF_CLOCK_HAS_HFCLK192M

--- a/drivers/flash/soc_flash_nrf_rram.c
+++ b/drivers/flash/soc_flash_nrf_rram.c
@@ -54,6 +54,11 @@ LOG_MODULE_REGISTER(flash_nrf_rram, CONFIG_FLASH_LOG_LEVEL);
 #define WRITE_BLOCK_SIZE_FROM_DT DT_PROP(RRAM, write_block_size)
 #define ERASE_VALUE              0xFF
 
+#if CONFIG_TRUSTED_EXECUTION_NONSECURE && USE_PARTITION_MANAGER
+#include <soc_secure.h>
+#include <pm_config.h>
+#endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE && USE_PARTITION_MANAGER */
+
 #ifdef CONFIG_MULTITHREADING
 static struct k_sem sem_lock;
 #define SYNC_INIT()   k_sem_init(&sem_lock, 1, 1)
@@ -278,6 +283,12 @@ static int nrf_rram_read(const struct device *dev, off_t addr, void *data, size_
 		return -EINVAL;
 	}
 	addr += RRAM_START;
+
+#if CONFIG_TRUSTED_EXECUTION_NONSECURE && USE_PARTITION_MANAGER && PM_APP_ADDRESS
+	if (addr < PM_APP_ADDRESS) {
+		return soc_secure_mem_read(data, (void *)addr, len);
+	}
+#endif
 
 	memcpy(data, (void *)addr, len);
 

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -353,10 +353,11 @@ static void uarte_nrfx_isr_int(const void *arg)
 	if (txstopped && (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) || LOW_POWER_ENABLED(config))) {
 		unsigned int key = irq_lock();
 
-		if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME) &&
-		    (data->flags & UARTE_FLAG_POLL_OUT)) {
-			data->flags &= ~UARTE_FLAG_POLL_OUT;
-			pm_device_runtime_put(dev);
+		if (IS_ENABLED(CONFIG_PM_DEVICE_RUNTIME)) {
+			if (data->flags & UARTE_FLAG_POLL_OUT) {
+				data->flags &= ~UARTE_FLAG_POLL_OUT;
+				pm_device_runtime_put(dev);
+			}
 		} else {
 			nrf_uarte_disable(uarte);
 		}

--- a/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
+++ b/drivers/wifi/nrf_wifi/src/wifi_mgmt_scan.c
@@ -297,6 +297,8 @@ static inline enum wifi_security_type drv_to_wifi_mgmt(int drv_security_type)
 		return WIFI_SECURITY_TYPE_WAPI;
 	case NRF_WIFI_EAP:
 		return WIFI_SECURITY_TYPE_EAP;
+	case NRF_WIFI_EAP_TLS_SHA256:
+		return WIFI_SECURITY_TYPE_EAP_TLS_SHA256;
 	default:
 		return WIFI_SECURITY_TYPE_UNKNOWN;
 	}

--- a/soc/nordic/common/poweroff.c
+++ b/soc/nordic/common/poweroff.c
@@ -50,6 +50,15 @@ void z_sys_poweroff(void)
 
 	/* Disable retention for all memory blocks */
 	nrfx_ram_ctrl_retention_enable_set(ram_start, ram_size, false);
+#if defined(DEVELOP_IN_NRF54L15) && defined(NRF54L05_XXAA)
+	nrf_memconf_ramblock_ret_mask_enable_set(NRF_MEMCONF, 0, 0x1F8, false);
+	nrf_memconf_ramblock_ret2_mask_enable_set(NRF_MEMCONF, 0, 0x1F8, false);
+#endif
+#if defined(DEVELOP_IN_NRF54L15) && defined(NRF54L10_XXAA)
+	nrf_memconf_ramblock_ret_mask_enable_set(NRF_MEMCONF, 0, 0x1C0, false);
+	nrf_memconf_ramblock_ret2_mask_enable_set(NRF_MEMCONF, 0, 0x1C0, false);
+#endif
+
 #endif
 
 #if defined(CONFIG_RETAINED_MEM_NRF_RAM_CTRL)

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -37,6 +37,22 @@
 #if USE_PARTITION_MANAGER
 #include <pm_config.h>
 
+#if CONFIG_MCUBOOT_APPLICATION_IMAGE_NUMBER != -1
+/* Sysbuild */
+#ifdef CONFIG_MCUBOOT
+/* lib is part of MCUboot -> operate on the primary application slot */
+#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_PRIMARY_ID
+#else
+/* TODO: Add firmware loader support */
+/* lib is part of the app -> operate on active slot */
+#if defined(CONFIG_NCS_IS_VARIANT_IMAGE)
+#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_SECONDARY_ID
+#else
+#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_PRIMARY_ID
+#endif
+#endif /* CONFIG_MCUBOOT */
+#else
+/* Legacy child/parent */
 #if CONFIG_BUILD_WITH_TFM
 	#define PM_ADDRESS_OFFSET (PM_MCUBOOT_PAD_SIZE + PM_TFM_SIZE)
 #else
@@ -44,20 +60,19 @@
 #endif
 
 #ifdef CONFIG_MCUBOOT
-	/* lib is part of MCUboot -> operate on the primart application slot */
-	#define ACTIVE_SLOT_ID		PM_MCUBOOT_PRIMARY_ID
+	/* lib is part of MCUboot -> operate on the primary application slot */
+	#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_PRIMARY_ID
 #else
 	/* lib is part of the App -> operate on active slot */
 #if (PM_ADDRESS - PM_ADDRESS_OFFSET) == PM_MCUBOOT_PRIMARY_ADDRESS
-	#define ACTIVE_SLOT_ID		PM_MCUBOOT_PRIMARY_ID
+	#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_PRIMARY_ID
 #elif (PM_ADDRESS - PM_ADDRESS_OFFSET) == PM_MCUBOOT_SECONDARY_ADDRESS
-	#define ACTIVE_SLOT_ID		PM_MCUBOOT_SECONDARY_ID
+	#define ACTIVE_SLOT_FLASH_AREA_ID	PM_MCUBOOT_SECONDARY_ID
 #else
 	#error Missing partition definitions.
 #endif
 #endif /* CONFIG_MCUBOOT */
-
-#define ACTIVE_SLOT_FLASH_AREA_ID ACTIVE_SLOT_ID
+#endif /* CONFIG_MCUBOOT_APPLICATION_IMAGE_NUMBER != -1 */
 #else
 /* Get active partition. zephyr,code-partition chosen node must be defined */
 #define ACTIVE_SLOT_FLASH_AREA_ID DT_FIXED_PARTITION_ID(DT_CHOSEN(zephyr_code_partition))

--- a/west.yml
+++ b/west.yml
@@ -303,7 +303,7 @@ manifest:
       revision: 3cfca0192ff84da919e9bc7978bcc2239cd6a395
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 71261e2b719b98500b7741c3398a74a5fb631596
+      revision: f6b950a3b5c0187fe499b0e518426d5bf88b7e68
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: b735edbc739ad59156eb55bb8ce2583d74537719


### PR DESCRIPTION
When CONFIG_PM_DEVICE_RUNTIME is enabled, the code can incorrectly call
nrf_uarte_disable() after TXSTOPPED, even though runtime power management is
supposed to handle disabling the UARTE.

This happens if the UARTE_FLAG_POLL_OUT flag is not set — in that case,
the call to pm_device_runtime_put() is skipped, and nrf_uarte_disable() is
called directly instead, which isn't correct when runtime PM is active.

This fix prevents nrf_uarte_disable() from being called in this scenario,
so that the UARTE is only disabled by the PM system when appropriate.