### PR TITLE
[Backport ncs-v3.1-branch] [nrf fromlist] soc: nordic: Use default SYS_CLOCK_TICKS_PER_SEC for P…

### DIFF
--- a/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuppr
+++ b/soc/nordic/nrf54h/Kconfig.defconfig.nrf54h20_cpuppr
@@ -6,8 +6,6 @@ if SOC_NRF54H20_CPUPPR
 config NUM_IRQS
 	default 496
 
-config SYS_CLOCK_TICKS_PER_SEC
-	default 1000
 #
 # As PPR has limited memory most of tests does not fit with asserts enabled.
 config ASSERT

--- a/soc/nordic/nrf92/Kconfig.defconfig.nrf9280_cpuppr
+++ b/soc/nordic/nrf92/Kconfig.defconfig.nrf9280_cpuppr
@@ -6,9 +6,6 @@ if SOC_NRF9280_CPUPPR
 config NUM_IRQS
 	default 496
 
-config SYS_CLOCK_TICKS_PER_SEC
-	default 1000
-
 config RV_BOOT_HART
 	default 13 if SOC_NRF9230_ENGB
 


### PR DESCRIPTION
Backport https://github.com/nrfconnect/sdk-zephyr/commit/e78ab1d9e5814a0043b5fbfa8359fd021ec1f8fe from https://github.com/nrfconnect/sdk-zephyr/pull/3176.