### PR TITLE
[nrf fromtree] drivers: gpio_nrfx: Free channel when changing mode

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -444,6 +444,15 @@ static int gpio_nrfx_pin_interrupt_configure(const struct device *port,
 		}
 
 		trigger_config.p_in_channel = &ch;
+	} else {
+		/* If edge mode with channel was previously used and we are changing to sense or
+		 * level triggered, we must free the channel.
+		 */
+		err = nrfx_gpiote_channel_get(&cfg->gpiote, abs_pin, &ch);
+		if (err == NRFX_SUCCESS) {
+			err = nrfx_gpiote_channel_free(&cfg->gpiote, ch);
+			__ASSERT_NO_MSG(err == NRFX_SUCCESS);
+		}
 	}
 
 	err = nrfx_gpiote_input_configure(&cfg->gpiote, abs_pin, &input_pin_config);


### PR DESCRIPTION
Fix an issue where calling gpio_pin_interrupt_configure with edge mode and later calling it with level mode, did not release the allocated gpiote channel.

Repeating the above sequence caused us to run out of gpiote channels.


(cherry picked from commit 581f75656d01f37aec6280326a1924d7d80f2d30)