### PR TITLE
[nrf noup] manifest: update hal_nordic to have reverted nrfx_grtc

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 1f169d927e367eb1e161972e9504da5aa1f10c42
+      revision: pull/301/head
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Apparently nrfx_grtc optimizations from 3.12 release causes issues in some non-callback use-cases.