### PR TITLE
[nrf fromlist] Spim custom frequencies downstream

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -170,11 +170,14 @@ static inline void finalize_spi_transaction(const struct device *dev, bool deact
 
 static inline uint32_t get_nrf_spim_frequency(uint32_t frequency)
 {
+	if (NRF_SPIM_HAS_PRESCALER) {
+		return frequency;
+	}
 	/* Get the highest supported frequency not exceeding the requested one.
 	 */
-	if (frequency >= MHZ(32) && (NRF_SPIM_HAS_32_MHZ_FREQ || NRF_SPIM_HAS_PRESCALER)) {
+	if (frequency >= MHZ(32) && NRF_SPIM_HAS_32_MHZ_FREQ) {
 		return MHZ(32);
-	} else if (frequency >= MHZ(16) && (NRF_SPIM_HAS_16_MHZ_FREQ || NRF_SPIM_HAS_PRESCALER)) {
+	} else if (frequency >= MHZ(16) && NRF_SPIM_HAS_16_MHZ_FREQ) {
 		return MHZ(16);
 	} else if (frequency >= MHZ(8)) {
 		return MHZ(8);

--- a/tests/drivers/spi/spi_controller_peripheral/boards/1m333333hz.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/1m333333hz.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dut_spi_dt {
+	spi-max-frequency = <1333333>;
+};

--- a/tests/drivers/spi/spi_controller_peripheral/boards/2m666666hz.overlay
+++ b/tests/drivers/spi/spi_controller_peripheral/boards/2m666666hz.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&dut_spi_dt {
+	spi-max-frequency = <2666666>;
+};

--- a/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
+++ b/tests/drivers/spi/spi_controller_peripheral/testcase.yaml
@@ -45,6 +45,22 @@ tests:
     integration_platforms:
       - nrf52840dk/nrf52840
 
+  drivers.spi.spi_1M333333Hz:
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=0
+    extra_args: EXTRA_DTC_OVERLAY_FILE="boards/1m333333hz.overlay"
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+
+  drivers.spi.spi_2M666666Hz:
+    extra_configs:
+      - CONFIG_TESTED_SPI_MODE=0
+    extra_args: EXTRA_DTC_OVERLAY_FILE="boards/2m666666hz.overlay"
+    integration_platforms:
+      - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54h20dk/nrf54h20/cpuapp
+
   drivers.spi.spi_4MHz:
     extra_configs:
       - CONFIG_TESTED_SPI_MODE=2


### PR DESCRIPTION
Disabled spim frequency approximation algorithm when device has prescaler