### PR TITLE
[nrf fromlist] tests: drivers: clock_control_api: Adjust to nRF54L09 and nRF54L20

### DIFF
--- a/tests/drivers/clock_control/clock_control_api/src/nrf_device_subsys.h
+++ b/tests/drivers/clock_control/clock_control_api/src/nrf_device_subsys.h
@@ -11,8 +11,9 @@ static const struct device_subsys_data subsys_data[] = {
 	{
 		.subsys = CLOCK_CONTROL_NRF_SUBSYS_HF,
 		.startup_us =
-			IS_ENABLED(CONFIG_SOC_SERIES_NRF91X) ?
-				3000 : 500
+			(IS_ENABLED(CONFIG_SOC_NRF54L20_ENGA) ||
+			 IS_ENABLED(CONFIG_SOC_NRF54L09_ENGA)) ?
+				1000 : (IS_ENABLED(CONFIG_SOC_SERIES_NRF91X) ? 3000 : 500)
 	},
 #ifndef CONFIG_SOC_NRF52832
 	/* On nrf52832 LF clock cannot be stopped because it leads


### PR DESCRIPTION
nRF54L09 and nRF54L20 need double the time for startup of their clocks.

Upstream PR #: 88956