### PR TITLE
[nrf fromlist] drivers: spi: nrfx: release constlat mode on suspend

### DIFF
--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -806,7 +806,7 @@ static void spim_suspend(const struct device *dev)
 #if SPIM_CROSS_DOMAIN_PINS_HANDLE
 		int err;
 
-		err = nrf_sys_event_request_global_constlat();
+		err = nrf_sys_event_release_global_constlat();
 		(void)err;
 		__ASSERT_NO_MSG(err >= 0);
 #else

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -451,7 +451,7 @@ static void spi_nrfx_suspend(const struct device *dev)
 #if SPIS_CROSS_DOMAIN_PINS_HANDLE
 		int err;
 
-		err = nrf_sys_event_request_global_constlat();
+		err = nrf_sys_event_release_global_constlat();
 		(void)err;
 		__ASSERT_NO_MSG(err >= 0);
 #else


### PR DESCRIPTION
Release instead of requesting constant latency mode on SPI suspend.

Upstream PR #: 94153