### PR TITLE
[Backport v4.0.99-ncs1-branch] [nrf fromlist] drivers: nrf_wifi: Fix SR co-ex RF switch configuration

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -175,7 +175,7 @@ config NRF70_SR_COEX
 
 config NRF70_SR_COEX_RF_SWITCH
 	bool "GPIO configuration to control SR side RF switch position"
-	depends on $(dt_node_has_prop,nrf70, srrf-switch-gpios)
+	depends on $(dt_nodelabel_has_prop,nrf70,srrf-switch-gpios)
 	depends on NRF70_SR_COEX
 	help
 	  Select this option to enable GPIO configuration to control SR side RF switch position.


### PR DESCRIPTION
Backport b4d256022e3be724062cc5f55fbfde259875395a from #2732.