### PR TITLE
[Backport ncs-v3.1-branch] [nrf fromlist] drivers: nrf_wifi: Add check for minimum RX buffer size

### DIFF
--- a/drivers/wifi/nrf_wifi/src/fmac_main.c
+++ b/drivers/wifi/nrf_wifi/src/fmac_main.c
@@ -79,6 +79,8 @@ BUILD_ASSERT(CONFIG_NRF70_TX_MAX_DATA_SIZE % 4 == 0,
 	"TX buffer size must be a multiple of 4");
 BUILD_ASSERT(CONFIG_NRF70_RX_MAX_DATA_SIZE % 4 == 0,
 	"RX buffer size must be a multiple of 4");
+BUILD_ASSERT(CONFIG_NRF70_RX_MAX_DATA_SIZE >= 400,
+	"RX buffer size must be at least 400 bytes");
 
 static const unsigned char aggregation = 1;
 static const unsigned char max_num_tx_agg_sessions = 4;


### PR DESCRIPTION
Add check for the RX data buffer size. It should be atleast 400 bytes, anthing less than that scan fails.

Upstream PR #: 94106


(cherry picked from commit 39a962774d40381bdd99f94f7efa14c102035434)