### PR TITLE
diag: Fix exiting diag when transmission is ongoing

### DIFF
--- a/modules/openthread/platform/diag.c
+++ b/modules/openthread/platform/diag.c
@@ -92,18 +92,25 @@ otError otPlatDiagProcess(otInstance *aInstance, uint8_t aArgsLength, char *aArg
 	return OT_ERROR_NOT_IMPLEMENTED;
 }
 
+static void log_error_returned(otError aError, const char * aName)
+{
+	if (aError != OT_ERROR_NONE) {
+		otPlatLog(OT_LOG_LEVEL_WARN, OT_LOG_REGION_PLATFORM,
+				  "%s failed (%d)", aName, aError);
+	}		
+}
+
 void otPlatDiagModeSet(bool aMode)
 {
-	otError error;
-
 	sDiagMode = aMode;
 
 	if (!sDiagMode) {
-		error = otPlatRadioSleep(NULL);
-		if (error != OT_ERROR_NONE) {
-			otPlatLog(OT_LOG_LEVEL_WARN, OT_LOG_REGION_PLATFORM,
-				  "%s failed (%d)", "otPlatRadioSleep", error);
+		if(OT_RADIO_STATE_TRANSMIT == otPlatRadioGetState(NULL)) {
+			log_error_returned(otPlatRadioReceive(NULL, sChannel), 
+							   "otPlatRadioReceive");
 		}
+
+		log_error_returned(otPlatRadioSleep(NULL), "otPlatRadioSleep");
 	}
 }
 
@@ -355,7 +362,6 @@ static otError startModCarrier(otInstance *aInstance, uint8_t aArgsLength, char 
 void otPlatDiagAlarmCallback(otInstance *aInstance)
 {
 	uint32_t now;
-	otError error;
 	otRadioFrame *txPacket;
 	const uint16_t diag_packet_len = 30;
 
@@ -381,11 +387,8 @@ void otPlatDiagAlarmCallback(otInstance *aInstance)
 				txPacket->mPsdu[i] = i;
 			}
 
-			error = otPlatRadioTransmit(aInstance, txPacket);
-			if (error != OT_ERROR_NONE) {
-				otPlatLog(OT_LOG_LEVEL_WARN, OT_LOG_REGION_PLATFORM,
-					  "%s failed (%d)", "otPlatRadioTransmit", error);
-			}
+			log_error_returned(otPlatRadioTransmit(aInstance, txPacket), 
+						 	   "otPlatRadioTransmit");
 
 			if (sTxCount != -1) {
 				sTxCount--;
@@ -421,10 +424,7 @@ static otError processTransmit(otInstance *aInstance, uint8_t aArgsLength, char 
 		diag_output("diagnostic message transmission is stopped\r\n");
 		sTransmitMode = DIAG_TRANSMIT_MODE_IDLE;
 		error = otPlatRadioReceive(aInstance, sChannel);
-		if (error != OT_ERROR_NONE) {
-			otPlatLog(OT_LOG_LEVEL_WARN, OT_LOG_REGION_PLATFORM,
-				  "%s failed (%d)", "otPlatRadioReceive", error);
-		}
+		log_error_returned(error, "otPlatRadioReceive");
 	} else if (strcmp(aArgs[0], "start") == 0) {
 		if (sTransmitMode != DIAG_TRANSMIT_MODE_IDLE) {
 			return OT_ERROR_INVALID_STATE;

--- a/modules/openthread/platform/radio.c
+++ b/modules/openthread/platform/radio.c
@@ -809,6 +809,11 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 	radio_api->start(radio_dev);
 	sState = OT_RADIO_STATE_RECEIVE;
 
+	if(is_pending_event_set(PENDING_EVENT_TX_DONE))
+	{
+		reset_pending_event(PENDING_EVENT_TX_DONE);
+	}
+
 	return OT_ERROR_NONE;
 }
 


### PR DESCRIPTION
Crash was observed if "diag stop" was invoked during the transmission. The issue was sacused by an update to otPlatRadioSleep that made it compilant with the documentation and not allowing direct Transmeet to sleep transition.
The transmission result was forwarded to OpenThread making it crash due to an invalid state.