### PR TITLE
[Backport v4.0.99-ncs1-branch] drivers: flash: Optimize mspi_nor driver memory

### DIFF
--- a/drivers/flash/flash_mspi_nor.h
+++ b/drivers/flash/flash_mspi_nor.h
@@ -39,7 +39,7 @@ struct flash_mspi_nor_config {
 	struct flash_pages_layout layout;
 #endif
 	uint8_t jedec_id[SPI_NOR_MAX_ID_LEN];
-	struct flash_mspi_nor_cmds *jedec_cmds;
+	const struct flash_mspi_nor_cmds *jedec_cmds;
 	struct flash_mspi_nor_quirks *quirks;
 	uint8_t dw15_qer;
 };
@@ -73,169 +73,169 @@ struct flash_mspi_nor_cmds {
 	struct flash_mspi_nor_cmd sfdp;
 };
 
-struct flash_mspi_nor_cmds commands[] = {
-	[MSPI_IO_MODE_SINGLE] = {
-		.id = {
-			.dir = MSPI_RX,
-			.cmd = JESD216_CMD_READ_ID,
-			.cmd_length = 1,
-		},
-		.write_en = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_WREN,
-			.cmd_length = 1,
-		},
-		.read = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_CMD_READ_FAST,
-			.cmd_length = 1,
-			.addr_length = 3,
-			.rx_dummy = 8,
-		},
-		.status = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_CMD_RDSR,
-			.cmd_length = 1,
-		},
-		.config = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_CMD_RDCR,
-			.cmd_length = 1,
-		},
-		.page_program = {
-			.dir  = MSPI_TX,
-			.cmd = SPI_NOR_CMD_PP,
-			.cmd_length = 1,
-			.addr_length = 3,
-		},
-		.sector_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_SE,
-			.cmd_length = 1,
-			.addr_length = 3,
-		},
-		.chip_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_CE,
-			.cmd_length = 1,
-		},
-		.sfdp = {
-			.dir = MSPI_RX,
-			.cmd = JESD216_CMD_READ_SFDP,
-			.cmd_length = 1,
-			.addr_length = 3,
-			.rx_dummy = 8,
-		},
+const struct flash_mspi_nor_cmds commands_single = {
+	.id = {
+		.dir = MSPI_RX,
+		.cmd = JESD216_CMD_READ_ID,
+		.cmd_length = 1,
 	},
-	[MSPI_IO_MODE_QUAD_1_4_4] = {
-		.id = {
-			.dir = MSPI_RX,
-			.cmd = JESD216_CMD_READ_ID,
-			.cmd_length = 1,
-			.force_single = true,
-		},
-		.write_en = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_WREN,
-			.cmd_length = 1,
-		},
-		.read = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_CMD_4READ,
-			.cmd_length = 1,
-			.addr_length = 3,
-			.rx_dummy = 6,
-		},
-		.status = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_CMD_RDSR,
-			.cmd_length = 1,
-			.force_single = true,
-		},
-		.config = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_CMD_RDCR,
-			.cmd_length = 1,
-			.force_single = true,
-		},
-		.page_program = {
-			.dir  = MSPI_TX,
-			.cmd = SPI_NOR_CMD_PP_1_4_4,
-			.cmd_length = 1,
-			.addr_length = 3,
-		},
-		.sector_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_SE,
-			.cmd_length = 1,
-			.addr_length = 3,
-			.force_single = true,
-		},
-		.chip_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_CMD_CE,
-			.cmd_length = 1,
-		},
-		.sfdp = {
-			.dir = MSPI_RX,
-			.cmd = JESD216_CMD_READ_SFDP,
-			.cmd_length = 1,
-			.addr_length = 3,
-			.rx_dummy = 8,
-			.force_single = true,
-		},
+	.write_en = {
+		.dir = MSPI_TX,
+		.cmd = SPI_NOR_CMD_WREN,
+		.cmd_length = 1,
 	},
-	[MSPI_IO_MODE_OCTAL] = {
-		.id = {
-			.dir = MSPI_RX,
-			.cmd = JESD216_OCMD_READ_ID,
-			.cmd_length = 2,
-			.addr_length = 4,
-			.rx_dummy = 4
-		},
-		.write_en = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_OCMD_WREN,
-			.cmd_length = 2,
-		},
-		.read = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_OCMD_RD,
-			.cmd_length = 2,
-			.addr_length = 4,
-			.rx_dummy = 20,
-		},
-		.status = {
-			.dir = MSPI_RX,
-			.cmd = SPI_NOR_OCMD_RDSR,
-			.cmd_length = 2,
-			.addr_length = 4,
-			.rx_dummy = 4,
-		},
-		.page_program = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_OCMD_PAGE_PRG,
-			.cmd_length = 2,
-			.addr_length = 4,
-		},
-		.sector_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_OCMD_SE,
-			.cmd_length = 2,
-			.addr_length = 4,
-		},
-		.chip_erase = {
-			.dir = MSPI_TX,
-			.cmd = SPI_NOR_OCMD_CE,
-			.cmd_length = 2,
-		},
-		.sfdp = {
-			.dir = MSPI_RX,
-			.cmd = JESD216_OCMD_READ_SFDP,
-			.cmd_length = 2,
-			.addr_length = 4,
-			.rx_dummy = 20,
-		},
+	.read = {
+		.dir = MSPI_RX,
+		.cmd = SPI_NOR_CMD_READ_FAST,
+		.cmd_length = 1,
+		.addr_length = 3,
+		.rx_dummy = 8,
+	},
+	.status = {
+		.dir = MSPI_RX,
+		.cmd = SPI_NOR_CMD_RDSR,
+		.cmd_length = 1,
+	},
+	.config = {
+		.dir = MSPI_RX,
+		.cmd = SPI_NOR_CMD_RDCR,
+		.cmd_length = 1,
+	},
+	.page_program = {
+		.dir  = MSPI_TX,
+		.cmd = SPI_NOR_CMD_PP,
+		.cmd_length = 1,
+		.addr_length = 3,
+	},
+	.sector_erase = {
+		.dir = MSPI_TX,
+		.cmd = SPI_NOR_CMD_SE,
+		.cmd_length = 1,
+		.addr_length = 3,
+	},
+	.chip_erase = {
+		.dir = MSPI_TX,
+		.cmd = SPI_NOR_CMD_CE,
+		.cmd_length = 1,
+	},
+	.sfdp = {
+		.dir = MSPI_RX,
+		.cmd = JESD216_CMD_READ_SFDP,
+		.cmd_length = 1,
+		.addr_length = 3,
+		.rx_dummy = 8,
+	},
+};
+
+const struct flash_mspi_nor_cmds commands_quad_1_4_4 = {
+	.id = {
+		.dir = MSPI_RX,
+		.cmd = JESD216_CMD_READ_ID,
+		.cmd_length = 1,
+		.force_single = true,
+	},
+	.write_en = {
+		.dir = MSPI_TX,
+		.cmd = SPI_NOR_CMD_WREN,
+		.cmd_length = 1,
+	},
+	.read = {
+		.dir = MSPI_RX,
+		.cmd = SPI_NOR_CMD_4READ,
+		.cmd_length = 1,
+		.addr_length = 3,
+		.rx_dummy = 6,
+	},
+	.status = {
+		.dir = MSPI_RX,
+		.cmd = SPI_NOR_CMD_RDSR,
+		.cmd_length = 1,
+		.force_single = true,
+	},
+	.config = {
+		.dir = MSPI_RX,
+		.cmd = SPI_NOR_CMD_RDCR,
+		.cmd_length = 1,
+		.force_single = true,
+	},
+	.page_program = {
+		.dir  = MSPI_TX,
+		.cmd = SPI_NOR_CMD_PP_1_4_4,
+		.cmd_length = 1,
+		.addr_length = 3,
+	},
+	.sector_erase = {
+		.dir = MSPI_TX,
+		.cmd = SPI_NOR_CMD_SE,
+		.cmd_length = 1,
+		.addr_length = 3,
+		.force_single = true,
+	},
+	.chip_erase = {
+		.dir = MSPI_TX,
+		.cmd = SPI_NOR_CMD_CE,
+		.cmd_length = 1,
+	},
+	.sfdp = {
+		.dir = MSPI_RX,
+		.cmd = JESD216_CMD_READ_SFDP,
+		.cmd_length = 1,
+		.addr_length = 3,
+		.rx_dummy = 8,
+		.force_single = true,
+	},
+};
+
+const struct flash_mspi_nor_cmds commands_octal = {
+	.id = {
+		.dir = MSPI_RX,
+		.cmd = JESD216_OCMD_READ_ID,
+		.cmd_length = 2,
+		.addr_length = 4,
+		.rx_dummy = 4
+	},
+	.write_en = {
+		.dir = MSPI_TX,
+		.cmd = SPI_NOR_OCMD_WREN,
+		.cmd_length = 2,
+	},
+	.read = {
+		.dir = MSPI_RX,
+		.cmd = SPI_NOR_OCMD_RD,
+		.cmd_length = 2,
+		.addr_length = 4,
+		.rx_dummy = 20,
+	},
+	.status = {
+		.dir = MSPI_RX,
+		.cmd = SPI_NOR_OCMD_RDSR,
+		.cmd_length = 2,
+		.addr_length = 4,
+		.rx_dummy = 4,
+	},
+	.page_program = {
+		.dir = MSPI_TX,
+		.cmd = SPI_NOR_OCMD_PAGE_PRG,
+		.cmd_length = 2,
+		.addr_length = 4,
+	},
+	.sector_erase = {
+		.dir = MSPI_TX,
+		.cmd = SPI_NOR_OCMD_SE,
+		.cmd_length = 2,
+		.addr_length = 4,
+	},
+	.chip_erase = {
+		.dir = MSPI_TX,
+		.cmd = SPI_NOR_OCMD_CE,
+		.cmd_length = 2,
+	},
+	.sfdp = {
+		.dir = MSPI_RX,
+		.cmd = JESD216_OCMD_READ_SFDP,
+		.cmd_length = 2,
+		.addr_length = 4,
+		.rx_dummy = 20,
 	},
 };
 

--- a/drivers/flash/flash_mspi_nor_quirks.h
+++ b/drivers/flash/flash_mspi_nor_quirks.h
@@ -75,7 +75,7 @@ static inline int mxicy_mx25r_post_switch_mode(const struct device *dev)
 	} while (status & SPI_NOR_WIP_BIT);
 
 	/* Write enable */
-	flash_mspi_command_set(dev, &commands[MSPI_IO_MODE_SINGLE].write_en);
+	flash_mspi_command_set(dev, &commands_single.write_en);
 	rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
 			     &dev_data->xfer);
 	if (rc < 0) {
@@ -154,7 +154,7 @@ static inline int mxicy_mx25u_post_switch_mode(const struct device *dev)
 	}
 
 	/* Write enable */
-	flash_mspi_command_set(dev, &commands[MSPI_IO_MODE_SINGLE].write_en);
+	flash_mspi_command_set(dev, &commands_single.write_en);
 	rc = mspi_transceive(dev_config->bus, &dev_config->mspi_id,
 			     &dev_data->xfer);
 	if (rc < 0) {


### PR DESCRIPTION
Backport c9a539dac2900d053e57d80c6f381f1b6e46dbd6 from #2745.