### PR TITLE
[nrf noup] ci: Add static entry for NRF Kconfig path

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -483,7 +483,21 @@ class KconfigCheck(ComplianceTest):
                     re.sub('[^a-zA-Z0-9]', '_', module).upper(),
                     modules_dir / module / 'Kconfig'
                 ))
+            # Add NRF as static entry as workaround for ext Kconfig root support
+            fp_module_file.write("ZEPHYR_NRF_KCONFIG = {}\n".format(
+                nrf_modules_dir / '..' / 'Kconfig.nrf'
+            ))
             fp_module_file.write(content)
+
+        with open(sysbuild_modules_file, 'r') as fp_sysbuild_module_file:
+            content = fp_sysbuild_module_file.read()
+
+        with open(sysbuild_modules_file, 'w') as fp_sysbuild_module_file:
+            # Add NRF as static entry as workaround for ext Kconfig root support
+            fp_sysbuild_module_file.write("SYSBUILD_NRF_KCONFIG = {}\n".format(
+                nrf_modules_dir / '..' / 'sysbuild' / 'Kconfig.sysbuild'
+            ))
+            fp_sysbuild_module_file.write(content)
 
     def get_kconfig_dts(self, kconfig_dts_file, settings_file):
         """

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1253,6 +1253,7 @@ class SysbuildKconfigCheck(KconfigCheck):
         "DTM_NO_DFE", # Used by DTM application
         "DTM_TRANSPORT_HCI", # Used by DTM application
         "INCLUDE_REMOTE_IMAGE", # Used by machine learning application
+        "MCUBOOT_FPROTECT_ALLOW_COMBINED_REGIONS", # Used in migration documentation
         "ML_APP_INCLUDE_REMOTE_IMAGE", # Used by machine learning application
         "ML_APP_REMOTE_BOARD", # Used by machine learning application
         "MY_APP_IMAGE_ABC", # Used in documentation


### PR DESCRIPTION
nrf-squash! [nrf noup] ci: set `ZEPHYR_<MODULE_NAME>_KCONFIG` for NCS modules

Adds a static path for the NRF Kconfig variable in the check compliance script, this is a temporary workaround due to supporting an external root for NCS that should be reworked to use package helper in future

manifest-pr-skip