### PR TITLE
[nrf fromtree] tests: drivers: audio: dmic_api: Enable coverage calcu…

### DIFF
--- a/tests/drivers/audio/dmic_api/src/main.c
+++ b/tests/drivers/audio/dmic_api/src/main.c
@@ -34,8 +34,14 @@ static const struct device *dmic_dev = DEVICE_DT_GET(DT_ALIAS(dmic_dev));
 /* Milliseconds to wait for a block to be read. */
 #define READ_TIMEOUT 1000
 /* Size of a block for 100 ms of audio data. */
+#if defined(CONFIG_COVERAGE)
+/* Use smaller buffer in coverage mode. */
+#define BLOCK_SIZE(_sample_rate, _number_of_channels) \
+	(BYTES_PER_SAMPLE * (_sample_rate / 100) * _number_of_channels)
+#else
 #define BLOCK_SIZE(_sample_rate, _number_of_channels) \
 	(BYTES_PER_SAMPLE * (_sample_rate / 10) * _number_of_channels)
+#endif
 
 /* Driver will allocate blocks from this slab to receive audio data into them.
  * Application, after getting a given block from the driver and processing its


### PR DESCRIPTION
…lation

When test is run with enabled coverage, additional RAM is required to store coverage data.
Digital Microphone test is reserving most of the available RAM to store audio samples. Thus, test fails to build with coverage enabled due to RAM overflow.

Decrease size of the audio buffer when coverage is enabled.

Upstream PR #: 89084