### PR TITLE
[Backport v4.0.99-ncs1-branch] Nrfx 7252 rename to hpf

### DIFF
--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -112,8 +112,8 @@ static const nrf_gpio_pin_drive_t drive_modes[NRF_DRIVE_COUNT] = {
 #define NRF_PSEL_TDM(reg, line) ((NRF_TDM_Type *)reg)->PSEL.line
 #endif
 
-#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrfe_mspi_controller) || \
-	defined(CONFIG_MSPI_NRFE) || \
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || \
+	defined(CONFIG_MSPI_HPF) || \
 	DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0)
 #if defined(CONFIG_SOC_SERIES_NRF54LX)
 #define NRF_PSEL_SDP_MSPI(psel) \
@@ -122,7 +122,7 @@ static const nrf_gpio_pin_drive_t drive_modes[NRF_DRIVE_COUNT] = {
 /* On nRF54H, pin routing is controlled by secure domain, via UICR. */
 #define NRF_PSEL_SDP_MSPI(psel)
 #endif
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_nrfe_mspi_controller) || ... */
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || ... */
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			   uintptr_t reg)

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -172,34 +172,62 @@
 #define NRF_FUN_GRTC_CLKOUT_FAST 55U
 /** GRTC slow clock output */
 #define NRF_FUN_GRTC_CLKOUT_32K  56U
-/** SDP_MSPI CK */
+/** SDP_MSPI clock pin */
 #define NRF_FUN_SDP_MSPI_SCK 57U
-/** SDP_MSPI DQ0 */
+/** SDP_MSPI data pin 0 */
 #define NRF_FUN_SDP_MSPI_DQ0 58U
-/** SDP_MSPI DQ1 */
+/** SDP_MSPI data pin 1 */
 #define NRF_FUN_SDP_MSPI_DQ1 59U
-/** SDP_MSPI DQ2 */
+/** SDP_MSPI data pin 2 */
 #define NRF_FUN_SDP_MSPI_DQ2 60U
-/** SDP_MSPI DQ3 */
+/** SDP_MSPI data pin 3 */
 #define NRF_FUN_SDP_MSPI_DQ3 61U
-/** SDP_MSPI DQ4 */
+/** SDP_MSPI data pin 4 */
 #define NRF_FUN_SDP_MSPI_DQ4 62U
-/** SDP_MSPI DQ5 */
+/** SDP_MSPI data pin 5 */
 #define NRF_FUN_SDP_MSPI_DQ5 63U
-/** SDP_MSPI DQ6 */
+/** SDP_MSPI data pin 6 */
 #define NRF_FUN_SDP_MSPI_DQ6 64U
-/** SDP_MSPI DQ7 */
+/** SDP_MSPI data pin 7 */
 #define NRF_FUN_SDP_MSPI_DQ7 65U
-/** SDP_MSPI CS0 */
+/** SDP_MSPI chip select 0 */
 #define NRF_FUN_SDP_MSPI_CS0 66U
-/** SDP_MSPI CS1 */
+/** SDP_MSPI chip select 1 */
 #define NRF_FUN_SDP_MSPI_CS1 67U
-/** SDP_MSPI CS2 */
+/** SDP_MSPI chip select 2 */
 #define NRF_FUN_SDP_MSPI_CS2 68U
-/** SDP_MSPI CS3 */
+/** SDP_MSPI chip select 3 */
 #define NRF_FUN_SDP_MSPI_CS3 69U
-/** SDP_MSPI CS4 */
+/** SDP_MSPI chip select 4 */
 #define NRF_FUN_SDP_MSPI_CS4 70U
+/** High-Performance Framework MSPI clock pin */
+#define NRF_FUN_HPF_MSPI_SCK NRF_FUN_SDP_MSPI_SCK
+/** High-Performance Framework MSPI data pin 0 */
+#define NRF_FUN_HPF_MSPI_DQ0 NRF_FUN_SDP_MSPI_DQ0
+/** High-Performance Framework MSPI data pin 1 */
+#define NRF_FUN_HPF_MSPI_DQ1 NRF_FUN_SDP_MSPI_DQ1
+/** High-Performance Framework MSPI data pin 2 */
+#define NRF_FUN_HPF_MSPI_DQ2 NRF_FUN_SDP_MSPI_DQ2
+/** High-Performance Framework MSPI data pin 3 */
+#define NRF_FUN_HPF_MSPI_DQ3 NRF_FUN_SDP_MSPI_DQ3
+/** High-Performance Framework MSPI data pin 4 */
+#define NRF_FUN_HPF_MSPI_DQ4 NRF_FUN_SDP_MSPI_DQ4
+/** High-Performance Framework MSPI data pin 5 */
+#define NRF_FUN_HPF_MSPI_DQ5 NRF_FUN_SDP_MSPI_DQ5
+/** High-Performance Framework MSPI data pin 6 */
+#define NRF_FUN_HPF_MSPI_DQ6 NRF_FUN_SDP_MSPI_DQ6
+/** High-Performance Framework MSPI data pin 7 */
+#define NRF_FUN_HPF_MSPI_DQ7 NRF_FUN_SDP_MSPI_DQ7
+/** High-Performance Framework MSPI chip select pin 0 */
+#define NRF_FUN_HPF_MSPI_CS0 NRF_FUN_SDP_MSPI_CS0
+/** High-Performance Framework MSPI chip select pin 1 */
+#define NRF_FUN_HPF_MSPI_CS1 NRF_FUN_SDP_MSPI_CS1
+/** High-Performance Framework MSPI chip select pin 2 */
+#define NRF_FUN_HPF_MSPI_CS2 NRF_FUN_SDP_MSPI_CS2
+/** High-Performance Framework MSPI chip select pin 3 */
+#define NRF_FUN_HPF_MSPI_CS3 NRF_FUN_SDP_MSPI_CS3
+/** High-Performance Framework MSPI chip select pin 4 */
+#define NRF_FUN_HPF_MSPI_CS4 NRF_FUN_SDP_MSPI_CS4
 /** TDM SCK in master mode */
 #define NRF_FUN_TDM_SCK_M        71U
 /** TDM SCK in slave mode */

--- a/samples/basic/blinky/boards/nrf54l15dk_nrf54l15_cpuapp_hpf_gpio.overlay
+++ b/samples/basic/blinky/boards/nrf54l15dk_nrf54l15_cpuapp_hpf_gpio.overlay
@@ -5,5 +5,5 @@
  */
 
 &led0 {
-	gpios = <&egpio 9 GPIO_ACTIVE_HIGH>;
+	gpios = <&hpf_gpio 9 GPIO_ACTIVE_HIGH>;
 };


### PR DESCRIPTION
Backport a4c0f9551c0cb9abc58fb555ca3eb9c677f75edb~2..a4c0f9551c0cb9abc58fb555ca3eb9c677f75edb from #2729.