### PR TITLE
nrf_hw_models: Update to latest revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -325,7 +325,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 968d55ff22579080466bf2f482596dd6e35361c6
+      revision: 6e5961223f81aa2707c555db138819a5c1b7942c
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 787eea1a3c8dd13c86214e204a919e6f9bcebf91

--- a/west.yml
+++ b/west.yml
@@ -325,7 +325,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: 6e5961223f81aa2707c555db138819a5c1b7942c
+      revision: 8b6001d6bdd9e2c8bb858fdb26f696f6d5f73db5
       path: modules/bsim_hw_models/nrf_hw_models
     - name: nrf_wifi
       revision: 787eea1a3c8dd13c86214e204a919e6f9bcebf91


### PR DESCRIPTION
 Update the HW models module to:
 6e5961223f81aa2707c555db138819a5c1b7942c

Including the following:
    6e59612 CLOCK (52,53): Fix test interface with multiple instances
    ecf2292 54 CRACEN: Improve model
    1277b16 irq controller: Remove out of date comment

    8b6001d CLOCK (54): Fix XOTUNE subscription sideeffecting for nrf54L15
    9af1ac8 nRF54LM20: Bugfix: Add missing UART configuration
    e6af4a7 RADIO: Fix register init for some devices (at least nRF54LM20)
    2fe99ab CLOCK (54): Add XO24M/PLL24M/HFCLK24M
    ffd578a CLOCK (54): Fixes around XOTUNE