### PR TITLE
[nrf fromlist] drivers: adc: adc_nrfx_saadc: Extend internal reference values

### DIFF
--- a/drivers/adc/adc_nrfx_saadc.c
+++ b/drivers/adc/adc_nrfx_saadc.c
@@ -754,7 +754,9 @@ static DEVICE_API(adc, adc_nrfx_driver_api) = {
 #ifdef CONFIG_ADC_ASYNC
 	.read_async    = adc_nrfx_read_async,
 #endif
-#if defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
+#if defined(NRF54LV10A_ENGA_XXAA)
+	.ref_internal  = 1300,
+#elif defined(CONFIG_SOC_COMPATIBLE_NRF54LX)
 	.ref_internal  = 900,
 #elif defined(CONFIG_NRF_PLATFORM_HALTIUM)
 	.ref_internal  = 1024,


### PR DESCRIPTION
Current target-reference mapping does not cover all cases.

Upstream PR #: 91581