### PR TITLE
Allow to add suffix overlays

### DIFF
--- a/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
+++ b/share/sysbuild/cmake/modules/sysbuild_extensions.cmake
@@ -261,7 +261,7 @@ function(ExternalZephyrProject_Add)
   set(sysbuild_image_conf_dir ${APP_DIR}/sysbuild)
   set(sysbuild_image_name_conf_dir ${APP_DIR}/sysbuild/${ZBUILD_APPLICATION})
   # User defined `-D<image>_CONF_FILE=<file.conf>` takes precedence over anything else.
-  if (NOT ${ZBUILD_APPLICATION}_CONF_FILE)
+  if(NOT ${ZBUILD_APPLICATION}_CONF_FILE)
     if(EXISTS ${sysbuild_image_name_conf_dir})
       set(${ZBUILD_APPLICATION}_APPLICATION_CONFIG_DIR ${sysbuild_image_name_conf_dir}
           CACHE INTERNAL "Application configuration dir controlled by sysbuild"
@@ -275,7 +275,7 @@ function(ExternalZephyrProject_Add)
                 NAMES ${ZBUILD_APPLICATION}.conf SUFFIX ${FILE_SUFFIX}
     )
 
-    if (NOT (${ZBUILD_APPLICATION}_OVERLAY_CONFIG OR ${ZBUILD_APPLICATION}_EXTRA_CONF_FILE)
+    if(NOT (${ZBUILD_APPLICATION}_OVERLAY_CONFIG OR ${ZBUILD_APPLICATION}_EXTRA_CONF_FILE)
         AND EXISTS ${sysbuild_image_conf_fragment}
     )
       set(${ZBUILD_APPLICATION}_EXTRA_CONF_FILE ${sysbuild_image_conf_fragment}
@@ -283,12 +283,23 @@ function(ExternalZephyrProject_Add)
       )
     endif()
 
-    # Check for overlay named <ZBUILD_APPLICATION>.overlay.
-    set(sysbuild_image_dts_overlay ${sysbuild_image_conf_dir}/${ZBUILD_APPLICATION}.overlay)
-    if (NOT ${ZBUILD_APPLICATION}_DTC_OVERLAY_FILE AND EXISTS ${sysbuild_image_dts_overlay})
-      set(${ZBUILD_APPLICATION}_DTC_OVERLAY_FILE ${sysbuild_image_dts_overlay}
-          CACHE INTERNAL "devicetree overlay file defined by main application"
-      )
+    if(NOT ${ZBUILD_APPLICATION}_DTC_OVERLAY_FILE)
+      # Check for overlay named <ZBUILD_APPLICATION>.overlay.
+      set(sysbuild_image_dts_overlay_files ${sysbuild_image_conf_dir}/${ZBUILD_APPLICATION}.overlay)
+
+      # Check for overlay named <ZBUILD_APPLICATION>_<FILE_SUFFIX>.overlay.
+      if(FILE_SUFFIX)
+        list(PREPEND sysbuild_image_dts_overlay_files ${sysbuild_image_conf_dir}/${ZBUILD_APPLICATION}_${FILE_SUFFIX}.overlay)
+      endif()
+
+      foreach(sysbuild_image_dts_overlay_files overlay_file)
+        if(EXISTS ${overlay_file})
+          set(${ZBUILD_APPLICATION}_DTC_OVERLAY_FILE ${overlay_file}
+            CACHE INTERNAL "devicetree overlay file defined by main application"
+          )
+          break()
+        endif()
+      endforeach()
     endif()
   endif()
 


### PR DESCRIPTION
Allow to add an image-specific DTS overlay, that is applied based on the `FILE_SUFFIX`.
Up to this point, it was possible to specify such Kconfig files (`sysbuild/<image>_<file_suffix>.conf`), but it did not work with dts overlays (`sysbuild/<image>_<file_suffix>.overlay`).
This commit aligns the logic of finding configuration files for both scenarios mentioned above.

Ref: NCSDK-NONE