### PR TITLE
[nrf fromlist] soc: nordic: nrf54l: add Kconfig to control whether to…

### DIFF
--- a/modules/hal_nordic/nrfx/CMakeLists.txt
+++ b/modules/hal_nordic/nrfx/CMakeLists.txt
@@ -197,6 +197,7 @@ endif()
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_SKIP_CLOCK_CONFIG NRF_SKIP_CLOCK_CONFIGURATION)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_DISABLE_FICR_TRIMCNF NRF_DISABLE_FICR_TRIMCNF)
 zephyr_compile_definitions_ifdef(CONFIG_SOC_NRF54LX_SKIP_GLITCHDETECTOR_DISABLE NRF_SKIP_GLITCHDETECTOR_DISABLE)
+zephyr_compile_definitions_ifndef(CONFIG_SOC_NRF54L_ANOMALY_56_WORKAROUND NRF54L_CONFIGURATION_56_ENABLE=0)
 
 # Inject code to skip TAMPC setup for nRF54L20 and nRF54L09. It is not supported for now.
 # It needs to be removed when support is provided.

--- a/soc/nordic/nrf54l/Kconfig
+++ b/soc/nordic/nrf54l/Kconfig
@@ -92,4 +92,10 @@ config SOC_NRF_FORCE_CONSTLAT
 	  of base resources on while in sleep. The advantage of having a constant
 	  and predictable latency will be at the cost of having increased power consumption.
 
+config SOC_NRF54L_ANOMALY_56_WORKAROUND
+	bool "Apply workaround 56 for nRF54L SoCs"
+	default y
+	help
+	   This option enables configuration workaround 56 for nRF54L Series SoCs.
+
 endif # SOC_SERIES_NRF54LX


### PR DESCRIPTION
… apply Errata 56

Adds config option that allows configuration workaround 56.

### Upstream
Upstream PR #: 92315
https://github.com/zephyrproject-rtos/zephyr/pull/92315