### PR TITLE
[Backport v4.0.99-ncs1-branch] [nrf fromlist] soc: nordic: nrf54h: Fix s2ram

### DIFF
--- a/soc/nordic/nrf54h/pm_s2ram.c
+++ b/soc/nordic/nrf54h/pm_s2ram.c
@@ -166,6 +166,8 @@ int soc_s2ram_suspend(pm_s2ram_system_off_fn_t system_off)
 	nvic_suspend(&backup_data.nvic_context);
 	mpu_suspend(&backup_data.mpu_context);
 	ret = arch_pm_s2ram_suspend(system_off);
+	/* Cache is powered down so power up is needed even if s2ram failed. */
+	nrf_power_up_cache();
 	if (ret < 0) {
 		return ret;
 	}


### PR DESCRIPTION
Backport 7607c65855669ed61b8c74e4bf38841396f2c30d from #2776.