### PR TITLE
[nrf fromtree] net: lwm2m: Fix blockwise Ack NUM calculation

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -1057,9 +1057,6 @@ static int lwm2m_write_handler_opaque(struct lwm2m_engine_obj_inst *obj_inst,
 				return ret;
 			}
 		}
-		if (msg->in.block_ctx && !last_pkt_block) {
-			msg->in.block_ctx->ctx.current += len;
-		}
 		opaque_ctx.offset += len;
 		written += len;
 	}


### PR DESCRIPTION
After the PR #85000 the calculation of NUM field of Block 1 option on CoAP Ack packet started to advance to next packet block.

We should not update the ctx->current field because it is used for calculating the NUM field in response packet. It should point to beginning of the payload,
so the response is correct.

Leshan server don't seem to care about this, but Coiote does.


(cherry picked from commit 252f8fefe03db52f52fe8cecbb0029f265d6311b)