### PR TITLE
[nrf fromtree] include: drivers: clock_control: Remove strict inclusion for nrf_clock.h

### DIFF
--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NRF_CLOCK_CONTROL_H_
 
 #include <zephyr/device.h>
-#if defined(NRF_CLOCK) && !defined(NRF_LFRC)
+#ifdef NRF_CLOCK
 #include <hal/nrf_clock.h>
 #endif
 #include <zephyr/sys/onoff.h>


### PR DESCRIPTION
Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/88164