### PR TITLE
[nrf fromtree] Bluetooth: Mesh: make corresponding group ID unique

### DIFF
--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -1830,8 +1830,8 @@ int bt_mesh_model_correspond(const struct bt_mesh_model *corresponding_mod,
 
 	MOD_REL_LIST_FOR_EACH(i) {
 		if (mod_rel_list[i].type < RELATION_TYPE_EXT &&
-		    mod_rel_list[i].type > cor_id) {
-			cor_id = mod_rel_list[i].type;
+		    mod_rel_list[i].type >= cor_id) {
+			cor_id = mod_rel_list[i].type + 1;
 		}
 
 		if ((IS_MOD_BASE(base_mod, i, base_offset) ||

--- a/tests/bsim/bluetooth/mesh/src/test_cdp1.c
+++ b/tests/bsim/bluetooth/mesh/src/test_cdp1.c
@@ -197,7 +197,7 @@ static const struct bt_mesh_comp_p1_model_item test_p1_mod2 = {
 	.cor_present = 1,
 	.format = 0,
 	.ext_item_cnt = 1,
-	.cor_id = 0,
+	.cor_id = 1,
 };
 
 static const struct bt_mesh_comp_p1_model_item test_p1_mod3 = {
@@ -211,7 +211,7 @@ static const struct bt_mesh_comp_p1_model_item test_p1_mod4 = {
 	.cor_present = 1,
 	.format = 0,
 	.ext_item_cnt = 0,
-	.cor_id = 0,
+	.cor_id = 1,
 };
 
 static const struct bt_mesh_comp_p1_model_item test_p1_mod5 = {


### PR DESCRIPTION
Commit fixes bug when corresponding group ID was never incremented for independent corresponding relationships.


(cherry picked from commit 69c5c6f40ea01946bc419067fc1577d74ae3e5f4)