### PR TITLE
[nrf noup] bluetooth: host: cs: Fix bt_le_cs_start_test param_len update

### DIFF
--- a/subsys/bluetooth/host/cs.c
+++ b/subsys/bluetooth/host/cs.c
@@ -617,7 +617,7 @@ int bt_le_cs_start_test(const struct bt_le_cs_test_param *params)
 
 	cp->override_parameters_length = override_parameters_length;
 
-	struct bt_hci_cmd_hdr *hdr = (struct bt_hci_cmd_hdr *)buf->data;
+	struct bt_hci_cmd_hdr *hdr = (struct bt_hci_cmd_hdr *)&buf->data[1];
 
 	hdr->param_len += override_parameters_length;
 


### PR DESCRIPTION
There was a change in HCI fuffers encoding: #88710. First byte in the HCI buf->data[0] is HCI type.
The header starts from buf->data[1].

Current implementation was overwriting the opcode field in the buffer when updating the hdr->param_len.