### PR TITLE
[nrf fromtree] boards: nordic: Enable nfct on the supporting boards

### DIFF
--- a/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.dts
+++ b/boards/nordic/nrf21540dk/nrf21540dk_nrf52840.dts
@@ -158,6 +158,10 @@
 	gpio-as-nreset;
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpiote {
 	status = "okay";
 };

--- a/boards/nordic/nrf52833dk/nrf52833dk_nrf52833.dts
+++ b/boards/nordic/nrf52833dk/nrf52833dk_nrf52833.dts
@@ -135,6 +135,10 @@
 	gpio-as-nreset;
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpiote {
 	status = "okay";
 };

--- a/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
+++ b/boards/nordic/nrf52840dk/nrf52840dk_nrf52840.dts
@@ -153,6 +153,10 @@
 	status = "okay";
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 	gpio-reserved-ranges = <0 2>, <6 1>, <8 3>, <17 7>;

--- a/boards/nordic/nrf52dk/nrf52dk_nrf52832.dts
+++ b/boards/nordic/nrf52dk/nrf52dk_nrf52832.dts
@@ -146,6 +146,10 @@
 	gpio-as-nreset;
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpiote {
 	status = "okay";
 };

--- a/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf5340_audio_dk/nrf5340_audio_dk_nrf5340_cpuapp_common.dtsi
@@ -105,6 +105,10 @@
 	};
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpiote {
 	status = "okay";
 };

--- a/boards/nordic/nrf5340dk/nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf5340dk/nrf5340_cpuapp_common.dtsi
@@ -74,6 +74,10 @@
 	status = "okay";
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpiote {
 	status = "okay";
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -214,6 +214,11 @@ ipc0: &cpuapp_cpurad_ipc {
 	source-memory = <&cpuflpr_code_partition>;
 };
 
+&nfct {
+	status = "okay";
+	memory-regions = <&cpuapp_dma_region>;
+};
+
 &gpiote130 {
 	status = "okay";
 	owned-channels = <0 1 2 3 4 5 6 7>;

--- a/boards/nordic/nrf54l15dk/nrf54l_05_10_15_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l_05_10_15_cpuapp_common.dtsi
@@ -56,6 +56,10 @@
 	status = "okay";
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };

--- a/boards/nordic/nrf54l20pdk/nrf54l20_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l20pdk/nrf54l20_cpuapp_common.dtsi
@@ -80,6 +80,10 @@
 	status = "okay";
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpio0 {
 	status = "okay";
 };

--- a/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7002dk/nrf5340_cpuapp_common.dtsi
@@ -143,6 +143,10 @@
 	status = "okay";
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpiote {
 	status = "okay";
 };

--- a/boards/nordic/thingy52/thingy52_nrf52832.dts
+++ b/boards/nordic/thingy52/thingy52_nrf52832.dts
@@ -113,6 +113,10 @@
 	status = "okay";
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpiote {
 	status = "okay";
 };

--- a/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
+++ b/boards/nordic/thingy53/thingy53_nrf5340_common.dtsi
@@ -188,6 +188,10 @@
 	};
 };
 
+&nfct {
+	status = "okay";
+};
+
 &gpiote {
 	status = "okay";
 };


### PR DESCRIPTION
Enable NFCT device in dts of the boards that have
NFC connector.

This is part of NCSDK-32456, since it didn't make it before upmerge.

(cherry picked from commit e37b68bfa4b62b7fc19c29eeec6521fd56e6cd30)