### PR TITLE
[nrf fromlist] manifest: update hal_nordic to fix missing event clear in nrfx_grtc

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 1f169d927e367eb1e161972e9504da5aa1f10c42
+      revision: pull/300/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
GRTC events must be cleared even if user handler is not provided.

Upstream PR #: 91201

Link: https://github.com/zephyrproject-rtos/zephyr/pull/91201