### PR TITLE
[nrf fromtree] mgmt: mcumgr: grp: os_mgmt: Add optional boot mode for…

### DIFF
--- a/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
+++ b/include/zephyr/mgmt/mcumgr/grp/os_mgmt/os_mgmt_callbacks.h
@@ -26,6 +26,11 @@ extern "C" {
 struct os_mgmt_reset_data {
 	/** Contains the value of the force parameter. */
 	bool force;
+
+#if defined(CONFIG_MCUMGR_GRP_OS_RESET_BOOT_MODE) || defined(__DOXYGEN__)
+	/** Contains the value of the boot_mode parameter. */
+	uint8_t boot_mode;
+#endif
 };
 
 /**

--- a/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/os_mgmt/Kconfig
@@ -43,6 +43,14 @@ config MCUMGR_GRP_OS_RESET_HOOK
 	  and will allow the application to perform any required operations
 	  before accepting or declining the reset request.
 
+config MCUMGR_GRP_OS_RESET_BOOT_MODE
+	bool "Boot mode"
+	depends on RETENTION_BOOT_MODE
+	help
+	  Allows applications to set the boot mode using the retention boot mode module which
+	  allows for booting other images e.g. as part of a bootloader. This is done with an
+	  optional field in the reset command which specifies the value of the boot mode.
+
 endif
 
 config MCUMGR_GRP_OS_TASKSTAT


### PR DESCRIPTION
… reset

Adds an optional boot mode field which can be used to boot into a specific image or mode using MCUmgr's OS mgmt reset command


(cherry picked from commit 0adcf2e66d2f0ea6fcca179921c6755ccfc2bf15)