### PR TITLE
[nrf fromtree] tests: kernel: timer: timer_behavior: Fix max_stddev c…

### DIFF
--- a/tests/kernel/timer/timer_behavior/src/jitter_drift.c
+++ b/tests/kernel/timer/timer_behavior/src/jitter_drift.c
@@ -237,8 +237,8 @@ static void do_test_using(void (*sample_collection_fn)(void), const char *mechan
 		- expected_time_drift_us;
 	double time_diff_us_abs = time_diff_us >= 0.0 ? time_diff_us : -time_diff_us;
 
-	/* If max stddev is lower than a single clock cycle then round it up. */
-	uint32_t max_stddev = MAX(k_cyc_to_us_ceil32(1), CONFIG_TIMER_TEST_MAX_STDDEV);
+	/* If max stddev is lower than a single clock tick then round it up. */
+	uint32_t max_stddev = MAX(k_ticks_to_us_ceil32(1), CONFIG_TIMER_TEST_MAX_STDDEV);
 
 	TC_PRINT("timer clock rate %u, kernel tick rate %d\n",
 		 sys_clock_hw_cycles_per_sec(), CONFIG_SYS_CLOCK_TICKS_PER_SEC);


### PR DESCRIPTION
…alculation

max_stddev calculation was previously patched to be more at least 1 system clock cycle to cover for platforms that use higher frequency system clock (32kHz). On that platform (nRF52) system clock frequency was the same as tick frequency but on nRF54x that is no longer true. Initially, the intention was to use 1 system tick and not cycle. Fixing it now.


(cherry picked from commit 26fe43dd363838e6cfe9c928e72c2af481b84e47)