### PR TITLE
[nrf fromlist] samples: boards: nordic: spis_wakeup: fix boot for h20

### DIFF
--- a/samples/boards/nordic/spis_wakeup/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/samples/boards/nordic/spis_wakeup/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -1,0 +1,4 @@
+# Copyright (c) 2025 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_NRF54H20_CPURAD_ENABLE=y


### PR DESCRIPTION
Explicit start radio core.

Upstream PR #: 93966