### PR TITLE
[nrf noup] ci: enable custom base for `manifest-PR`

### DIFF
--- a/.github/workflows/manifest-PR.yml
+++ b/.github/workflows/manifest-PR.yml
@@ -3,7 +3,7 @@ on:
   pull_request_target:
     types: [opened, synchronize, closed]
     branches:
-      - main
+      - v3.0-ncs-branch
 
 
 jobs:
@@ -15,3 +15,4 @@ jobs:
         with:
           token: ${{ secrets.NCS_GITHUB_TOKEN }}
           manifest-pr-title-details: ${{ github.event.pull_request.title }}
+          base-branch: v3.0-branch


### PR DESCRIPTION
new arg base-branch defaults to main,
but can map zephyr release branch to nrf release base

Signed-off-by: Thomas Stilwell <thomas.stilwell@nordicsemi.no>
