### PR TITLE
[nrf fromlist] soc: nordic: ironside: dvfs: check abb analog status m…

### DIFF
--- a/soc/nordic/ironside/Kconfig
+++ b/soc/nordic/ironside/Kconfig
@@ -65,11 +65,12 @@ config NRF_IRONSIDE_DVFS_SERVICE
 
 if NRF_IRONSIDE_DVFS_SERVICE
 
-config NRF_IRONSIDE_DVFS_OPPOINT_CHANGE_MUTEX_TIMEOUT_MS
-	int "IRONSside DVFS change oppoint mutex timeout"
-	default 100
+config NRF_IRONSIDE_ABB_STATUSANA_CHECK_MAX_ATTEMPTS
+	int "IRONSside DVFS ABB analog status check maximum attempts"
+	range 0 255
+	default 50
 	help
-	  Maximum timeout when waiting for DVFS oppoint change mutex lock.
+	  Maximum attempts with 10us intervals before busy status will be reported.
 
 endif # NRF_IRONSIDE_DVFS_SERVICE
 

--- a/soc/nordic/ironside/Kconfig
+++ b/soc/nordic/ironside/Kconfig
@@ -69,7 +69,7 @@ config NRF_IRONSIDE_DVFS_OPPOINT_CHANGE_MUTEX_TIMEOUT_MS
 	int "IRONSside DVFS change oppoint mutex timeout"
 	default 100
 	help
-	  Maximum tiemout when waiting for DVFS oppoint change mutex lock.
+	  Maximum timeout when waiting for DVFS oppoint change mutex lock.
 
 endif # NRF_IRONSIDE_DVFS_SERVICE
 


### PR DESCRIPTION
…ore than once

Added ABB analog status lock read retries if needed. After cpu idle ABB macro may need some time to initialize and report status locked. Attempts cound can be configured using Kconfig option.

Upstream PR #: 93595