### PR TITLE
[nrf fromlist] boards: nordic: nrf54l15dk: Add button/LED aliases

### DIFF
--- a/boards/nordic/nrf54l15dk/nrf54l_05_10_15_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l_05_10_15_cpuapp_common.dtsi
@@ -20,6 +20,11 @@
 		zephyr,ieee802154 = &ieee802154;
 		zephyr,boot-mode = &boot_mode0;
 	};
+
+	aliases {
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
+	};
 };
 
 &cpuapp_sram {


### PR DESCRIPTION
Adds aliases so that these devices can use MCUboot serial recovery

Upstream PR #: 93090