### PR TITLE
[Backport v4.0.99-ncs1-branch] soc: nordic: Add missing flash runner config

### DIFF
--- a/soc/nordic/soc.yml
+++ b/soc/nordic/soc.yml
@@ -115,9 +115,11 @@ runners:
               - nrf54l09/cpuflpr
           - qualifiers:
               - nrf54l10/cpuapp
+              - nrf54l10/cpuapp/ns
               - nrf54l10/cpuflpr
           - qualifiers:
               - nrf54l15/cpuapp
+              - nrf54l15/cpuapp/ns
               - nrf54l15/cpuflpr
           - qualifiers:
               - nrf54l20/cpuapp
@@ -179,9 +181,11 @@ runners:
               - nrf54l09/cpuflpr
           - qualifiers:
               - nrf54l10/cpuapp
+              - nrf54l10/cpuapp/ns
               - nrf54l10/cpuflpr
           - qualifiers:
               - nrf54l15/cpuapp
+              - nrf54l15/cpuapp/ns
               - nrf54l15/cpuflpr
           - qualifiers:
               - nrf54l20/cpuapp
@@ -243,9 +247,11 @@ runners:
               - nrf54l09/cpuflpr
           - qualifiers:
               - nrf54l10/cpuapp
+              - nrf54l10/cpuapp/ns
               - nrf54l10/cpuflpr
           - qualifiers:
               - nrf54l15/cpuapp
+              - nrf54l15/cpuapp/ns
               - nrf54l15/cpuflpr
           - qualifiers:
               - nrf54l20/cpuapp


### PR DESCRIPTION
Backport 37e76921f9fecbd6a43e98ae82428b40590460ac from #2774.