### PR TITLE
[nrf fromlist] openthread: Use OPENTHREAD instead of L2_OPENTHREAD in…

### DIFF
--- a/modules/mbedtls/Kconfig.mbedtls
+++ b/modules/mbedtls/Kconfig.mbedtls
@@ -485,7 +485,7 @@ config MBEDTLS_ENTROPY_POLL_ZEPHYR
 
 config MBEDTLS_OPENTHREAD_OPTIMIZATIONS_ENABLED
 	bool "MbedTLS optimizations for OpenThread"
-	depends on NET_L2_OPENTHREAD
+	depends on OPENTHREAD
 	default y if !NET_SOCKETS_SOCKOPT_TLS
 	help
 	  Enable some OpenThread specific mbedTLS optimizations that allows to

--- a/subsys/logging/backends/Kconfig.spinel
+++ b/subsys/logging/backends/Kconfig.spinel
@@ -4,7 +4,7 @@
 config LOG_BACKEND_SPINEL
 	bool "OpenThread dedicated Spinel protocol backend"
 	depends on !LOG_BACKEND_UART
-	depends on NET_L2_OPENTHREAD
+	depends on OPENTHREAD
 	help
 	  When enabled, backend will use OpenThread dedicated SPINEL protocol for logging.
 	  This protocol is byte oriented and wraps given messages into serial frames.


### PR DESCRIPTION
… dependencies

Update Kconfig dependencies in mbedTLS and logging backend to use OPENTHREAD instead of NET_L2_OPENTHREAD.

Upstream PR #: 94054