### PR TITLE
nRF54H20 USB cherry-picks for 2.9.0-nRF54H20-2

### DIFF
--- a/drivers/usb/udc/udc_common.c
+++ b/drivers/usb/udc/udc_common.c
@@ -745,6 +745,7 @@ int udc_enable(const struct device *dev)
 	}
 
 	data->stage = CTRL_PIPE_STAGE_SETUP;
+	data->setup = NULL;
 
 	ret = api->enable(dev);
 	if (ret == 0) {
@@ -1010,6 +1011,14 @@ void udc_ctrl_update_stage(const struct device *dev,
 
 	if (bi->setup && bi->ep == USB_CONTROL_EP_OUT) {
 		uint16_t length  = udc_data_stage_length(buf);
+
+		if (data->setup) {
+			/* Host started new control transfer before the previous
+			 * one finished. This was most likely due to a timeout.
+			 * Release old setup buffer as it is no longer needed.
+			 */
+			net_buf_unref(data->setup);
+		}
 
 		data->setup = buf;
 

--- a/subsys/usb/device_next/usbd_ch9.c
+++ b/subsys/usb/device_next/usbd_ch9.c
@@ -1102,6 +1102,7 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 		buf, bi->ep, buf->len, bi->setup, bi->data, bi->status);
 
 	if (bi->setup && bi->ep == USB_CONTROL_EP_OUT) {
+		struct udc_data *data = uds_ctx->dev->data;
 		struct net_buf *next_buf;
 
 		if (ctrl_xfer_get_setup(uds_ctx, buf)) {
@@ -1112,6 +1113,7 @@ int usbd_handle_ctrl_xfer(struct usbd_context *const uds_ctx,
 
 		/* Remove setup packet buffer from the chain */
 		next_buf = net_buf_frag_del(NULL, buf);
+		data->setup = NULL;
 		if (next_buf == NULL) {
 			LOG_ERR("Buffer for data|status is missing");
 			goto ctrl_xfer_stall;


### PR DESCRIPTION
PR88642 is backported to apply on 2.9.0-nRF54H20 sdk-zephyr without requiring to pull in other changes.