### PR TITLE
[nrf fromtree] cmake: linker: ld: fix duplicate LINK_FLAGS

### DIFF
--- a/cmake/linker/ld/target.cmake
+++ b/cmake/linker/ld/target.cmake
@@ -148,7 +148,7 @@ macro(toolchain_linker_finalize)
   endforeach()
   string(REPLACE ";" " " zephyr_std_libs "${zephyr_std_libs}")
 
-  set(link_libraries "<LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES> ${zephyr_std_libs}")
+  set(link_libraries "<OBJECTS> -o <TARGET> <LINK_LIBRARIES> ${zephyr_std_libs}")
   set(common_link "<LINK_FLAGS> ${link_libraries}")
 
   set(CMAKE_ASM_LINK_EXECUTABLE "<CMAKE_ASM_COMPILER> <FLAGS> <CMAKE_ASM_LINK_FLAGS> ${common_link}")


### PR DESCRIPTION
Original implementation of `toolchain_linker_finalize` duplicates the `LINK_FLAGS` in the link command. This can cause some problems like duplicate definitions when using link options like `--whole-archive`.

This commit fixes it by removing the duplicate `LINK_FLAGS`.

Fixes #82281


(cherry picked from commit 841311330b03d01c4b224b7031a21c6350390206)