### PR TITLE
[nrf fromlist] soc: nordic: common: Fix HAS_HW_NRF_NFCT condition

### DIFF
--- a/soc/nordic/common/Kconfig.peripherals
+++ b/soc/nordic/common/Kconfig.peripherals
@@ -120,7 +120,8 @@ config HAS_HW_NRF_MWU
 	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_MWU))
 
 config HAS_HW_NRF_NFCT
-	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_NFCT))
+	def_bool $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_NFCT)) || \
+		 $(dt_compat_enabled,$(DT_COMPAT_NORDIC_NRF_NFCT_V2))
 
 config HAS_HW_NRF_NVMC_PE
 	def_bool $(dt_nodelabel_bool_prop,flash_controller,partial-erase)


### PR DESCRIPTION
Include nordic,nrf-nfct-v2 compatible in the option.

Upstream PR #: 91274