### PR TITLE
[nrf noup] manifest: Update hal_nordic with MDK 8.68.2 release

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -188,7 +188,8 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 54bde38c6f6ffb3780b26ae728cf79426184384e
+      url: https://github.com/nrfconnect/sdk-hal_nordic
+      revision: bc671cbc669b492144d021faab7df84e79fb0712
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Updated MDK improves support for nRF54L05 and nRF54L10 erratas. As NCS 2.9.x uses legacy nrfx 3.9 version, changes had to be introduced via sdk-hal_nordic repository.