### PR TITLE
[nrf fromlist] dfu: Fix MCUBOOT_UPDATE_FOOTER_SIZE warning

### DIFF
--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -106,3 +106,17 @@ config UPDATEABLE_IMAGE_NUMBER
 endif
 
 endif # IMG_MANAGER
+
+if BOOTLOADER_MCUBOOT
+# This option is defined regardless of whether IMG_MANAGER is enabled to prevent
+# build warnings when IMG_MANAGER is not selected - as it is being unconditionally
+# set in MCUBOOT.
+config MCUBOOT_UPDATE_FOOTER_SIZE
+	hex "Estimated update footer size"
+	default 0x0
+	help
+	  Estimated size of update image data, which is used to prevent loading of firmware updates
+	  that MCUboot cannot update due to being too large. This should be set from sysbuild, only
+	  used when MCUMGR_GRP_IMG_TOO_LARGE_SYSBUILD is enabled.
+
+endif #BOOTLOADER_MCUBOOT

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -14,6 +14,17 @@ menuconfig IMG_MANAGER
 	help
 	  Enable support for managing DFU image.
 
+# This option is defined regardless of whether IMG_MANAGER is enabled to prevent
+# build warnings when IMG_MANAGER is not selected - as it is being unconditionally
+# set in MCUBOOT.
+config MCUBOOT_UPDATE_FOOTER_SIZE
+	hex "Estimated update footer size"
+	default 0x0
+	help
+	  Estimated size of update image data, which is used to prevent loading of firmware updates
+	  that MCUboot cannot update due to being too large. This should be set from sysbuild, only
+	  used when MCUMGR_GRP_IMG_TOO_LARGE_SYSBUILD is enabled.
+
 if IMG_MANAGER
 
 choice
@@ -51,14 +62,6 @@ config MCUBOOT_TRAILER_SWAP_TYPE
 	  (https://github.com/JuulLabs-OSS/mcuboot/pull/485)
 	  Disable this option if need to be compatible with earlier version
 	  of MCUBoot.
-
-config MCUBOOT_UPDATE_FOOTER_SIZE
-	hex "Estimated update footer size"
-	default 0x0
-	help
-	  Estimated size of update image data, which is used to prevent loading of firmware updates
-	  that MCUboot cannot update due to being too large. This should be set from sysbuild, only
-	  used when MCUMGR_GRP_IMG_TOO_LARGE_SYSBUILD is enabled.
 
 config IMG_BLOCK_BUF_SIZE
 	int "Image writer buffer size"


### PR DESCRIPTION
The warning was the result of the MCUBOOT_UPDATE_FOOTER_SIZE Kconfig option being under "if IMG_MANAGER", but at the same time being unconditionally set in by CMake mcuboot.

At the same there is no way for CMake to find out if CONFIG_IMG_MANAGER is set before setting the value of CONFIG_MCUBOOT_UPDATE_FOOTER_SIZE (as the value of CONFIG_IMG_MANAGER is uknown before finishing
Kconfig parsing).

Upstream PR #: 90721