### PR TITLE
[nrf noup] cmake: nrf54l: iar: fix cmake linker generator for kmu

### DIFF
--- a/soc/nordic/nrf54l/CMakeLists.txt
+++ b/soc/nordic/nrf54l/CMakeLists.txt
@@ -16,4 +16,6 @@ if(NOT CONFIG_BUILD_WITH_TFM AND CONFIG_PSA_NEED_CRACEN_KMU_DRIVER AND NOT kmu_p
 # Exclamation mark is printable character with the lowest number in ASCII table.
 # We are sure that this file will be included first.
 zephyr_linker_sources(RAM_SECTIONS SORT_KEY ! kmu_push_area_section.ld)
+
+zephyr_linker_section(NAME ".nrf_kmu_reserved_push_area" ADDRESS "${RAM_ADDR}" GROUP RAM_REGION NOINIT)
 endif()


### PR DESCRIPTION
This adds the required parts for nrf54l kmu in
cmake linker generator.