### PR TITLE
[Backport v4.0.99-ncs1-branch] [nrf fromlist] zperf: moving declaration of variable to top of function

### DIFF
--- a/subsys/net/lib/zperf/zperf_shell.c
+++ b/subsys/net/lib/zperf/zperf_shell.c
@@ -842,6 +842,7 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 	int start = 0;
 	size_t opt_cnt = 0;
 	int ret;
+	int seconds;
 
 	param.options.priority = -1;
 	is_udp = proto == IPPROTO_UDP;
@@ -909,7 +910,7 @@ static int shell_cmd_upload(const struct shell *sh, size_t argc,
 			break;
 
 		case 'i':
-			int seconds = parse_arg(&i, argc, argv);
+			seconds = parse_arg(&i, argc, argv);
 
 			if (is_udp) {
 				shell_fprintf(sh, SHELL_WARNING,
@@ -1076,6 +1077,7 @@ static int shell_cmd_upload2(const struct shell *sh, size_t argc,
 	bool async = false;
 	int start = 0;
 	size_t opt_cnt = 0;
+	int seconds;
 
 	is_udp = proto == IPPROTO_UDP;
 
@@ -1142,7 +1144,7 @@ static int shell_cmd_upload2(const struct shell *sh, size_t argc,
 			break;
 
 		case 'i':
-			int seconds = parse_arg(&i, argc, argv);
+			seconds = parse_arg(&i, argc, argv);
 
 			if (is_udp) {
 				shell_fprintf(sh, SHELL_WARNING,


### PR DESCRIPTION
Backport 25e27e349f6f3873e9b0d48573eccbf73dbab2fb from #2741.