### PR TITLE
[nrf fromtree] boards: nordic: nrf54lm20dk: Extend ext memory node wi…

### DIFF
--- a/boards/nordic/nrf54lm20dk/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20a_cpuapp_common.dtsi
@@ -166,5 +166,6 @@ zephyr_udc0: &usbhs {
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <35000>;
+		reset-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 	};
 };


### PR DESCRIPTION
…th reset GPIO

Extend external memory node with 'reset-gpios' property.