### PR TITLE
[nrf fromlist] soc: drivers: nrf: Add support for UARTE23 and UARTE24

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -111,6 +111,16 @@ nrfx_uart_num = 22
 rsource "Kconfig.nrfx_uart_instance"
 endif
 
+if HAS_HW_NRF_UARTE23
+nrfx_uart_num = 23
+rsource "Kconfig.nrfx_uart_instance"
+endif
+
+if HAS_HW_NRF_UARTE24
+nrfx_uart_num = 24
+rsource "Kconfig.nrfx_uart_instance"
+endif
+
 if HAS_HW_NRF_UARTE30
 nrfx_uart_num = 30
 rsource "Kconfig.nrfx_uart_instance"

--- a/soc/nordic/common/Kconfig.peripherals
+++ b/soc/nordic/common/Kconfig.peripherals
@@ -608,6 +608,12 @@ config HAS_HW_NRF_UARTE21
 config HAS_HW_NRF_UARTE22
 	def_bool $(dt_nodelabel_enabled_with_compat,uart22,$(DT_COMPAT_NORDIC_NRF_UARTE))
 
+config HAS_HW_NRF_UARTE23
+	def_bool $(dt_nodelabel_enabled_with_compat,uart23,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
+config HAS_HW_NRF_UARTE24
+	def_bool $(dt_nodelabel_enabled_with_compat,uart24,$(DT_COMPAT_NORDIC_NRF_UARTE))
+
 config HAS_HW_NRF_UARTE30
 	def_bool $(dt_nodelabel_enabled_with_compat,uart30,$(DT_COMPAT_NORDIC_NRF_UARTE))
 


### PR DESCRIPTION
Extends configuration to support instances used in new SOCs.

Upstream PR #: 90373