### PR TITLE
[nrf noup] bluetooth: host: Allow auto swap feature without privacy

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -633,7 +633,7 @@ config BT_ID_UNPAIR_MATCHING_BONDS
 config BT_ID_AUTO_SWAP_MATCHING_BONDS
 	bool "Automatically swap conflicting entries in the Resolving List"
 	depends on !BT_ID_UNPAIR_MATCHING_BONDS
-	depends on BT_PRIVACY && BT_PERIPHERAL && !BT_CENTRAL
+	depends on BT_SMP && BT_PERIPHERAL && !BT_CENTRAL
 	help
 	  If this option is enabled, the Host will not add a new bond with
 	  the same peer address (or IRK) to the Resolving List if there is


### PR DESCRIPTION
Allow to use CONFIG_BT_ID_AUTO_SWAP_MATCHING_BONDS Kconfig option even if CONFIG_BT_PRIVACY is disabled.

This is because CONFIG_BT_PRIVACY configures privacy of local device will still allows to resolve peer address. During pairing, peer device may send its Identity Address and IRK which then can be used for address resolution. This doesn't require CONFIG_BT_PRIVACY be enabled.

nrf-squash! [nrf noup] bluetooth: host: Add support for bonding with same peer