### PR TITLE
[nrf fromlist] boards: nordic: nrf54h20dk:…

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -264,14 +264,14 @@ slot3_partition: &cpurad_slot1_partition {
 };
 
 &gpio6 {
-	status = "okay";
+	status = "disabled";
 };
 
 &exmif {
 	pinctrl-0 = <&exmif_default>;
 	pinctrl-1 = <&exmif_sleep>;
 	pinctrl-names = "default", "sleep";
-	status = "okay";
+	status = "disabled";
 
 	mx25uw63: mx25uw6345g@0 {
 		compatible = "mxicy,mx25u", "jedec,mspi-nor";

--- a/samples/drivers/jesd216/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/jesd216/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -4,6 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&gpio6 {
+	status = "okay";
+	zephyr,pm-device-runtime-auto;
+};
+
+&exmif {
+	status = "okay";
+	zephyr,pm-device-runtime-auto;
+};
+
 &mx25uw63 {
 	status = "okay";
 };

--- a/samples/drivers/spi_flash/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/drivers/spi_flash/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -4,6 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&gpio6 {
+	status = "okay";
+	zephyr,pm-device-runtime-auto;
+};
+
+&exmif {
+	status = "okay";
+	zephyr,pm-device-runtime-auto;
+};
+
 &mx25uw63 {
 	status = "okay";
 };

--- a/tests/drivers/flash/common/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/flash/common/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -4,6 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+&gpio6 {
+	status = "okay";
+	zephyr,pm-device-runtime-auto;
+};
+
+&exmif {
+	status = "okay";
+	zephyr,pm-device-runtime-auto;
+};
+
 &mx25uw63 {
 	status = "okay";
 };


### PR DESCRIPTION
… Disable EXMIF and GPIO6 by default

External flash memory is typically not used, so it should be disabled by default. The GPIO6 port used by this device should also be disabled.

Upstream PR #: 94180