### PR TITLE
[nrf noup] tests: crypto: Add ENTROPY_GENERATOR in overlays

### DIFF
--- a/tests/crypto/mbedtls_psa/boards/nrf54l05dk_nrf54l05_cpuapp.conf
+++ b/tests/crypto/mbedtls_psa/boards/nrf54l05dk_nrf54l05_cpuapp.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_ENTROPY_GENERATOR=y

--- a/tests/crypto/mbedtls_psa/boards/nrf54l15dk_nrf54l10_cpuapp.conf
+++ b/tests/crypto/mbedtls_psa/boards/nrf54l15dk_nrf54l10_cpuapp.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_ENTROPY_GENERATOR=y

--- a/tests/crypto/mbedtls_psa/boards/nrf54l15dk_nrf54l15_cpuapp.conf
+++ b/tests/crypto/mbedtls_psa/boards/nrf54l15dk_nrf54l15_cpuapp.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_ENTROPY_GENERATOR=y

--- a/tests/crypto/mbedtls_psa/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
+++ b/tests/crypto/mbedtls_psa/boards/nrf54lm20dk_nrf54lm20a_cpuapp.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_ENTROPY_GENERATOR=y

--- a/tests/crypto/mbedtls_psa/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
+++ b/tests/crypto/mbedtls_psa/boards/nrf54lv10dk_nrf54lv10a_cpuapp.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2024 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+#
+CONFIG_ENTROPY_GENERATOR=y


### PR DESCRIPTION
Add ENTROPY_GENERATOR=y in overlays for l series devices. This fixes an error where a trng source is not included in ncs.

I attempted to fix this without an ugly noup here: https://github.com/nrfconnect/sdk-nrf/commit/8479106bf17e1fdcd06c1d8af8e92a7ec87be9ce, but this causes regressions in `benchmarks.current_consumption.systemoff.grtc_wakeup` and `tests/drivers/uart/uart_mix_fifo_poll/drivers.uart.uart_mix_poll_fifo`. The issue here is with the mismatch between how zephyr handles including the rng and how it is handled in NCS. In NCS the assumption is made that when required it is enabled explicitly, while in zephyr it is implicitly enabled  as long as it exists in the device tree. In the L series the assumption is also made that rng will not be called inside an interrupt as it owns and uses its own mutexes. The easiest way to handle this then was with these overlays as a noup. 