### PR TITLE
[nrf fromlist] drivers: hwinfo: nrf: extend supported reset reasons

### DIFF
--- a/drivers/hwinfo/hwinfo_nrf.c
+++ b/drivers/hwinfo/hwinfo_nrf.c
@@ -207,6 +207,15 @@ int z_impl_hwinfo_get_supported_reset_cause(uint32_t *supported)
 		      | RESET_SOFTWARE
 		      | RESET_CPU_LOCKUP
 		      | RESET_LOW_POWER_WAKE
+#if NRFX_RESET_REASON_HAS_VBUS
+		      | RESET_POR
+#endif
+#if NRFX_RESET_REASON_HAS_GRTC
+		      | RESET_CLOCK
+#endif
+#if defined(NRFX_RESET_REASON_TAMPC_MASK) || defined(NRFX_RESET_REASON_SECTAMPER_MASK)
+		      | RESET_SECURITY
+#endif
 		      | RESET_DEBUG);
 
 	return 0;


### PR DESCRIPTION
Added missing supported reset reasons based on conditional guards.