### PR TITLE
[nrf fromlist] update hal_nordic revision to integrate nrfx 3.12.0

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -65,7 +65,9 @@ static const uint32_t saadc_psels[NRF_SAADC_DVDD + 1] = {
 	[NRF_SAADC_AIN6] = NRF_PIN_PORT_TO_PIN_NUMBER(4U, 1),
 	[NRF_SAADC_AIN7] = NRF_PIN_PORT_TO_PIN_NUMBER(3U, 1),
 	[NRF_SAADC_VDD]  = NRF_SAADC_INPUT_VDD,
+#if defined(NRF_SAADC_INPUT_AVDD)
 	[NRF_SAADC_AVDD] = NRF_SAADC_INPUT_AVDD,
+#endif
 	[NRF_SAADC_DVDD] = NRF_SAADC_INPUT_DVDD,
 };
 #endif
@@ -231,6 +233,7 @@ static int adc_nrfx_channel_setup(const struct device *dev,
 		return -EINVAL;
 	}
 
+#if NRF_SAADC_HAS_CH_GAIN
 	switch (channel_cfg->gain) {
 #if defined(SAADC_CH_CONFIG_GAIN_Gain1_6)
 	case ADC_GAIN_1_6:
@@ -284,6 +287,9 @@ static int adc_nrfx_channel_setup(const struct device *dev,
 		break;
 #endif
 	default:
+#else
+	if (channel_cfg->gain != ADC_GAIN_1) {
+#endif /* defined(NRF_SAADC_HAS_CH_GAIN) */
 		LOG_ERR("Selected ADC gain is not valid");
 		return -EINVAL;
 	}

--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -220,7 +220,9 @@ static int adc_nrfx_channel_setup(const struct device *dev,
 		.resistor_p     = NRF_SAADC_RESISTOR_DISABLED,
 		.resistor_n     = NRF_SAADC_RESISTOR_DISABLED,
 #endif
+#if NRF_SAADC_HAS_CH_BURST
 		.burst          = NRF_SAADC_BURST_DISABLED,
+#endif
 	};
 	uint8_t channel_id = channel_cfg->channel_id;
 	uint32_t input_negative = channel_cfg->input_negative;
@@ -530,6 +532,7 @@ static int start_read(const struct device *dev,
 	uint8_t resolution = sequence->resolution;
 	uint8_t active_channels;
 	uint8_t channel_id;
+	nrf_saadc_burst_t burst;
 
 	/* Signal an error if channel selection is invalid (no channels or
 	 * a non-existing one is selected).
@@ -581,10 +584,13 @@ static int start_read(const struct device *dev,
 			 * is not used (hence, the multiple channel sampling is
 			 * possible), the burst mode have to be deactivated.
 			 */
-			nrf_saadc_burst_set(NRF_SAADC, channel_id,
-				(sequence->oversampling != 0U ?
-					NRF_SAADC_BURST_ENABLED :
-					NRF_SAADC_BURST_DISABLED));
+			burst = (sequence->oversampling != 0U ?
+				 NRF_SAADC_BURST_ENABLED : NRF_SAADC_BURST_DISABLED);
+#if NRF_SAADC_HAS_CH_BURST
+			nrf_saadc_channel_burst_set(NRF_SAADC, channel_id, burst);
+#else
+			nrf_saadc_burst_set(NRF_SAADC, burst);
+#endif
 			nrf_saadc_channel_pos_input_set(
 				NRF_SAADC,
 				channel_id,
@@ -596,10 +602,12 @@ static int start_read(const struct device *dev,
 				);
 			++active_channels;
 		} else {
-			nrf_saadc_burst_set(
-				NRF_SAADC,
-				channel_id,
-				NRF_SAADC_BURST_DISABLED);
+			burst = NRF_SAADC_BURST_DISABLED;
+#if NRF_SAADC_HAS_CH_BURST
+			nrf_saadc_channel_burst_set(NRF_SAADC, channel_id, burst);
+#else
+			nrf_saadc_burst_set(NRF_SAADC, burst);
+#endif
 			nrf_saadc_channel_pos_input_set(
 				NRF_SAADC,
 				channel_id,

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 4eafaa44a55a557595e529f8cbdfc8dc1248da36
+      revision: 1f169d927e367eb1e161972e9504da5aa1f10c42
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
New nrfx release contains MDK 8.71.1 and various fixes for nRF devices.

Upstream PR #: 90944

Link: https://github.com/zephyrproject-rtos/zephyr/pull/90944