### PR TITLE
[nrf fromlist] boards: 54h20: Support IPC between SEC and APP

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_iron.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_iron.dts
@@ -8,7 +8,6 @@
 
 /delete-node/&cpurad_rx_partitions;
 /delete-node/&cpuapp_rx_partitions;
-/delete-node/&cpusec_cpuapp_ipc;
 
 /* This is not yet an exhaustive memory map, and contain only a minimum required to boot
  * the application core.


### PR DESCRIPTION
Support IPC between SEC and APP. This is needed for PSA Crypto support.

This patch is expected to be removed within a couple of weeks by the ongoing work in NCSDK-32158.

Upstream PR #: 88285

Ref: NCSDK-NONE