### PR TITLE
Snipplet is called serial-console not uart-console

### DIFF
--- a/snippets/serial-console/README.rst
+++ b/snippets/serial-console/README.rst
@@ -1,6 +1,6 @@
-.. _snippet-uart-console:
+.. _snippet-serial-console:
 
-UART Console Snippet (uart-console)
+UART Console Snippet (serial-console)
 ###################################
 
 Overview


### PR DESCRIPTION
Fix that snipplet "serial-console" is wrongly referred to as "uart-console"