### PR TITLE
[nrf fromlist] zperf: moving declaration of variable to top of function

### DIFF
--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -842,6 +842,7 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 	int start = 0;
 	size_t opt_cnt = 0;
 	int ret;
+	int seconds;
 
 	param.options.priority = -1;
 	is_udp = proto == IPPROTO_UDP;
@@ -909,7 +910,7 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 			break;
 
 		case 'i':
-			int seconds = parse_arg(&i, argc, argv);
+			seconds = parse_arg(&i, argc, argv);
 
 			if (is_udp) {
 				shell_fprintf(sh, SHELL_WARNING,
@@ -1076,6 +1077,7 @@ static int shell_cmd_upload2(const struct shell *sh, size_t argc,
 	bool async = false;
 	int start = 0;
 	size_t opt_cnt = 0;
+	int seconds;
 
 	is_udp = proto == IPPROTO_UDP;
 
@@ -1142,7 +1144,7 @@ static int shell_cmd_upload2(const struct shell *sh, size_t argc,
 			break;
 
 		case 'i':
-			int seconds = parse_arg(&i, argc, argv);
+			seconds = parse_arg(&i, argc, argv);
 
 			if (is_udp) {
 				shell_fprintf(sh, SHELL_WARNING,


### PR DESCRIPTION
Declaration of variables after a label inside a switch statement is a c23 extension, not c99.

This results in the following warning when compiling with clang:
> .../subsys/net/lib/zperf/zperf_shell.c:912:4: warning: label followed
>                by a declaration is a C23 extension [-Wc23-extensions]
>   912 |                      int seconds = parse_arg(&i, argc, argv);
>       |                         ^
> .../subsys/net/lib/zperf/zperf_shell.c:1145:4: warning: label followed
>                by a declaration is a C23 extension [-Wc23-extensions]
>  1145 |                      int seconds = parse_arg(&i, argc, argv);
>       |                         ^
> 2 warnings generated.

There are no practical reasons why the variable should be declared inside the switch statement, therefore move the declaration and place it together with declaration of other variables.

Upstream PR #: 88403