### PR TITLE
[nrf_fromlist] modules: hostap: Increase supplicant stack size

### DIFF
--- a/modules/hostap/Kconfig
+++ b/modules/hostap/Kconfig
@@ -35,7 +35,7 @@ config WIFI_NM_WPA_SUPPLICANT_THREAD_STACK_SIZE
 	# TODO: Providing higher stack size for Enterprise mode to fix stack
 	# overflow issues. Need to identify the cause for higher stack usage.
 	default 8192 if WIFI_NM_WPA_SUPPLICANT_CRYPTO_ENTERPRISE
-	default 5600
+	default 5800
 
 config WIFI_NM_WPA_SUPPLICANT_WQ_STACK_SIZE
 	int "Stack size for wpa_supplicant iface workqueue"


### PR DESCRIPTION
SoftAP operation needs around 5700 bytes of stack. With a buffer of 100 bytes, set the supplicant stack size to 5800. Fixes SHEL-3604.

Upstream PR #: 89116