### PR TITLE
[nrf fromtree] tests: spi: loopback: use CONFIG_ZTEST_STACK_SIZE for …

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -693,7 +693,8 @@ ZTEST(spi_loopback, test_spi_word_size_32)
 				    sizeof(buffer_tx_32), &spec_copies[4], 32);
 }
 
-static K_THREAD_STACK_DEFINE(thread_stack[3], 512);
+static K_THREAD_STACK_DEFINE(thread_stack[3], CONFIG_ZTEST_STACK_SIZE +
+					      CONFIG_TEST_EXTRA_STACK_SIZE);
 static struct k_thread thread[3];
 
 static K_SEM_DEFINE(thread_sem, 0, 3);


### PR DESCRIPTION
…thread stacks

The spi_loopback test suite creates three internal threads. The stack sizes for these threads is hardcoded to 512, which is to little for some socs, namely the nrf54h20 cpuapp if pm device runtime is enabled. Instead, determine the stack sizes the same way ztest stack sizes are determined.


(cherry picked from commit 5163b8c96aee6922a90cd3f7f11e80d2e82f1235)