### PR TITLE
[Backport v4.0.99-ncs1-branch] [nrf fromlist] drivers: udc_dwc2: Mark endpoint idle on disable while hibernated

### DIFF
--- a/drivers/usb/udc/udc_ambiq.c
+++ b/drivers/usb/udc/udc_ambiq.c
@@ -96,13 +96,14 @@ static int usbd_ctrl_feed_dout(const struct device *dev, const size_t length)
 static int udc_ambiq_tx(const struct device *dev, uint8_t ep, struct net_buf *buf)
 {
 	const struct udc_ambiq_data *priv = udc_get_private(dev);
+	struct udc_ep_config *cfg = udc_get_ep_cfg(dev, ep);
 	uint32_t status;
 
-	if (udc_ep_is_busy(dev, ep)) {
+	if (udc_ep_is_busy(cfg)) {
 		LOG_WRN("ep 0x%02x is busy!", ep);
 		return 0;
 	}
-	udc_ep_set_busy(dev, ep, true);
+	udc_ep_set_busy(cfg, true);
 
 	/* buf equals NULL is used as indication of ZLP request */
 	if (buf == NULL) {
@@ -112,7 +113,7 @@ static int udc_ambiq_tx(const struct device *dev, uint8_t ep, struct net_buf *bu
 	}
 
 	if (status != AM_HAL_STATUS_SUCCESS) {
-		udc_ep_set_busy(dev, ep, false);
+		udc_ep_set_busy(cfg, false);
 		LOG_ERR("am_hal_usb_ep_xfer write failed(0x%02x), %d", ep, (int)status);
 		return -EIO;
 	}
@@ -123,15 +124,16 @@ static int udc_ambiq_tx(const struct device *dev, uint8_t ep, struct net_buf *bu
 static int udc_ambiq_rx(const struct device *dev, uint8_t ep, struct net_buf *buf)
 {
 	struct udc_ambiq_data *priv = udc_get_private(dev);
+	struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, ep);
 	struct udc_ep_config *cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
 	uint32_t status;
 	uint16_t rx_size = buf->size;
 
-	if (udc_ep_is_busy(dev, ep)) {
+	if (udc_ep_is_busy(ep_cfg)) {
 		LOG_WRN("ep 0x%02x is busy!", ep);
 		return 0;
 	}
-	udc_ep_set_busy(dev, ep, true);
+	udc_ep_set_busy(ep_cfg, true);
 
 	/* Make sure that OUT transaction size triggered doesn't exceed EP's MPS */
 	if ((ep != USB_CONTROL_EP_OUT) && (cfg->mps < rx_size)) {
@@ -140,7 +142,7 @@ static int udc_ambiq_rx(const struct device *dev, uint8_t ep, struct net_buf *bu
 
 	status = am_hal_usb_ep_xfer(priv->usb_handle, ep, buf->data, rx_size);
 	if (status != AM_HAL_STATUS_SUCCESS) {
-		udc_ep_set_busy(dev, ep, false);
+		udc_ep_set_busy(ep_cfg, false);
 		LOG_ERR("am_hal_usb_ep_xfer read(rx) failed(0x%02x), %d", ep, (int)status);
 		return -EIO;
 	}
@@ -223,7 +225,9 @@ static void udc_ambiq_ep_xfer_complete_callback(const struct device *dev, uint8_
 	if (USB_EP_DIR_IS_IN(ep_addr)) {
 		evt.type = UDC_AMBIQ_EVT_HAL_IN_CMP;
 	} else {
-		buf = udc_buf_peek(dev, ep_addr);
+		struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, ep_addr);
+
+		buf = udc_buf_peek(ep_cfg);
 		if (buf == NULL) {
 			LOG_ERR("No buffer for ep 0x%02x", ep_addr);
 			udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
@@ -281,12 +285,12 @@ static int udc_ambiq_ep_dequeue(const struct device *dev, struct udc_ep_config *
 
 	lock_key = irq_lock();
 
-	buf = udc_buf_get_all(dev, ep_cfg->addr);
+	buf = udc_buf_get_all(ep_cfg);
 	if (buf) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}
 
-	udc_ep_set_busy(dev, ep_cfg->addr, false);
+	udc_ep_set_busy(ep_cfg, false);
 	am_hal_usb_ep_state_reset(priv->usb_handle, ep_cfg->addr);
 	irq_unlock(lock_key);
 
@@ -320,7 +324,7 @@ static int udc_ambiq_ep_clear_halt(const struct device *dev, struct udc_ep_confi
 	ep_cfg->stat.halted = false;
 
 	/* Resume queued transfer if any */
-	if (udc_buf_peek(dev, ep_cfg->addr)) {
+	if (udc_buf_peek(ep_cfg)) {
 		struct udc_ambiq_event evt = {
 			.ep = ep_cfg->addr,
 			.type = UDC_AMBIQ_EVT_XFER,
@@ -647,14 +651,14 @@ static inline void ambiq_handle_evt_dout(const struct device *dev, struct udc_ep
 	struct net_buf *buf;
 
 	/* retrieve endpoint buffer */
-	buf = udc_buf_get(dev, cfg->addr);
+	buf = udc_buf_get(cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer queued for control ep");
 		return;
 	}
 
 	/* Clear endpoint busy status */
-	udc_ep_set_busy(dev, cfg->addr, false);
+	udc_ep_set_busy(cfg, false);
 
 	/* Handle transfer complete event */
 	if (cfg->addr == USB_CONTROL_EP_OUT) {
@@ -686,9 +690,9 @@ static void ambiq_handle_evt_din(const struct device *dev, struct udc_ep_config 
 	bool udc_ambiq_rx_status_in_completed = false;
 
 	/* Clear endpoint busy status */
-	udc_ep_set_busy(dev, cfg->addr, false);
+	udc_ep_set_busy(cfg, false);
 	/* Check and Handle ZLP flag */
-	buf = udc_buf_peek(dev, cfg->addr);
+	buf = udc_buf_peek(cfg);
 	if (cfg->addr != USB_CONTROL_EP_IN) {
 		if (udc_ep_buf_has_zlp(buf)) {
 			udc_ep_buf_clear_zlp(buf);
@@ -699,7 +703,7 @@ static void ambiq_handle_evt_din(const struct device *dev, struct udc_ep_config 
 	}
 
 	/* retrieve endpoint buffer */
-	buf = udc_buf_get(dev, cfg->addr);
+	buf = udc_buf_get(cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer queued for control ep");
 		return;
@@ -754,7 +758,7 @@ static void udc_event_xfer(const struct device *dev, struct udc_ep_config *const
 {
 	struct net_buf *buf;
 
-	buf = udc_buf_peek(dev, cfg->addr);
+	buf = udc_buf_peek(cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer for ep 0x%02x", cfg->addr);
 		return;

--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -78,22 +78,13 @@ struct udc_ep_config *udc_get_ep_cfg(const struct device *dev, const uint8_t ep)
 	return data->ep_lut[USB_EP_LUT_IDX(ep)];
 }
 
-bool udc_ep_is_busy(const struct device *dev, const uint8_t ep)
+bool udc_ep_is_busy(const struct udc_ep_config *const ep_cfg)
 {
-	struct udc_ep_config *ep_cfg;
-
-	ep_cfg = udc_get_ep_cfg(dev, ep);
-	__ASSERT(ep_cfg != NULL, "ep 0x%02x is not available", ep);
-
 	return ep_cfg->stat.busy;
 }
 
-void udc_ep_set_busy(const struct device *dev, const uint8_t ep, const bool busy)
+void udc_ep_set_busy(struct udc_ep_config *const ep_cfg, const bool busy)
 {
-	struct udc_ep_config *ep_cfg;
-
-	ep_cfg = udc_get_ep_cfg(dev, ep);
-	__ASSERT(ep_cfg != NULL, "ep 0x%02x is not available", ep);
 	ep_cfg->stat.busy = busy;
 }
 
@@ -115,34 +106,21 @@ int udc_register_ep(const struct device *dev, struct udc_ep_config *const cfg)
 	return 0;
 }
 
-struct net_buf *udc_buf_get(const struct device *dev, const uint8_t ep)
+struct net_buf *udc_buf_get(struct udc_ep_config *const ep_cfg)
 {
-	struct udc_ep_config *ep_cfg;
-
-	ep_cfg = udc_get_ep_cfg(dev, ep);
-	if (ep_cfg == NULL) {
-		return NULL;
-	}
-
 	return k_fifo_get(&ep_cfg->fifo, K_NO_WAIT);
 }
 
-struct net_buf *udc_buf_get_all(const struct device *dev, const uint8_t ep)
+struct net_buf *udc_buf_get_all(struct udc_ep_config *const ep_cfg)
 {
-	struct udc_ep_config *ep_cfg;
 	struct net_buf *buf;
-
-	ep_cfg = udc_get_ep_cfg(dev, ep);
-	if (ep_cfg == NULL) {
-		return NULL;
-	}
 
 	buf = k_fifo_get(&ep_cfg->fifo, K_NO_WAIT);
 	if (!buf) {
 		return NULL;
 	}
 
-	LOG_DBG("ep 0x%02x dequeue %p", ep, buf);
+	LOG_DBG("ep 0x%02x dequeue %p", ep_cfg->addr, buf);
 	for (struct net_buf *n = buf; !k_fifo_is_empty(&ep_cfg->fifo); n = n->frags) {
 		n->frags = k_fifo_get(&ep_cfg->fifo, K_NO_WAIT);
 		LOG_DBG("|-> %p ", n->frags);
@@ -154,15 +132,8 @@ struct net_buf *udc_buf_get_all(const struct device *dev, const uint8_t ep)
 	return buf;
 }
 
-struct net_buf *udc_buf_peek(const struct device *dev, const uint8_t ep)
+struct net_buf *udc_buf_peek(struct udc_ep_config *const ep_cfg)
 {
-	struct udc_ep_config *ep_cfg;
-
-	ep_cfg = udc_get_ep_cfg(dev, ep);
-	if (ep_cfg == NULL) {
-		return NULL;
-	}
-
 	return k_fifo_peek_head(&ep_cfg->fifo);
 }
 

--- a/drivers/usb/udc/udc_common.h
+++ b/drivers/usb/udc/udc_common.h
@@ -61,21 +61,19 @@ struct udc_ep_config *udc_get_ep_cfg(const struct device *dev,
 /**
  * @brief Checks if the endpoint is busy
  *
- * @param[in] dev    Pointer to device struct of the driver instance
- * @param[in] ep     Endpoint address
+ * @param[in] ep_cfg Pointer to endpoint configuration
  *
  * @return true if endpoint is busy
  */
-bool udc_ep_is_busy(const struct device *dev, const uint8_t ep);
+bool udc_ep_is_busy(const struct udc_ep_config *const ep_cfg);
 
 /**
  * @brief Helper function to set endpoint busy state
  *
- * @param[in] dev    Pointer to device struct of the driver instance
- * @param[in] ep     Endpoint address
+ * @param[in] ep_cfg Pointer to endpoint configuration
  * @param[in] busy   Busy state
  */
-void udc_ep_set_busy(const struct device *dev, const uint8_t ep,
+void udc_ep_set_busy(struct udc_ep_config *const ep_cfg,
 		     const bool busy);
 
 /**
@@ -85,13 +83,11 @@ void udc_ep_set_busy(const struct device *dev, const uint8_t ep,
  * Use it when transfer is finished and request should
  * be passed to the higher level.
  *
- * @param[in] dev     Pointer to device struct of the driver instance
- * @param[in] ep      Endpoint address
+ * @param[in] ep_cfg Pointer to endpoint configuration
  *
  * @return pointer to UDC request or NULL on error.
  */
-struct net_buf *udc_buf_get(const struct device *dev,
-			    const uint8_t ep);
+struct net_buf *udc_buf_get(struct udc_ep_config *const ep_cfg);
 
 /**
  * @brief Get all UDC request from endpoint FIFO.
@@ -100,13 +96,11 @@ struct net_buf *udc_buf_get(const struct device *dev,
  * This function removes all request from endpoint FIFO and
  * is typically used to dequeue endpoint FIFO.
  *
- * @param[in] dev    Pointer to device struct of the driver instance
- * @param[in] ep     Endpoint address
+ * @param[in] ep_cfg Pointer to endpoint configuration
  *
  * @return pointer to UDC request or NULL on error.
  */
-struct net_buf *udc_buf_get_all(const struct device *dev,
-				const uint8_t ep);
+struct net_buf *udc_buf_get_all(struct udc_ep_config *const ep_cfg);
 
 /**
  * @brief Peek request at the head of endpoint FIFO.
@@ -114,13 +108,11 @@ struct net_buf *udc_buf_get_all(const struct device *dev,
  * Return request from the head of endpoint FIFO without removing.
  * Use it when request buffer is required for a transfer.
  *
- * @param[in] dev     Pointer to device struct of the driver instance
- * @param[in] ep      Endpoint address
+ * @param[in] ep_cfg Pointer to endpoint configuration
  *
  * @return pointer to request or NULL on error.
  */
-struct net_buf *udc_buf_peek(const struct device *dev,
-			     const uint8_t ep);
+struct net_buf *udc_buf_peek(struct udc_ep_config *const ep_cfg);
 
 /**
  * @brief Put request at the tail of endpoint FIFO.

--- a/drivers/usb/udc/udc_dwc2.c
+++ b/drivers/usb/udc/udc_dwc2.c
@@ -1553,6 +1553,7 @@ static void udc_dwc2_ep_disable(const struct device *dev,
 			priv->pending_tx_flush |= BIT(usb_dwc2_get_depctl_txfnum(dxepctl));
 		}
 
+		udc_ep_set_busy(cfg, false);
 		return;
 	}
 

--- a/drivers/usb/udc/udc_nrf.c
+++ b/drivers/usb/udc/udc_nrf.c
@@ -96,13 +96,14 @@ static void udc_nrf_clear_control_out(const struct device *dev)
 
 static void udc_event_xfer_in_next(const struct device *dev, const uint8_t ep)
 {
+	struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, ep);
 	struct net_buf *buf;
 
-	if (udc_ep_is_busy(dev, ep)) {
+	if (udc_ep_is_busy(ep_cfg)) {
 		return;
 	}
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf != NULL) {
 		nrf_usbd_common_transfer_t xfer = {
 			.p_data = {.tx = buf->data},
@@ -118,7 +119,7 @@ static void udc_event_xfer_in_next(const struct device *dev, const uint8_t ep)
 			/* REVISE: remove from endpoint queue? ASSERT? */
 			udc_submit_ep_event(dev, buf, -ECONNREFUSED);
 		} else {
-			udc_ep_set_busy(dev, ep, true);
+			udc_ep_set_busy(ep_cfg, true);
 		}
 	}
 }
@@ -151,9 +152,10 @@ static void udc_event_xfer_ctrl_in(const struct device *dev,
 
 static void udc_event_fake_status_in(const struct device *dev)
 {
+	struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, USB_CONTROL_EP_IN);
 	struct net_buf *buf;
 
-	buf = udc_buf_get(dev, USB_CONTROL_EP_IN);
+	buf = udc_buf_get(ep_cfg);
 	if (unlikely(buf == NULL)) {
 		LOG_DBG("ep 0x%02x queue is empty", USB_CONTROL_EP_IN);
 		return;
@@ -166,19 +168,22 @@ static void udc_event_fake_status_in(const struct device *dev)
 static void udc_event_xfer_in(const struct device *dev,
 			      nrf_usbd_common_evt_t const *const event)
 {
+	struct udc_ep_config *ep_cfg;
 	uint8_t ep = event->data.eptransfer.ep;
 	struct net_buf *buf;
 
+	ep_cfg = udc_get_ep_cfg(dev, ep);
+
 	switch (event->data.eptransfer.status) {
 	case NRF_USBD_COMMON_EP_OK:
-		buf = udc_buf_get(dev, ep);
+		buf = udc_buf_get(ep_cfg);
 		if (buf == NULL) {
 			LOG_ERR("ep 0x%02x queue is empty", ep);
 			__ASSERT_NO_MSG(false);
 			return;
 		}
 
-		udc_ep_set_busy(dev, ep, false);
+		udc_ep_set_busy(ep_cfg, false);
 		if (ep == USB_CONTROL_EP_IN) {
 			udc_event_xfer_ctrl_in(dev, buf);
 			return;
@@ -189,14 +194,14 @@ static void udc_event_xfer_in(const struct device *dev,
 
 	case NRF_USBD_COMMON_EP_ABORTED:
 		LOG_WRN("aborted IN ep 0x%02x", ep);
-		buf = udc_buf_get_all(dev, ep);
+		buf = udc_buf_get_all(ep_cfg);
 
 		if (buf == NULL) {
 			LOG_DBG("ep 0x%02x queue is empty", ep);
 			return;
 		}
 
-		udc_ep_set_busy(dev, ep, false);
+		udc_ep_set_busy(ep_cfg, false);
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 		break;
 
@@ -226,13 +231,14 @@ static void udc_event_xfer_ctrl_out(const struct device *dev,
 
 static void udc_event_xfer_out_next(const struct device *dev, const uint8_t ep)
 {
+	struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, ep);
 	struct net_buf *buf;
 
-	if (udc_ep_is_busy(dev, ep)) {
+	if (udc_ep_is_busy(ep_cfg)) {
 		return;
 	}
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf != NULL) {
 		nrf_usbd_common_transfer_t xfer = {
 			.p_data = {.rx = buf->data},
@@ -247,7 +253,7 @@ static void udc_event_xfer_out_next(const struct device *dev, const uint8_t ep)
 			/* REVISE: remove from endpoint queue? ASSERT? */
 			udc_submit_ep_event(dev, buf, -ECONNREFUSED);
 		} else {
-			udc_ep_set_busy(dev, ep, true);
+			udc_ep_set_busy(ep_cfg, true);
 		}
 	} else {
 		LOG_DBG("ep 0x%02x waiting, queue is empty", ep);
@@ -257,6 +263,7 @@ static void udc_event_xfer_out_next(const struct device *dev, const uint8_t ep)
 static void udc_event_xfer_out(const struct device *dev,
 			       nrf_usbd_common_evt_t const *const event)
 {
+	struct udc_ep_config *ep_cfg;
 	uint8_t ep = event->data.eptransfer.ep;
 	nrf_usbd_common_ep_status_t err_code;
 	struct net_buf *buf;
@@ -276,14 +283,15 @@ static void udc_event_xfer_out(const struct device *dev,
 			LOG_ERR("OUT transfer failed %d", err_code);
 		}
 
-		buf = udc_buf_get(dev, ep);
+		ep_cfg = udc_get_ep_cfg(dev, ep);
+		buf = udc_buf_get(ep_cfg);
 		if (buf == NULL) {
 			LOG_ERR("ep 0x%02x ok, queue is empty", ep);
 			return;
 		}
 
 		net_buf_add(buf, len);
-		udc_ep_set_busy(dev, ep, false);
+		udc_ep_set_busy(ep_cfg, false);
 		if (ep == USB_CONTROL_EP_OUT) {
 			udc_event_xfer_ctrl_out(dev, buf);
 		} else {
@@ -616,7 +624,7 @@ static int udc_nrf_ep_dequeue(const struct device *dev,
 		 * HAL driver does not generate event for an OUT endpoint
 		 * or when IN endpoint is not busy.
 		 */
-		buf = udc_buf_get_all(dev, cfg->addr);
+		buf = udc_buf_get_all(cfg);
 		if (buf) {
 			udc_submit_ep_event(dev, buf, -ECONNABORTED);
 		} else {
@@ -625,7 +633,7 @@ static int udc_nrf_ep_dequeue(const struct device *dev,
 
 	}
 
-	udc_ep_set_busy(dev, cfg->addr, false);
+	udc_ep_set_busy(cfg, false);
 
 	return 0;
 }

--- a/drivers/usb/udc/udc_renesas_ra.c
+++ b/drivers/usb/udc/udc_renesas_ra.c
@@ -97,13 +97,14 @@ static void udc_renesas_ra_interrupt_handler(void *arg)
 static void udc_event_xfer_next(const struct device *dev, const uint8_t ep)
 {
 	struct udc_renesas_ra_data *data = udc_get_private(dev);
+	struct udc_ep_config *ep_cfg = udc_get_ep_cfg(dev, ep);
 	struct net_buf *buf;
 
-	if (udc_ep_is_busy(dev, ep)) {
+	if (udc_ep_is_busy(ep_cfg)) {
 		return;
 	}
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf != NULL) {
 		int err;
 
@@ -117,7 +118,7 @@ static void udc_event_xfer_next(const struct device *dev, const uint8_t ep)
 			LOG_ERR("ep 0x%02x error", ep);
 			udc_submit_ep_event(dev, buf, -ECONNREFUSED);
 		} else {
-			udc_ep_set_busy(dev, ep, true);
+			udc_ep_set_busy(ep_cfg, true);
 		}
 	}
 }
@@ -200,7 +201,7 @@ static void udc_event_status_in(const struct device *dev)
 	struct udc_renesas_ra_data *data = udc_get_private(dev);
 	struct net_buf *buf;
 
-	buf = udc_buf_get(dev, USB_CONTROL_EP_IN);
+	buf = udc_buf_get(udc_get_ep_cfg(dev, USB_CONTROL_EP_IN));
 	if (unlikely(buf == NULL)) {
 		LOG_DBG("ep 0x%02x queue is empty", USB_CONTROL_EP_IN);
 		return;
@@ -234,14 +235,16 @@ static void udc_event_xfer_complete(const struct device *dev, struct udc_renesas
 {
 	struct net_buf *buf;
 	struct udc_renesas_ra_data *data = udc_get_private(dev);
+	struct udc_ep_config *ep_cfg;
 
 	uint8_t ep = evt->hal_evt.xfer_complete.ep_addr;
 	usbd_xfer_result_t result = evt->hal_evt.xfer_complete.result;
 	uint32_t len = evt->hal_evt.xfer_complete.len;
 
-	udc_ep_set_busy(dev, ep, false);
+	ep_cfg = udc_get_ep_cfg(dev, ep);
+	udc_ep_set_busy(ep_cfg, false);
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf == NULL) {
 		return;
 	}
@@ -260,7 +263,7 @@ static void udc_event_xfer_complete(const struct device *dev, struct udc_renesas
 		return;
 	}
 
-	buf = udc_buf_get(dev, ep);
+	buf = udc_buf_get(ep_cfg);
 
 	if (ep == USB_CONTROL_EP_IN) {
 		udc_event_xfer_ctrl_in(dev, buf);
@@ -351,7 +354,7 @@ static int udc_renesas_ra_ep_dequeue(const struct device *dev, struct udc_ep_con
 
 	lock_key = irq_lock();
 
-	buf = udc_buf_get_all(dev, cfg->addr);
+	buf = udc_buf_get_all(cfg);
 	if (buf != NULL) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}
@@ -360,7 +363,7 @@ static int udc_renesas_ra_ep_dequeue(const struct device *dev, struct udc_ep_con
 		return -EIO;
 	}
 
-	udc_ep_set_busy(dev, cfg->addr, false);
+	udc_ep_set_busy(cfg, false);
 
 	irq_unlock(lock_key);
 

--- a/drivers/usb/udc/udc_rpi_pico.c
+++ b/drivers/usb/udc/udc_rpi_pico.c
@@ -278,14 +278,16 @@ static int rpi_pico_ctrl_feed_dout(const struct device *dev, const size_t length
 
 static void drop_control_transfers(const struct device *dev)
 {
+	struct udc_ep_config *cfg_out = udc_get_ep_cfg(dev, USB_CONTROL_EP_OUT);
+	struct udc_ep_config *cfg_in = udc_get_ep_cfg(dev, USB_CONTROL_EP_IN);
 	struct net_buf *buf;
 
-	buf = udc_buf_get_all(dev, USB_CONTROL_EP_OUT);
+	buf = udc_buf_get_all(cfg_out);
 	if (buf != NULL) {
 		net_buf_unref(buf);
 	}
 
-	buf = udc_buf_get_all(dev, USB_CONTROL_EP_IN);
+	buf = udc_buf_get_all(cfg_in);
 	if (buf != NULL) {
 		net_buf_unref(buf);
 	}
@@ -337,14 +339,14 @@ static inline int rpi_pico_handle_evt_dout(const struct device *dev,
 	struct net_buf *buf;
 	int err = 0;
 
-	buf = udc_buf_get(dev, cfg->addr);
+	buf = udc_buf_get(cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer for OUT ep 0x%02x", cfg->addr);
 		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 		return -ENODATA;
 	}
 
-	udc_ep_set_busy(dev, cfg->addr, false);
+	udc_ep_set_busy(cfg, false);
 
 	if (cfg->addr == USB_CONTROL_EP_OUT) {
 		if (udc_ctrl_stage_is_status_out(dev)) {
@@ -373,15 +375,15 @@ static int rpi_pico_handle_evt_din(const struct device *dev,
 	struct net_buf *buf;
 	int err;
 
-	buf = udc_buf_peek(dev, cfg->addr);
+	buf = udc_buf_peek(cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer for ep 0x%02x", cfg->addr);
 		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
 		return -ENOBUFS;
 	}
 
-	buf = udc_buf_get(dev, cfg->addr);
-	udc_ep_set_busy(dev, cfg->addr, false);
+	buf = udc_buf_get(cfg);
+	udc_ep_set_busy(cfg, false);
 
 	if (cfg->addr == USB_CONTROL_EP_IN) {
 		if (udc_ctrl_stage_is_status_in(dev) ||
@@ -415,7 +417,7 @@ static void rpi_pico_handle_xfer_next(const struct device *dev,
 	struct net_buf *buf;
 	int err;
 
-	buf = udc_buf_peek(dev, cfg->addr);
+	buf = udc_buf_peek(cfg);
 	if (buf == NULL) {
 		return;
 	}
@@ -429,7 +431,7 @@ static void rpi_pico_handle_xfer_next(const struct device *dev,
 	if (err != 0) {
 		udc_submit_ep_event(dev, buf, -ECONNREFUSED);
 	} else {
-		udc_ep_set_busy(dev, cfg->addr, true);
+		udc_ep_set_busy(cfg, true);
 	}
 }
 
@@ -460,7 +462,7 @@ static ALWAYS_INLINE void rpi_pico_thread_handler(void *const arg)
 		break;
 	}
 
-	if (ep_cfg->addr != USB_CONTROL_EP_OUT && !udc_ep_is_busy(dev, ep_cfg->addr)) {
+	if (ep_cfg->addr != USB_CONTROL_EP_OUT && !udc_ep_is_busy(ep_cfg)) {
 		rpi_pico_handle_xfer_next(dev, ep_cfg);
 	}
 }
@@ -503,7 +505,7 @@ static void rpi_pico_handle_buff_status_in(const struct device *dev, const uint8
 	struct net_buf *buf;
 	size_t len;
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer for ep 0x%02x", ep);
 		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
@@ -538,7 +540,7 @@ static void rpi_pico_handle_buff_status_out(const struct device *dev, const uint
 	struct net_buf *buf;
 	size_t len;
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf == NULL) {
 		LOG_ERR("No buffer for ep 0x%02x", ep);
 		udc_submit_event(dev, UDC_EVT_ERROR, -ENOBUFS);
@@ -739,7 +741,7 @@ static int udc_rpi_pico_ep_dequeue(const struct device *dev,
 	lock_key = irq_lock();
 
 	rpi_pico_ep_cancel(dev, cfg->addr);
-	buf = udc_buf_get_all(dev, cfg->addr);
+	buf = udc_buf_get_all(cfg);
 	if (buf) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}
@@ -856,7 +858,7 @@ static int udc_rpi_pico_ep_clear_halt(const struct device *dev,
 		arch_nop();
 		rpi_pico_bit_clr(buf_ctrl_reg, USB_BUF_CTRL_STALL);
 
-		if (udc_buf_peek(dev, cfg->addr)) {
+		if (udc_buf_peek(cfg)) {
 			k_msgq_put(&drv_msgq, &evt, K_NO_WAIT);
 		}
 	}

--- a/drivers/usb/udc/udc_skeleton.c
+++ b/drivers/usb/udc/udc_skeleton.c
@@ -119,7 +119,7 @@ static int udc_skeleton_ep_dequeue(const struct device *dev,
 
 	lock_key = irq_lock();
 
-	buf = udc_buf_get_all(dev, cfg->addr);
+	buf = udc_buf_get_all(cfg);
 	if (buf) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}

--- a/drivers/usb/udc/udc_stm32.c
+++ b/drivers/usb/udc/udc_stm32.c
@@ -194,7 +194,7 @@ void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
 	udc_submit_event(priv->dev, UDC_EVT_SOF, 0);
 }
 
-static int udc_stm32_tx(const struct device *dev, uint8_t ep,
+static int udc_stm32_tx(const struct device *dev, struct udc_ep_config *epcfg,
 			struct net_buf *buf)
 {
 	struct udc_stm32_data *priv = udc_get_private(dev);
@@ -202,31 +202,31 @@ static int udc_stm32_tx(const struct device *dev, uint8_t ep,
 	uint8_t *data; uint32_t len;
 	HAL_StatusTypeDef status;
 
-	LOG_DBG("TX ep 0x%02x len %u", ep, buf->len);
+	LOG_DBG("TX ep 0x%02x len %u", epcfg->addr, buf->len);
 
-	if (udc_ep_is_busy(dev, ep)) {
+	if (udc_ep_is_busy(epcfg)) {
 		return 0;
 	}
 
 	data = buf->data;
 	len = buf->len;
 
-	if (ep == USB_CONTROL_EP_IN) {
+	if (epcfg->addr == USB_CONTROL_EP_IN) {
 		len = MIN(cfg->ep0_mps, buf->len);
 	}
 
 	buf->data += len;
 	buf->len -= len;
 
-	status = HAL_PCD_EP_Transmit(&priv->pcd, ep, data, len);
+	status = HAL_PCD_EP_Transmit(&priv->pcd, epcfg->addr, data, len);
 	if (status != HAL_OK) {
-		LOG_ERR("HAL_PCD_EP_Transmit failed(0x%02x), %d", ep, (int)status);
+		LOG_ERR("HAL_PCD_EP_Transmit failed(0x%02x), %d", epcfg->addr, (int)status);
 		return -EIO;
 	}
 
-	udc_ep_set_busy(dev, ep, true);
+	udc_ep_set_busy(epcfg, true);
 
-	if (ep == USB_CONTROL_EP_IN && len > 0) {
+	if (epcfg->addr == USB_CONTROL_EP_IN && len > 0) {
 		/* Wait for an empty package from the host.
 		 * This also flushes the TX FIFO to the host.
 		 */
@@ -236,25 +236,25 @@ static int udc_stm32_tx(const struct device *dev, uint8_t ep,
 	return 0;
 }
 
-static int udc_stm32_rx(const struct device *dev, uint8_t ep,
+static int udc_stm32_rx(const struct device *dev, struct udc_ep_config *epcfg,
 			struct net_buf *buf)
 {
 	struct udc_stm32_data *priv = udc_get_private(dev);
 	HAL_StatusTypeDef status;
 
-	LOG_DBG("RX ep 0x%02x len %u", ep, buf->size);
+	LOG_DBG("RX ep 0x%02x len %u", epcfg->addr, buf->size);
 
-	if (udc_ep_is_busy(dev, ep)) {
+	if (udc_ep_is_busy(epcfg)) {
 		return 0;
 	}
 
-	status = HAL_PCD_EP_Receive(&priv->pcd, ep, buf->data, buf->size);
+	status = HAL_PCD_EP_Receive(&priv->pcd, epcfg->addr, buf->data, buf->size);
 	if (status != HAL_OK) {
-		LOG_ERR("HAL_PCD_EP_Receive failed(0x%02x), %d", ep, (int)status);
+		LOG_ERR("HAL_PCD_EP_Receive failed(0x%02x), %d", epcfg->addr, (int)status);
 		return -EIO;
 	}
 
-	udc_ep_set_busy(dev, ep, true);
+	udc_ep_set_busy(epcfg, true);
 
 	return 0;
 }
@@ -264,14 +264,16 @@ void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
 	uint32_t rx_count = HAL_PCD_EP_GetRxCount(hpcd, epnum);
 	struct udc_stm32_data *priv = hpcd2data(hpcd);
 	const struct device *dev = priv->dev;
+	struct udc_ep_config *epcfg;
 	uint8_t ep = epnum | USB_EP_DIR_OUT;
 	struct net_buf *buf;
 
 	LOG_DBG("DataOut ep 0x%02x",  ep);
 
-	udc_ep_set_busy(dev, ep, false);
+	epcfg = udc_get_ep_cfg(dev, ep);
+	udc_ep_set_busy(epcfg, false);
 
-	buf = udc_buf_get(dev, ep);
+	buf = udc_buf_get(epcfg);
 	if (unlikely(buf == NULL)) {
 		LOG_ERR("ep 0x%02x queue is empty", ep);
 		return;
@@ -294,9 +296,9 @@ void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
 		udc_submit_ep_event(dev, buf, 0);
 	}
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(epcfg);
 	if (buf) {
-		udc_stm32_rx(dev, ep, buf);
+		udc_stm32_rx(dev, epcfg, buf);
 	}
 }
 
@@ -304,14 +306,16 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
 {
 	struct udc_stm32_data *priv = hpcd2data(hpcd);
 	const struct device *dev = priv->dev;
+	struct udc_ep_config *epcfg;
 	uint8_t ep = epnum | USB_EP_DIR_IN;
 	struct net_buf *buf;
 
 	LOG_DBG("DataIn ep 0x%02x",  ep);
 
-	udc_ep_set_busy(dev, ep, false);
+	epcfg = udc_get_ep_cfg(dev, ep);
+	udc_ep_set_busy(epcfg, false);
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(epcfg);
 	if (unlikely(buf == NULL)) {
 		return;
 	}
@@ -335,7 +339,7 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
 		return;
 	}
 
-	udc_buf_get(dev, ep);
+	udc_buf_get(epcfg);
 
 	if (ep == USB_CONTROL_EP_IN) {
 		if (udc_ctrl_stage_is_status_in(dev) ||
@@ -360,9 +364,9 @@ void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef *hpcd, uint8_t epnum)
 
 	udc_submit_ep_event(dev, buf, 0);
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(epcfg);
 	if (buf) {
-		udc_stm32_tx(dev, ep, buf);
+		udc_stm32_tx(dev, epcfg, buf);
 	}
 }
 
@@ -763,9 +767,9 @@ static int udc_stm32_ep_enqueue(const struct device *dev,
 	lock_key = irq_lock();
 
 	if (USB_EP_DIR_IS_IN(epcfg->addr)) {
-		ret = udc_stm32_tx(dev, epcfg->addr, buf);
+		ret = udc_stm32_tx(dev, epcfg, buf);
 	} else {
-		ret = udc_stm32_rx(dev, epcfg->addr, buf);
+		ret = udc_stm32_rx(dev, epcfg, buf);
 	}
 
 	irq_unlock(lock_key);
@@ -780,12 +784,12 @@ static int udc_stm32_ep_dequeue(const struct device *dev,
 
 	udc_stm32_ep_flush(dev, epcfg);
 
-	buf = udc_buf_get_all(dev, epcfg->addr);
+	buf = udc_buf_get_all(epcfg);
 	if (buf) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}
 
-	udc_ep_set_busy(dev, epcfg->addr, false);
+	udc_ep_set_busy(epcfg, false);
 
 	return 0;
 }

--- a/drivers/usb/udc/udc_virtual.c
+++ b/drivers/usb/udc/udc_virtual.c
@@ -172,7 +172,7 @@ static int vrt_handle_out(const struct device *dev,
 		return vrt_request_reply(dev, pkt, UVB_REPLY_STALL);
 	}
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf == NULL) {
 		LOG_DBG("reply NACK ep 0x%02x", ep);
 		return vrt_request_reply(dev, pkt, UVB_REPLY_NACK);
@@ -184,7 +184,7 @@ static int vrt_handle_out(const struct device *dev,
 	LOG_DBG("Handle data OUT, %zu | %zu", pkt->length, net_buf_tailroom(buf));
 
 	if (net_buf_tailroom(buf) == 0 || pkt->length < udc_mps_ep_size(ep_cfg)) {
-		buf = udc_buf_get(dev, ep);
+		buf = udc_buf_get(ep_cfg);
 
 		if (ep == USB_CONTROL_EP_OUT) {
 			err = vrt_handle_ctrl_out(dev, buf);
@@ -239,7 +239,7 @@ static int vrt_handle_in(const struct device *dev,
 		return vrt_request_reply(dev, pkt, UVB_REPLY_STALL);
 	}
 
-	buf = udc_buf_peek(dev, ep);
+	buf = udc_buf_peek(ep_cfg);
 	if (buf == NULL) {
 		LOG_DBG("reply NACK ep 0x%02x", ep);
 		return vrt_request_reply(dev, pkt, UVB_REPLY_NACK);
@@ -259,7 +259,7 @@ static int vrt_handle_in(const struct device *dev,
 		}
 
 		LOG_DBG("Finish data IN %zu | %u", pkt->length, buf->len);
-		buf = udc_buf_get(dev, ep);
+		buf = udc_buf_get(ep_cfg);
 
 		if (ep == USB_CONTROL_EP_IN) {
 			err = isr_handle_ctrl_in(dev, buf);
@@ -411,7 +411,7 @@ static int udc_vrt_ep_dequeue(const struct device *dev,
 
 	lock_key = irq_lock();
 	/* Draft dequeue implementation */
-	buf = udc_buf_get_all(dev, cfg->addr);
+	buf = udc_buf_get_all(cfg);
 	if (buf) {
 		udc_submit_ep_event(dev, buf, -ECONNABORTED);
 	}


### PR DESCRIPTION
Backport 7a28ef1dc00aeeae17034631b79cdc0d52a13c6b~2..7a28ef1dc00aeeae17034631b79cdc0d52a13c6b from #2717.