### PR TITLE
soc: nrf54l: Change logic for KMU reserved area

### DIFF
--- a/soc/nordic/nrf54l/CMakeLists.txt
+++ b/soc/nordic/nrf54l/CMakeLists.txt
@@ -7,10 +7,12 @@ zephyr_library_sources(
   )
 zephyr_include_directories(.)
 
+dt_nodelabel(kmu_push_area_node NODELABEL nrf_kmu_reserved_push_area)
+
 # We need a buffer in memory in a static location which can be used by
 # the KMU peripheral. The KMU has a static destination address, we chose
 # this address to be 0x20000000, which is the first address in the SRAM.
-if(NOT CONFIG_BUILD_WITH_TFM AND CONFIG_PSA_NEED_CRACEN_KMU_DRIVER AND CONFIG_XIP)
+if(NOT CONFIG_BUILD_WITH_TFM AND CONFIG_PSA_NEED_CRACEN_KMU_DRIVER AND NOT kmu_push_area_node)
 # Exclamation mark is printable character with the lowest number in ASCII table.
 # We are sure that this file will be included first.
 zephyr_linker_sources(RAM_SECTIONS SORT_KEY ! kmu_push_area_section.ld)


### PR DESCRIPTION
nrf-squash! [nrf noup] soc: nrf54l: Add custom section for KMU

Change how the KMU reserved area is included in the linker file. Now there is a separate Kconfig which shows it the there is a dts entry for the KMU
reserved area.