### PR TITLE
[nrf noup] drivers: entropy: Add nRF7120 to fake entropy nRF PRNG driver

### DIFF
--- a/drivers/entropy/Kconfig.nrf_prng
+++ b/drivers/entropy/Kconfig.nrf_prng
@@ -9,7 +9,7 @@ config FAKE_ENTROPY_NRF_PRNG
 	bool "A fake nRF entropy driver"
 	default y
 	depends on DT_HAS_NORDIC_ENTROPY_PRNG_ENABLED
-	depends on (SOC_SERIES_NRF54HX || SOC_SERIES_NRF92X || SOC_SERIES_NRF54LX)
+	depends on (SOC_SERIES_NRF54HX || SOC_SERIES_NRF92X || SOC_SERIES_NRF54LX || SOC_SERIES_NRF71X)
 	select ENTROPY_HAS_DRIVER
 	help
 	  This is a super simple PRNG driver that can be used on nRF platforms that


### PR DESCRIPTION
This adds nrf7120 device to devices that can use fake entropy since final entropy source is not available yet.

TODO: Remove this commit when proper solution will be available.