### PR TITLE
[nrf fromlist] nrf_wifi: Fix the DTS compat for nRF71

### DIFF
--- a/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
+++ b/drivers/wifi/nrf_wifi/Kconfig.nrfwifi
@@ -6,7 +6,7 @@
 #
 
 # TODO: Use DTS generated Kconfig once the board support is added
-DT_COMPAT_NORDIC_WIFI71 := nordic,wifi71
+DT_COMPAT_NORDIC_WIFI71 := nordic,nrf7120
 
 menuconfig WIFI_NRF70
 	bool "nRF70 driver"

--- a/modules/nrf_wifi/bus/Kconfig
+++ b/modules/nrf_wifi/bus/Kconfig
@@ -10,7 +10,7 @@ DT_COMPAT_NORDIC_NRF7001_QSPI := nordic,nrf7001-qspi
 DT_COMPAT_NORDIC_NRF7001_SPI := nordic,nrf7001-spi
 DT_COMPAT_NORDIC_NRF7000_QSPI := nordic,nrf7000-qspi
 DT_COMPAT_NORDIC_NRF7000_SPI := nordic,nrf7000-spi
-DT_COMPAT_NORDIC_WIFI71 := nordic,wifi71
+DT_COMPAT_NORDIC_WIFI71 := nordic,nrf7120
 
 menuconfig NRF70_BUSLIB
 	bool "NRF70 Bus Library"


### PR DESCRIPTION
Use specific chipset for compat instead of a generic Series.

Upstream PR #: 93567