### PR TITLE
[nrf noup] dts: nrf21540-fem default tx-en-settle-time-us=26

### DIFF
--- a/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
+++ b/dts/bindings/net/wireless/nordic,nrf21540-fem.yaml
@@ -95,7 +95,7 @@ properties:
         This must be present to support SPI control of the FEM.
   tx-en-settle-time-us:
     type: int
-    default: 11
+    default: 26
     description: |
         Settling time in microseconds from state PG to TX.
 


### PR DESCRIPTION
The default value of the `tx-en-settle-time-us` property is set to 26 to avoid spurious emission issue.

Cherry-pick of commit that went to NSC 3.0 release with https://github.com/nrfconnect/sdk-zephyr/pull/2753
Requires MPSL: https://github.com/nrfconnect/sdk-nrfxlib/pull/1725