### PR TITLE
[nrf noup] mgmt: mcumgr: Fix nRF5340 network core hook

### DIFF
--- a/subsys/mgmt/mcumgr/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/CMakeLists.txt
@@ -17,10 +17,11 @@ add_subdirectory_ifdef(CONFIG_SMP_CLIENT    smp_client)
 
 zephyr_library_link_libraries(mgmt_mcumgr)
 
-if (CONFIG_BOOT_IMAGE_ACCESS_HOOKS)
-    zephyr_include_directories(
-        ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/bootutil/include
-        ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr/include
-    )
-    zephyr_library_sources(bootutil_hooks/nrf53_hooks.c)
+if(CONFIG_MCUMGR_GRP_IMG_NRF5340_BOOTUTIL_HOOK)
+  zephyr_include_directories(
+    ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/bootutil/include
+    ${ZEPHYR_MCUBOOT_MODULE_DIR}/boot/zephyr/include
+  )
+
+  zephyr_library_sources(bootutil_hooks/nrf53_hooks.c)
 endif()

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -6,7 +6,7 @@ menuconfig MCUMGR
 	bool "mcumgr Support"
 	depends on NET_BUF
 	depends on ZCBOR
-	imply BOOT_IMAGE_ACCESS_HOOKS if (SOC_NRF5340_CPUAPP_QKAA && MCUMGR_GRP_IMG)
+	imply BOOT_IMAGE_ACCESS_HOOKS if SOC_NRF5340_CPUAPP && MCUMGR_GRP_IMG && MCUBOOT_NETWORK_CORE_IMAGE_NUMBER > -1
 	help
 	  This option enables the mcumgr management library.
 

--- a/subsys/mgmt/mcumgr/bootutil_hooks/nrf53_hooks.c
+++ b/subsys/mgmt/mcumgr/bootutil_hooks/nrf53_hooks.c
@@ -8,19 +8,10 @@
 #include <zephyr/device.h>
 #include "bootutil/bootutil_public.h"
 
-#if CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER != -1
-/* Sysbuild */
-#define NET_CORE_IMAGE CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER
-#else
-/* Legacy child/parent */
-#define NET_CORE_IMAGE 1
-#endif
-
-int boot_read_swap_state_primary_slot_hook(int image_index,
-		struct boot_swap_state *state)
+int boot_read_swap_state_primary_slot_hook(int image_index, struct boot_swap_state *state)
 {
-	if (image_index == NET_CORE_IMAGE) {
-		/* Pretend that primary slot of image 1 unpopulated */
+	if (image_index == CONFIG_MCUBOOT_NETWORK_CORE_IMAGE_NUMBER) {
+		/* Pretend that primary slot of the network core update image is unpopulated */
 		state->magic = BOOT_MAGIC_UNSET;
 		state->swap_type = BOOT_SWAP_TYPE_NONE;
 		state->image_num = image_index;

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -224,6 +224,14 @@ config MCUMGR_GRP_IMG_QSPI_XIP_SPLIT_IMAGE
 	  sysbuild if needed. This enables selecting the correct slot when running a QSPI XIP
 	  split image application in DirectXIP mode.
 
+config MCUMGR_GRP_IMG_NRF5340_BOOTUTIL_HOOK
+	bool "nRF5340 network core bootutil hook"
+	depends on SOC_NRF5340_CPUAPP && BOOT_IMAGE_ACCESS_HOOKS && MCUBOOT_NETWORK_CORE_IMAGE_NUMBER > -1
+	default y
+	help
+	  This option will enable a bootutil hook that populates the network core update image
+	  slot with dummy data to allow for uploading a firmware update to the network core.
+
 module = MCUMGR_GRP_IMG
 module-str = mcumgr_grp_img
 source "subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
Fixes an issue whereby just enabling hooks would enable the nrf5340 network core hook despite lacking other requirements