### PR TITLE
wifi: drivers: Dynamic bandwidth signal controlling and Dynamic ED

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -913,4 +913,10 @@ config NRF_WIFI_DYNAMIC_BANDWIDTH_SIGNALLING
 	bool "Dynamic bandwidth signalling for Wi-Fi"
 	help
 	  This option enables support for dynamic bandwidth signalling.
+
+config NRF_WIFI_DYNAMIC_ED
+	bool "Dynamic ED"
+	help
+	  This option enables support for proprietary algorithm to
+	  enhance performance in high-traffic channels.
 endif # WIFI_NRF70

--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -908,4 +908,9 @@ config NRF_WIFI_RX_STBC_HT
 	help
 	  Receive packets encoded with STBC (Space-Time Block Coding)
 	  in HT (Wi-Fi4) mode.
+
+config NRF_WIFI_DYNAMIC_BANDWIDTH_SIGNALLING
+	bool "Dynamic bandwidth signalling for Wi-Fi"
+	help
+	  This option enables support for dynamic bandwidth signalling.
 endif # WIFI_NRF70

--- a/west.yml
+++ b/west.yml
@@ -328,7 +328,7 @@ manifest:
       revision: c6296f600a6851bd652f207ab4908d339e1ce705
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 294314b8622bfa582f43b229504d42201e1a3443
+      revision: 7cb2f44f46dfc86e4f97477ee90022944e138dd8
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: f7f4d083c7909a39d86e217376c69b416ec4faf3

--- a/west.yml
+++ b/west.yml
@@ -328,7 +328,7 @@ manifest:
       revision: c6296f600a6851bd652f207ab4908d339e1ce705
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 0cd7f28d34a5279cd839940c199658a294165722
+      revision: 1c1a7003ce90e492590c4a8a604eb9881bc8c5c1
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: f7f4d083c7909a39d86e217376c69b416ec4faf3

--- a/west.yml
+++ b/west.yml
@@ -328,7 +328,7 @@ manifest:
       revision: c6296f600a6851bd652f207ab4908d339e1ce705
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
-      revision: 1c1a7003ce90e492590c4a8a604eb9881bc8c5c1
+      revision: 294314b8622bfa582f43b229504d42201e1a3443
       path: modules/lib/nrf_wifi
     - name: open-amp
       revision: f7f4d083c7909a39d86e217376c69b416ec4faf3


### PR DESCRIPTION
Downstream PR for dynamic bandwidth signal controlling and dynamic ED kconfig.

manifest-pr-skip