### PR TITLE
[nrf fromlist] soc: nordic: nrf54h: Fix s2ram

### DIFF
--- a/soc/nordic/nrf54h/pm_s2ram.c
+++ b/soc/nordic/nrf54h/pm_s2ram.c
@@ -167,11 +167,11 @@ int soc_s2ram_suspend(pm_s2ram_system_off_fn_t system_off)
 	nvic_suspend(&backup_data.nvic_context);
 	mpu_suspend(&backup_data.mpu_context);
 	ret = arch_pm_s2ram_suspend(system_off);
+	/* Cache is powered down so power up is needed even if s2ram failed. */
+	nrf_power_up_cache();
 	if (ret < 0) {
 		return ret;
 	}
-
-	nrf_power_up_cache();
 
 	mpu_resume(&backup_data.mpu_context);
 	nvic_resume(&backup_data.nvic_context);


### PR DESCRIPTION
Cache was not enabled when s2ram did not completed which lead to system malfunction. Always power up cache when returning from s2ram function.

Upstream PR #: 88709