### PR TITLE
[nrf noup] ci: exclude mesh from find-my and nfc

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -208,7 +208,6 @@
   - "lib/crc/**/*"
   - "modules/hal_nordic/**/*"
   - "soc/nordic/**/*"
-  - "subsys/bluetooth/**/*"
   - "subsys/ipc/ipc_service/**/*"
   - "subsys/fs/**/*"
   - "subsys/mem_mgmt/**/*"
@@ -217,6 +216,9 @@
   - "subsys/settings/**/*"
   - "subsys/shell/**/*"
   - "subsys/storage/**/*"
+  - any:
+      - "subsys/bluetooth/**/*"
+      - "!subsys/bluetooth/mesh/**/*"
 
 "CI-matter-test":
   - "include/dfu/**/*"
@@ -241,7 +243,6 @@
   - "drivers/usb/**/*"
   - "drivers/regulator/**/*"
   - "soc/nordic/**/*"
-  - "subsys/bluetooth/**/*"
   - "subsys/dfu/**/*"
   - "subsys/fs/**/*"
   - "subsys/ipc/**/*"
@@ -251,6 +252,9 @@
   - "subsys/storage/**/*"
   - "subsys/tracing/**/*"
   - "subsys/usb/device/**/*"
+  - any:
+      - "subsys/bluetooth/**/*"
+      - "!subsys/bluetooth/mesh/**/*"
 
 "CI-rpc-test":
   - "subsys/ipc/ipc_service/**/*"


### PR DESCRIPTION
Neither NFC nor FindMy use Bluetooth Mesh, but CI is triggered and may fail.

FindMy excludes Bluetooth Mesh in sdk-nrf: https://github.com/nrfconnect/sdk-nrf/blob/3bda0a8675b1a51e30539bb2491cd0758877229c/.github/test-spec.yml#L430-L431

NFC doesn't include all `subsys/bluetooth` in sdk-nrf.