### PR TITLE
[nrf fromlist] tests: drivers: Turn on HFCLK before LFCLK calibration in nRF devices

### DIFF
--- a/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
+++ b/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
@@ -63,6 +63,10 @@ static void test_calibration(uint32_t exp_cal, uint32_t exp_skip,
 	int cal_cnt;
 	int skip_cnt;
 
+	const struct device *const clk_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
+
+	turn_on_clock(clk_dev, CLOCK_CONTROL_NRF_SUBSYS_HF);
+
 	cal_cnt = z_nrf_clock_calibration_count();
 	skip_cnt = z_nrf_clock_calibration_skips_count();
 
@@ -70,6 +74,8 @@ static void test_calibration(uint32_t exp_cal, uint32_t exp_skip,
 
 	cal_cnt = z_nrf_clock_calibration_count() - cal_cnt;
 	skip_cnt = z_nrf_clock_calibration_skips_count() - skip_cnt;
+
+	turn_off_clock(clk_dev, CLOCK_CONTROL_NRF_SUBSYS_HF);
 
 	zassert_equal(cal_cnt, exp_cal,
 			"%d: Unexpected number of calibrations (%d, exp:%d)",


### PR DESCRIPTION
This change plays with situation in nRF54L devices where XOTUNE make LF clock calibration process starts a bit longer. Now HF clock is configured to be ready right before LF calibration test.

Upstream PR #: 88797