### PR TITLE
[nrf noup] Added nrf54h20dk/nrf54h20/cpuapp/iron/mcuboot/b0

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/sample.yaml
@@ -92,6 +92,7 @@ tests:
       - rd_rw612_bga
       - nrf52840dk/nrf52840
       - nrf54h20dk/nrf54h20/cpuapp/iron
+      - nrf54h20dk/nrf54h20/cpuapp/iron/mcuboot/b0
       - pinnacle_100_dvk
       - mg100
     integration_platforms:


### PR DESCRIPTION
This is one of the solutions for adding an appropriate memory map in case mcuboot and NSIB are to be used.

Note: the nrf54h20dk/nrf54h20/cpuapp/iron/mcuboot/b0 board was added in zephyr. This might not be the final approach. Other ways of specifying the memory map might be used.