### PR TITLE
[nrf fromtree] west.yml: Update libmetal and open-amp cmake minimum v…

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -279,7 +279,7 @@ manifest:
       revision: bb85f7dde4195bfc0fca9e9c7c2eed0f8694203c
       path: modules/lib/liblc3
     - name: libmetal
-      revision: 3e8781aae9d7285203118c05bc01d4eb0ca565a7
+      revision: 14f519529a1e4a46aaea6826f5a41d99a3347276
       path: modules/hal/libmetal
       groups:
         - hal
@@ -321,7 +321,7 @@ manifest:
       revision: 8fd3cd7b088d62f145b8b9f5ecc985dd73bd9e77
       path: modules/lib/nrf_wifi
     - name: open-amp
-      revision: 52bb1783521c62c019451cee9b05b8eda9d7425f
+      revision: f7f4d083c7909a39d86e217376c69b416ec4faf3
       path: modules/lib/open-amp
     - name: openthread
       revision: 3ae741f95e7dfb391dec35c48742862049eb62e8


### PR DESCRIPTION
…ersion to 3.16

Update the OpenAMP libraries to the latest commits to support CMake 3.16 as the minimum version.

Signed-off-by: Arnaud Pouliquen <arnaud.pouliquen@foss.st.com>
(cherry picked from commit 0f852c82f02573da6f8d61f794ec2c1f1a7ed142)