### PR TITLE
wiif: Pull IOVDD current improvements

### DIFF
--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common_pinctrl.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common_pinctrl.dtsi
@@ -55,8 +55,12 @@
 				<NRF_PSEL(QSPI_IO0, 0, 13)>,
 				<NRF_PSEL(QSPI_IO1, 0, 14)>,
 				<NRF_PSEL(QSPI_IO2, 0, 15)>,
-				<NRF_PSEL(QSPI_IO3, 0, 16)>,
-				<NRF_PSEL(QSPI_CSN, 0, 18)>;
+				<NRF_PSEL(QSPI_IO3, 0, 16)>;
+			bias-pull-down;
+		};
+		group2 {
+			psels = <NRF_PSEL(QSPI_CSN, 0, 18)>;
+			bias-pull-up;
 		};
 	};
 
@@ -66,10 +70,14 @@
 				<NRF_PSEL(QSPI_IO0, 0, 13)>,
 				<NRF_PSEL(QSPI_IO1, 0, 14)>,
 				<NRF_PSEL(QSPI_IO2, 0, 15)>,
-				<NRF_PSEL(QSPI_IO3, 0, 16)>,
-				<NRF_PSEL(QSPI_CSN, 0, 18)>;
-			low-power-enable;
+				<NRF_PSEL(QSPI_IO3, 0, 16)>;
+			bias-pull-down;
 		};
+		group2 {
+			psels = <NRF_PSEL(QSPI_CSN, 0, 18)>;
+			bias-pull-up;
+		};
+		low-power-enable;
 	};
 
 	uart1_default: uart1_default {

--- a/boards/shields/nrf7002ek/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002ek/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -13,3 +13,34 @@
 &gpio_fwd {
 	status = "disabled";
 };
+
+/*
+ * Override the default pinctrl settings for SPI4 when used with the nRF7002 EK
+ * to pull down the MISO line. This is needed to avoid floating inputs when
+ * the SPI4 is not used. The default pinctrl settings are defined in the
+ * nrf5340_cpuapp_common_pinctrl.dtsi file.
+ */
+&pinctrl {
+	spi4_default: spi4_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(SPIM_MISO, 1, 14)>;
+			bias-pull-down;
+		};
+	};
+
+	spi4_sleep: spi4_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+		};
+		group2 {
+			psels = <NRF_PSEL(SPIM_MISO, 1, 14)>;
+			bias-pull-down;
+		};
+		low-power-enable;
+	};
+};

--- a/boards/shields/nrf7002ek/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/boards/shields/nrf7002ek/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -16,31 +16,21 @@
 
 /*
  * Override the default pinctrl settings for SPI4 when used with the nRF7002 EK
- * to pull down the MISO line. This is needed to avoid floating inputs when
+ * to pull down the SPIM lines. This is needed to avoid floating inputs when
  * the SPI4 is not used. The default pinctrl settings are defined in the
  * nrf5340_cpuapp_common_pinctrl.dtsi file.
  */
 &pinctrl {
 	spi4_default: spi4_default {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
-		};
-		group2 {
-			psels = <NRF_PSEL(SPIM_MISO, 1, 14)>;
 			bias-pull-down;
 		};
 	};
 
 	spi4_sleep: spi4_sleep {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
-		};
-		group2 {
-			psels = <NRF_PSEL(SPIM_MISO, 1, 14)>;
 			bias-pull-down;
+			low-power-enable;
 		};
-		low-power-enable;
 	};
 };


### PR DESCRIPTION
Put the GPIOs in low-power state when not in use.