### PR TITLE
[nrf fromlist] ci: Support standalone anchors for reusability

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -337,6 +337,10 @@ class Filters:
             tag.exclude = True
             tag.name = t
 
+            if not isinstance(x, dict) or x.get("files") is None:
+                logging.debug(f"Tag {t} is might be a standalone anchor, skipping...")
+                continue
+
             # tag._match_fn(path) tests if the path matches files and/or
             # files-regex
             tag._match_fn = _get_match_fn(x.get("files"), x.get("files-regex"))


### PR DESCRIPTION
If we want to reuse a set of files for multiple tags, then allow defining a standalone anchor and skip processing it.

e.g., below will work now, as the first entry wifi_common will be ignored

wifi_common: *wifi_common
  - a
  - b

ci_samples_wifi:
  files:
    - c
    - *wifi_common

Upstream PR #: 90028

manifest-pr-skip