### PR TITLE
drivers: saadc: Add support for nrf54h20 AIN8-14 pins

### DIFF
--- a/samples/drivers/adc/adc_sequence/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/adc/adc_sequence/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -45,6 +45,7 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN9>; /* P9.01 */
+		zephyr,vref-mv = <3686>; /* 3.6V * 1024 */
 		zephyr,resolution = <12>;
 		zephyr,oversampling = <8>;
 	};

--- a/samples/drivers/adc/adc_sequence/src/main.c
+++ b/samples/drivers/adc/adc_sequence/src/main.c
@@ -60,7 +60,7 @@ int main(void)
 			printf("Could not setup channel #%d (%d)\n", i, err);
 			return 0;
 		}
-		if (channel_cfgs[i].reference == ADC_REF_INTERNAL) {
+		if ((vrefs_mv[i] == 0) && (channel_cfgs[i].reference == ADC_REF_INTERNAL)) {
 			vrefs_mv[i] = adc_ref_internal(adc);
 		}
 	}


### PR DESCRIPTION
Add channel configuration build-time validation.
Demonstrate use of AIN8+ channel in `adc_sequence` sample.