### PR TITLE
[nrf noup] boards: xiao_ble: Add static partition manager configuration

### DIFF
--- a/boards/seeed/xiao_ble/pm_static.yml
+++ b/boards/seeed/xiao_ble/pm_static.yml
@@ -1,0 +1,18 @@
+# Mirror of partitions defined in nrf52840_partition_uf2_sdv7.dtsi
+# Default flash layout for nrf52840 using UF2 and SoftDevice s140 v7
+
+softdevice_reserved:
+  address: 0x00
+  size: 0x27000
+
+app:
+  address: 0x27000
+  size: 0xC5000
+
+settings_storage:
+  address: 0xEC000
+  size: 0x8000
+
+uf2_partition:
+  address: 0xF4000
+  size: 0xC000


### PR DESCRIPTION
The xiao_ble boards ship with a bootloader requiring an app offset of 0x27000. 
The upstream board defines this via DT partitions, which will not be used if partition manager is enabled.
Add a static partition configuration to allow binaries built for this board to work out-of-the-box in NCS, and match the behavior with sysbuild disabled.

The partitions match https://github.com/nrfconnect/sdk-zephyr/blob/main/dts/vendor/nordic/nrf52840_partition_uf2_sdv7.dtsi which is included by https://github.com/nrfconnect/sdk-zephyr/blob/main/boards/seeed/xiao_ble/xiao_ble_common.dtsi#L9