### PR TITLE
[nrf fromlist] tests: mbox: Add support for nRF54LM20A

### DIFF
--- a/tests/drivers/mbox/mbox_error_cases/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/mbox/mbox_error_cases/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	mbox-consumer {
+		compatible = "vnd,mbox-consumer";
+		mboxes = <&cpuapp_vevif_tx 21>, <&cpuapp_vevif_tx 32>,
+				 <&cpuapp_vevif_rx 20>, <&cpuapp_vevif_rx 32>;
+		mbox-names = "remote_valid", "remote_incorrect",
+					 "local_valid", "local_incorrect";
+
+	};
+};
+
+&cpuapp_vevif_rx {
+	status = "okay";
+};
+
+&cpuapp_vevif_tx {
+	status = "okay";
+};

--- a/tests/drivers/mbox/mbox_error_cases/sample.yaml
+++ b/tests/drivers/mbox/mbox_error_cases/sample.yaml
@@ -17,8 +17,10 @@ tests:
   tests.drivers.mbox_error_cases.nrf54l:
     platform_allow:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
     integration_platforms:
       - nrf54l15dk/nrf54l15/cpuapp
+      - nrf54lm20dk/nrf54lm20a/cpuapp
       - ophelia4ev/nrf54l15/cpuapp
     extra_args: SNIPPET=nordic-flpr

--- a/tests/drivers/mbox/mbox_error_cases/src/main.c
+++ b/tests/drivers/mbox/mbox_error_cases/src/main.c
@@ -11,7 +11,8 @@
 int dummy_value;
 
 #if defined(CONFIG_SOC_NRF54L05) || defined(CONFIG_SOC_NRF54L10) || \
-	defined(CONFIG_SOC_NRF54L15) || defined(CONFIG_SOC_NRF54H20)
+	defined(CONFIG_SOC_NRF54L15) || defined(CONFIG_SOC_NRF54H20) || \
+	defined(CONFIG_SOC_NRF54LM20A)
 #define EXPECTED_MTU_VALUE				(0)
 #define DATA_TRANSFER_MODE_SUPPORTED	(0)
 #define REMOTE_BUSY_SUPPORTED			(0)


### PR DESCRIPTION
Extend test coverage with new test.

Upstream PR #: 94110