### PR TITLE
[nrf fromlist] drivers: nrf_wifi: Fix SR co-ex RF switch configuration

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -175,7 +175,7 @@ config NRF70_SR_COEX
 
 config NRF70_SR_COEX_RF_SWITCH
 	bool "GPIO configuration to control SR side RF switch position"
-	depends on $(dt_node_has_prop,nrf70, srrf-switch-gpios)
+	depends on $(dt_nodelabel_has_prop,nrf70,srrf-switch-gpios)
 	depends on NRF70_SR_COEX
 	help
 	  Select this option to enable GPIO configuration to control SR side RF switch position.


### PR DESCRIPTION
This was not getting enabled because label was passed instead of path and dependency was not met.

Fix the DT function to use label.

Upstream PR #: 88306