### PR TITLE
[nrf fromlist] scripts: fix get_module_setting_root in compliance check

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -88,17 +88,15 @@ def get_module_setting_root(root, settings_file):
     # Invoke the script directly using the Python executable since this is
     # not a module nor a pip-installed Python utility
     root_paths = []
-
     if os.path.exists(settings_file):
         with open(settings_file, 'r') as fp_setting_file:
             content = fp_setting_file.read()
 
         lines = content.strip().split('\n')
         for line in lines:
-            root = root.upper()
-            if line.startswith(f'"{root}_ROOT":'):
+            if line.lstrip().startswith(f'{root}_root:'):
                 _, root_path = line.split(":", 1)
-                root_paths.append(Path(root_path.strip('"')))
+                root_paths.append(Path(root_path.strip()))
     return root_paths
 
 def get_vendor_prefixes(path, errfn = print) -> set[str]:


### PR DESCRIPTION
root settings in zephyr/module.yml are in lower case and without quotes, as seen in following example:
```build:
  settings:
    board_root: .
    dts_root: .
```

remove the `upper()` call and change `_ROOT` --> `_root`. Also remove the not needed `"` stripping.

Upstream PR #: 94343