### PR TITLE
soc: nordic: nrf54h: Disable GPD for MCUBoot

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/boards/nrf54h20dk_nrf54h20_cpuapp_iron.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/boards/nrf54h20dk_nrf54h20_cpuapp_iron.conf
@@ -1,3 +1,0 @@
-# Disable GPD because no IPC is enabled in SSDFW
-CONFIG_SOC_NRF54H20_GPD=n
-CONFIG_PM=n

--- a/soc/nordic/nrf54h/gpd/Kconfig
+++ b/soc/nordic/nrf54h/gpd/Kconfig
@@ -6,6 +6,6 @@ config SOC_NRF54H20_GPD
 	imply NRFS
 	imply NRFS_GDPWR_SERVICE_ENABLED
 	select ONOFF
-	default y if SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD
+	default y if !MCUBOOT && (SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD)
 	help
 	  This option enables the Global Power Domain service.


### PR DESCRIPTION
Disable GPD for MCUBoot build, as it cannot be reinitialized later in application (SDFW does not
support reinitialization).

Also, remove the GPD disabling from the mcumgr sample for nRF54H20 iron board app - it was the reinitialization that caused problems.

Upstream PR #: 88958

Signed-off-by: Michal Kozikowski <michal.kozikowski@nordicsemi.no>
(cherry picked from commit bece1c22bbf04d417839635e482ecc9e45bd5c15)