### PR TITLE
[nrf noup] zms: Fix undeclared variable error

### DIFF
--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -78,17 +78,6 @@ struct zms_fs {
  */
 
 /**
- * @brief ID type used in the ZMS API.
- *
- * @note The width of this type depends on @kconfig{CONFIG_ZMS_ID_64BIT}.
- */
-#if CONFIG_ZMS_ID_64BIT
-typedef uint64_t zms_id_t;
-#else
-typedef uint32_t zms_id_t;
-#endif
-
-/**
  * @brief Mount a ZMS file system onto the device specified in `fs`.
  *
  * @param fs Pointer to the file system.
@@ -138,7 +127,7 @@ int zms_clear(struct zms_fs *fs);
  * @retval -EINVAL if `len` is invalid.
  * @retval -ENOSPC if no space is left on the device.
  */
-ssize_t zms_write(struct zms_fs *fs, zms_id_t id, const void *data, size_t len);
+ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len);
 
 /**
  * @brief Delete an entry from the file system
@@ -151,7 +140,7 @@ ssize_t zms_write(struct zms_fs *fs, zms_id_t id, const void *data, size_t len);
  * @retval -ENXIO if there is a device error.
  * @retval -EIO if there is a memory read/write error.
  */
-int zms_delete(struct zms_fs *fs, zms_id_t id);
+int zms_delete(struct zms_fs *fs, uint32_t id);
 
 /**
  * @brief Read an entry from the file system.
@@ -169,7 +158,7 @@ int zms_delete(struct zms_fs *fs, zms_id_t id);
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given `id`.
  */
-ssize_t zms_read(struct zms_fs *fs, zms_id_t id, void *data, size_t len);
+ssize_t zms_read(struct zms_fs *fs, uint32_t id, void *data, size_t len);
 
 /**
  * @brief Read a history entry from the file system.
@@ -189,7 +178,7 @@ ssize_t zms_read(struct zms_fs *fs, zms_id_t id, void *data, size_t len);
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given `id` and history counter.
  */
-ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, uint32_t cnt);
+ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, uint32_t cnt);
 
 /**
  * @brief Gets the length of the data that is stored in an entry with a given `id`
@@ -204,7 +193,7 @@ ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, ui
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given id and history counter.
  */
-ssize_t zms_get_data_length(struct zms_fs *fs, zms_id_t id);
+ssize_t zms_get_data_length(struct zms_fs *fs, uint32_t id);
 
 /**
  * @brief Calculate the available free space in the file system.

--- a/include/zephyr/fs/zms.h
+++ b/include/zephyr/fs/zms.h
@@ -78,6 +78,17 @@ struct zms_fs {
  */
 
 /**
+ * @brief ID type used in the ZMS API.
+ *
+ * @note The width of this type depends on @kconfig{CONFIG_ZMS_ID_64BIT}.
+ */
+#if CONFIG_ZMS_ID_64BIT
+typedef uint64_t zms_id_t;
+#else
+typedef uint32_t zms_id_t;
+#endif
+
+/**
  * @brief Mount a ZMS file system onto the device specified in `fs`.
  *
  * @param fs Pointer to the file system.
@@ -127,7 +138,7 @@ int zms_clear(struct zms_fs *fs);
  * @retval -EINVAL if `len` is invalid.
  * @retval -ENOSPC if no space is left on the device.
  */
-ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len);
+ssize_t zms_write(struct zms_fs *fs, zms_id_t id, const void *data, size_t len);
 
 /**
  * @brief Delete an entry from the file system
@@ -140,7 +151,7 @@ ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len);
  * @retval -ENXIO if there is a device error.
  * @retval -EIO if there is a memory read/write error.
  */
-int zms_delete(struct zms_fs *fs, uint32_t id);
+int zms_delete(struct zms_fs *fs, zms_id_t id);
 
 /**
  * @brief Read an entry from the file system.
@@ -158,7 +169,7 @@ int zms_delete(struct zms_fs *fs, uint32_t id);
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given `id`.
  */
-ssize_t zms_read(struct zms_fs *fs, uint32_t id, void *data, size_t len);
+ssize_t zms_read(struct zms_fs *fs, zms_id_t id, void *data, size_t len);
 
 /**
  * @brief Read a history entry from the file system.
@@ -178,7 +189,7 @@ ssize_t zms_read(struct zms_fs *fs, uint32_t id, void *data, size_t len);
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given `id` and history counter.
  */
-ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, uint32_t cnt);
+ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, uint32_t cnt);
 
 /**
  * @brief Gets the length of the data that is stored in an entry with a given `id`
@@ -193,7 +204,7 @@ ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, ui
  * @retval -EIO if there is a memory read/write error.
  * @retval -ENOENT if there is no entry with the given id and history counter.
  */
-ssize_t zms_get_data_length(struct zms_fs *fs, uint32_t id);
+ssize_t zms_get_data_length(struct zms_fs *fs, zms_id_t id);
 
 /**
  * @brief Calculate the available free space in the file system.

--- a/subsys/fs/zms/Kconfig
+++ b/subsys/fs/zms/Kconfig
@@ -15,6 +15,15 @@ config ZMS
 
 if ZMS
 
+config ZMS_ID_64BIT
+	bool "64 bit ZMS IDs"
+	help
+	  When this option is true, the `zms_id_t` values passed to ZMS APIs will be 64 bit,
+	  as opposed to the default 32 bit.
+	  This option will also change the format of allocation table entries (ATEs) in memory
+	  to accommodate larger IDs. Currently, this will make ZMS unable to mount an existing
+	  file system if it has been initialized with a different ATE format.
+
 config ZMS_LOOKUP_CACHE
 	bool "ZMS lookup cache"
 	help
@@ -33,6 +42,7 @@ config ZMS_LOOKUP_CACHE_SIZE
 
 config ZMS_DATA_CRC
 	bool "ZMS data CRC"
+	depends on !ZMS_ID_64BIT
 
 config ZMS_CUSTOMIZE_BLOCK_SIZE
 	bool "Customize the size of the buffer used internally for reads and writes"
@@ -53,6 +63,7 @@ config ZMS_CUSTOM_BLOCK_SIZE
 config ZMS_LOOKUP_CACHE_FOR_SETTINGS
 	bool "ZMS Storage lookup cache optimized for settings"
 	depends on ZMS_LOOKUP_CACHE && SETTINGS_ZMS
+	depends on !ZMS_ID_64BIT
 	help
 	  Enable usage of lookup cache based on hashes to get, the best ZMS performance,
 	  provided that the ZMS is used only for the purpose of providing the settings

--- a/subsys/fs/zms/Kconfig
+++ b/subsys/fs/zms/Kconfig
@@ -15,15 +15,6 @@ config ZMS
 
 if ZMS
 
-config ZMS_ID_64BIT
-	bool "64 bit ZMS IDs"
-	help
-	  When this option is true, the `zms_id_t` values passed to ZMS APIs will be 64 bit,
-	  as opposed to the default 32 bit.
-	  This option will also change the format of allocation table entries (ATEs) in memory
-	  to accommodate larger IDs. Currently, this will make ZMS unable to mount an existing
-	  file system if it has been initialized with a different ATE format.
-
 config ZMS_LOOKUP_CACHE
 	bool "ZMS lookup cache"
 	help
@@ -42,7 +33,6 @@ config ZMS_LOOKUP_CACHE_SIZE
 
 config ZMS_DATA_CRC
 	bool "ZMS data CRC"
-	depends on !ZMS_ID_64BIT
 
 config ZMS_CUSTOMIZE_BLOCK_SIZE
 	bool "Customize the size of the buffer used internally for reads and writes"

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -13,7 +13,11 @@
 #include <zephyr/sys/crc.h>
 #include "zms_priv.h"
 #ifdef CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS
+#ifdef CONFIG_SETTINGS_ZMS_LEGACY
+#include <settings/settings_zms_legacy.h>
+#else
 #include <settings/settings_zms.h>
+#endif
 #endif
 
 #include <zephyr/logging/log.h>
@@ -32,6 +36,40 @@ static int zms_ate_valid_different_sector(struct zms_fs *fs, const struct zms_at
 static inline size_t zms_lookup_cache_pos(zms_id_t id)
 {
 #ifdef CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS
+#ifdef CONFIG_SETTINGS_ZMS_LEGACY
+	/*
+	 * 1. The ZMS settings backend uses up to (ZMS_NAME_ID_OFFSET - 1) ZMS IDs to
+	      store keys and equal number of ZMS IDs to store values.
+	 * 2. For each key-value pair, the value is stored at ZMS ID greater by exactly
+	 *    ZMS_NAME_ID_OFFSET than ZMS ID that holds the key.
+	 * 3. The backend tries to minimize the range of ZMS IDs used to store keys.
+	 *    That is, ZMS IDs are allocated sequentially, and freed ZMS IDs are reused
+	 *    before allocating new ones.
+	 *
+	 * Therefore, to assure the least number of collisions in the lookup cache,
+	 * the least significant bit of the hash indicates whether the given ZMS ID
+	 * represents a key or a value, and remaining bits of the hash are set to
+	 * the ordinal number of the key-value pair. Consequently, the hash function
+	 * provides the following mapping:
+	 *
+	 * 1st settings key   => hash 0
+	 * 1st settings value => hash 1
+	 * 2nd settings key   => hash 2
+	 * 2nd settings value => hash 3
+	 * ...
+	 */
+	BUILD_ASSERT(IS_POWER_OF_TWO(ZMS_NAMECNT_ID), "ZMS_NAMECNT_ID is not power of 2");
+	BUILD_ASSERT(IS_POWER_OF_TWO(ZMS_NAME_ID_OFFSET), "ZMS_NAME_ID_OFFSET is not power of 2");
+
+	uint32_t key_value_bit;
+	uint32_t key_value_ord;
+	uint32_t hash;
+
+	key_value_bit = (id >> LOG2(ZMS_NAME_ID_OFFSET)) & 1;
+	key_value_ord = id & (ZMS_NAME_ID_OFFSET - 1);
+
+	hash = ((key_value_ord << 1) | key_value_bit);
+#else
 	/*
 	 * 1. Settings subsystem is storing the name ID and the linked list node ID
 	 *    with only one bit difference at BIT(0).
@@ -57,6 +95,7 @@ static inline size_t zms_lookup_cache_pos(zms_id_t id)
 	key_value_ll = id & BIT(0);
 
 	hash = (key_value_hash << 2) | (key_value_bit << 1) | key_value_ll;
+#endif /* CONFIG_SETTINGS_ZMS_LEGACY */
 
 #elif defined(CONFIG_ZMS_ID_64BIT)
 	/* 64-bit integer hash function found by https://github.com/skeeto/hash-prospector. */

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -29,10 +29,8 @@ static int zms_ate_valid_different_sector(struct zms_fs *fs, const struct zms_at
 
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
 
-static inline size_t zms_lookup_cache_pos(uint32_t id)
+static inline size_t zms_lookup_cache_pos(zms_id_t id)
 {
-	uint32_t hash = id;
-
 #ifdef CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS
 	/*
 	 * 1. Settings subsystem is storing the name ID and the linked list node ID
@@ -52,14 +50,27 @@ static inline size_t zms_lookup_cache_pos(uint32_t id)
 	uint32_t key_value_bit;
 	uint32_t key_value_hash;
 	uint32_t key_value_ll;
+	uint32_t hash;
 
 	key_value_bit = (id >> LOG2(ZMS_DATA_ID_OFFSET)) & 1;
 	key_value_hash = (id & ZMS_HASH_MASK) >> (CONFIG_SETTINGS_ZMS_MAX_COLLISIONS_BITS + 1);
 	key_value_ll = id & BIT(0);
 
 	hash = (key_value_hash << 2) | (key_value_bit << 1) | key_value_ll;
+
+#elif defined(CONFIG_ZMS_ID_64BIT)
+	/* 64-bit integer hash function found by https://github.com/skeeto/hash-prospector. */
+	uint64_t hash = id;
+
+	hash ^= hash >> 32;
+	hash *= 0x42ab4abe4c475039ULL;
+	hash ^= hash >> 31;
+	hash *= 0xfa90c4424c537791ULL;
+	hash ^= hash >> 32;
 #else
 	/* 32-bit integer hash function found by https://github.com/skeeto/hash-prospector. */
+	uint32_t hash = id;
+
 	hash ^= hash >> 16;
 	hash *= 0x7feb352dU;
 	hash ^= hash >> 15;
@@ -239,7 +250,7 @@ static int zms_flash_ate_wrt(struct zms_fs *fs, const struct zms_ate *entry)
 		goto end;
 	}
 #ifdef CONFIG_ZMS_LOOKUP_CACHE
-	/* 0xFFFFFFFF is a special-purpose identifier. Exclude it from the cache */
+	/* ZMS_HEAD_ID is a special-purpose identifier. Exclude it from the cache */
 	if (entry->id != ZMS_HEAD_ID) {
 		fs->lookup_cache[zms_lookup_cache_pos(entry->id)] = fs->ate_wra;
 	}
@@ -487,7 +498,7 @@ static bool zms_close_ate_valid(struct zms_fs *fs, const struct zms_ate *entry)
 /* zms_empty_ate_valid validates an sector empty ate.
  * A valid sector empty ate should be:
  * - a valid ate
- * - with len = 0xffff and id = 0xffffffff
+ * - with len = 0xffff and id = ZMS_HEAD_ID
  * return true if valid, false otherwise
  */
 static bool zms_empty_ate_valid(struct zms_fs *fs, const struct zms_ate *entry)
@@ -500,13 +511,25 @@ static bool zms_empty_ate_valid(struct zms_fs *fs, const struct zms_ate *entry)
  * Valid gc_done_ate:
  * - valid ate
  * - len = 0
- * - id = 0xffffffff
+ * - id = ZMS_HEAD_ID
  * return true if valid, false otherwise
  */
 static bool zms_gc_done_ate_valid(struct zms_fs *fs, const struct zms_ate *entry)
 {
 	return (zms_ate_valid_different_sector(fs, entry, entry->cycle_cnt) && (!entry->len) &&
 		(entry->id == ZMS_HEAD_ID));
+}
+
+/* zms_sector_closed checks whether the current sector is closed, which would imply
+ * that the empty ATE and close ATE are both valid and have matching cycle counters
+ *
+ * return true if closed, false otherwise
+ */
+static bool zms_sector_closed(struct zms_fs *fs, struct zms_ate *empty_ate,
+			      struct zms_ate *close_ate)
+{
+	return (zms_empty_ate_valid(fs, empty_ate) && zms_close_ate_valid(fs, close_ate) &&
+		(empty_ate->cycle_cnt == close_ate->cycle_cnt));
 }
 
 /* Read empty and close ATE of the sector where belongs address "addr" and
@@ -526,8 +549,7 @@ static int zms_validate_closed_sector(struct zms_fs *fs, uint64_t addr, struct z
 		return rc;
 	}
 
-	if (zms_empty_ate_valid(fs, empty_ate) && zms_close_ate_valid(fs, close_ate) &&
-	    (empty_ate->cycle_cnt == close_ate->cycle_cnt)) {
+	if (zms_sector_closed(fs, empty_ate, close_ate)) {
 		/* Closed sector validated */
 		return 1;
 	}
@@ -536,7 +558,7 @@ static int zms_validate_closed_sector(struct zms_fs *fs, uint64_t addr, struct z
 }
 
 /* store an entry in flash */
-static int zms_flash_write_entry(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
+static int zms_flash_write_entry(struct zms_fs *fs, zms_id_t id, const void *data, size_t len)
 {
 	int rc;
 	struct zms_ate entry;
@@ -549,13 +571,13 @@ static int zms_flash_write_entry(struct zms_fs *fs, uint32_t id, const void *dat
 	entry.cycle_cnt = fs->sector_cycle;
 
 	if (len > ZMS_DATA_IN_ATE_SIZE) {
-		/* only compute CRC if len is greater than 8 bytes */
-		if (IS_ENABLED(CONFIG_ZMS_DATA_CRC)) {
-			entry.data_crc = crc32_ieee(data, len);
-		}
+#ifdef CONFIG_ZMS_DATA_CRC
+		/* only compute CRC if data is to be stored outside of entry */
+		entry.data_crc = crc32_ieee(data, len);
+#endif
 		entry.offset = (uint32_t)SECTOR_OFFSET(fs->data_wra);
 	} else if ((len > 0) && (len <= ZMS_DATA_IN_ATE_SIZE)) {
-		/* Copy data into entry for small data ( < 8B) */
+		/* Copy data into entry for small data (at most ZMS_DATA_IN_ATE_SIZE bytes) */
 		memcpy(&entry.data, data, len);
 	}
 
@@ -688,10 +710,12 @@ static int zms_sector_close(struct zms_fs *fs)
 	struct zms_ate close_ate;
 	struct zms_ate garbage_ate;
 
+	/* Initialize all members to 0xff */
+	memset(&close_ate, 0xff, sizeof(struct zms_ate));
+
 	close_ate.id = ZMS_HEAD_ID;
 	close_ate.len = 0U;
 	close_ate.offset = (uint32_t)SECTOR_OFFSET(fs->ate_wra + fs->ate_size);
-	close_ate.metadata = 0xffffffff;
 	close_ate.cycle_cnt = fs->sector_cycle;
 
 	/* When we close the sector, we must write all non used ATE with
@@ -740,11 +764,13 @@ static int zms_add_gc_done_ate(struct zms_fs *fs)
 {
 	struct zms_ate gc_done_ate;
 
+	/* Initialize all members to 0xff */
+	memset(&gc_done_ate, 0xff, sizeof(struct zms_ate));
+
 	LOG_DBG("Adding gc done ate at %llx", fs->ate_wra);
 	gc_done_ate.id = ZMS_HEAD_ID;
 	gc_done_ate.len = 0U;
 	gc_done_ate.offset = (uint32_t)SECTOR_OFFSET(fs->data_wra);
-	gc_done_ate.metadata = 0xffffffff;
 	gc_done_ate.cycle_cnt = fs->sector_cycle;
 
 	zms_ate_crc8_update(&gc_done_ate);
@@ -793,14 +819,17 @@ static int zms_add_empty_ate(struct zms_fs *fs, uint64_t addr)
 	int rc = 0;
 	uint64_t previous_ate_wra;
 
+	/* Initialize all members to 0 */
+	memset(&empty_ate, 0, sizeof(struct zms_ate));
+
 	addr &= ADDR_SECT_MASK;
 
 	LOG_DBG("Adding empty ate at %llx", (uint64_t)(addr + fs->sector_size - fs->ate_size));
 	empty_ate.id = ZMS_HEAD_ID;
 	empty_ate.len = 0xffff;
-	empty_ate.offset = 0U;
-	empty_ate.metadata =
-		FIELD_PREP(ZMS_MAGIC_NUMBER_MASK, ZMS_MAGIC_NUMBER) | ZMS_DEFAULT_VERSION;
+	empty_ate.metadata = FIELD_PREP(ZMS_VERSION_MASK, ZMS_DEFAULT_VERSION) |
+			     FIELD_PREP(ZMS_MAGIC_NUMBER_MASK, ZMS_MAGIC_NUMBER) |
+			     FIELD_PREP(ZMS_ATE_FORMAT_MASK, ZMS_DEFAULT_ATE_FORMAT);
 
 	rc = zms_get_sector_cycle(fs, addr, &cycle_cnt);
 	if (rc == -ENOENT) {
@@ -893,7 +922,7 @@ static int zms_get_sector_header(struct zms_fs *fs, uint64_t addr, struct zms_at
  * @retval 1 valid ATE with same ID found
  * @retval < 0 An error happened
  */
-static int zms_find_ate_with_id(struct zms_fs *fs, uint32_t id, uint64_t start_addr,
+static int zms_find_ate_with_id(struct zms_fs *fs, zms_id_t id, uint64_t start_addr,
 				uint64_t end_addr, struct zms_ate *ate, uint64_t *ate_addr)
 {
 	int rc;
@@ -1044,10 +1073,10 @@ static int zms_gc(struct zms_fs *fs)
 		 */
 		if (wlk_prev_addr == gc_prev_addr) {
 			/* copy needed */
-			LOG_DBG("Moving %d, len %d", gc_ate.id, gc_ate.len);
+			LOG_DBG("Moving %lld, len %d", (long long)gc_ate.id, gc_ate.len);
 
 			if (gc_ate.len > ZMS_DATA_IN_ATE_SIZE) {
-				/* Copy Data only when len > 8
+				/* Copy Data only when len > ZMS_DATA_IN_ATE_SIZE
 				 * Otherwise, Data is already inside ATE
 				 */
 				data_addr = (gc_prev_addr & ADDR_SECT_MASK);
@@ -1151,16 +1180,28 @@ static int zms_init(struct zms_fs *fs)
 	for (i = 0; i < fs->sector_count; i++) {
 		addr = zms_close_ate_addr(fs, ((uint64_t)i << ADDR_SECT_SHIFT));
 
-		/* verify if the sector is closed */
-		sec_closed = zms_validate_closed_sector(fs, addr, &empty_ate, &close_ate);
-		if (sec_closed < 0) {
-			rc = sec_closed;
+		/* read the header ATEs */
+		rc = zms_get_sector_header(fs, addr, &empty_ate, &close_ate);
+		if (rc) {
 			goto end;
 		}
 		/* update cycle count */
 		fs->sector_cycle = empty_ate.cycle_cnt;
 
-		if (sec_closed == 1) {
+		/* Check the ATE format indicator so that we know how to validate ATEs.
+		 * The metadata field has the same offset and size in all ATE formats
+		 * (the same is guaranteed for crc8 and cycle_cnt).
+		 * Currently, ZMS can only recognize one of its supported ATE formats
+		 * (the one chosen at build time), so their indicators are defined for
+		 * the possibility of a future extension.
+		 * If this indicator is unknown, then consider the header ATEs invalid,
+		 * because we might not be dealing with ZMS contents at all.
+		 */
+		if (ZMS_GET_ATE_FORMAT(empty_ate.metadata) != ZMS_DEFAULT_ATE_FORMAT) {
+			continue;
+		}
+
+		if (zms_sector_closed(fs, &empty_ate, &close_ate)) {
 			/* closed sector */
 			closed_sectors++;
 			/* Let's verify that this is a ZMS storage system */
@@ -1218,7 +1259,8 @@ static int zms_init(struct zms_fs *fs)
 			goto end;
 		}
 
-		if (zms_empty_ate_valid(fs, &empty_ate)) {
+		if ((ZMS_GET_ATE_FORMAT(empty_ate.metadata) == ZMS_DEFAULT_ATE_FORMAT) &&
+		    zms_empty_ate_valid(fs, &empty_ate)) {
 			/* Empty ATE is valid, let's verify that this is a ZMS storage system */
 			if (ZMS_GET_MAGIC_NUMBER(empty_ate.metadata) == ZMS_MAGIC_NUMBER) {
 				zms_magic_exist = true;
@@ -1458,7 +1500,7 @@ int zms_mount(struct zms_fs *fs)
 	return 0;
 }
 
-ssize_t zms_write(struct zms_fs *fs, uint32_t id, const void *data, size_t len)
+ssize_t zms_write(struct zms_fs *fs, zms_id_t id, const void *data, size_t len)
 {
 	int rc;
 	size_t data_size;
@@ -1598,12 +1640,12 @@ end:
 	return rc;
 }
 
-int zms_delete(struct zms_fs *fs, uint32_t id)
+int zms_delete(struct zms_fs *fs, zms_id_t id)
 {
 	return zms_write(fs, id, NULL, 0);
 }
 
-ssize_t zms_read_hist(struct zms_fs *fs, uint32_t id, void *data, size_t len, uint32_t cnt)
+ssize_t zms_read_hist(struct zms_fs *fs, zms_id_t id, void *data, size_t len, uint32_t cnt)
 {
 	int rc;
 	int prev_found = 0;
@@ -1700,7 +1742,7 @@ err:
 	return rc;
 }
 
-ssize_t zms_read(struct zms_fs *fs, uint32_t id, void *data, size_t len)
+ssize_t zms_read(struct zms_fs *fs, zms_id_t id, void *data, size_t len)
 {
 	int rc;
 
@@ -1713,7 +1755,7 @@ ssize_t zms_read(struct zms_fs *fs, uint32_t id, void *data, size_t len)
 	return MIN(rc, len);
 }
 
-ssize_t zms_get_data_length(struct zms_fs *fs, uint32_t id)
+ssize_t zms_get_data_length(struct zms_fs *fs, zms_id_t id)
 {
 	int rc;
 

--- a/subsys/fs/zms/zms.c
+++ b/subsys/fs/zms/zms.c
@@ -13,11 +13,7 @@
 #include <zephyr/sys/crc.h>
 #include "zms_priv.h"
 #ifdef CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS
-#ifdef CONFIG_SETTINGS_ZMS_LEGACY
-#include <settings/settings_zms_legacy.h>
-#else
 #include <settings/settings_zms.h>
-#endif
 #endif
 
 #include <zephyr/logging/log.h>
@@ -36,39 +32,6 @@ static int zms_ate_valid_different_sector(struct zms_fs *fs, const struct zms_at
 static inline size_t zms_lookup_cache_pos(zms_id_t id)
 {
 #ifdef CONFIG_ZMS_LOOKUP_CACHE_FOR_SETTINGS
-#ifdef CONFIG_SETTINGS_ZMS_LEGACY
-	/*
-	 * 1. The ZMS settings backend uses up to (ZMS_NAME_ID_OFFSET - 1) ZMS IDs to
-	      store keys and equal number of ZMS IDs to store values.
-	 * 2. For each key-value pair, the value is stored at ZMS ID greater by exactly
-	 *    ZMS_NAME_ID_OFFSET than ZMS ID that holds the key.
-	 * 3. The backend tries to minimize the range of ZMS IDs used to store keys.
-	 *    That is, ZMS IDs are allocated sequentially, and freed ZMS IDs are reused
-	 *    before allocating new ones.
-	 *
-	 * Therefore, to assure the least number of collisions in the lookup cache,
-	 * the least significant bit of the hash indicates whether the given ZMS ID
-	 * represents a key or a value, and remaining bits of the hash are set to
-	 * the ordinal number of the key-value pair. Consequently, the hash function
-	 * provides the following mapping:
-	 *
-	 * 1st settings key   => hash 0
-	 * 1st settings value => hash 1
-	 * 2nd settings key   => hash 2
-	 * 2nd settings value => hash 3
-	 * ...
-	 */
-	BUILD_ASSERT(IS_POWER_OF_TWO(ZMS_NAMECNT_ID), "ZMS_NAMECNT_ID is not power of 2");
-	BUILD_ASSERT(IS_POWER_OF_TWO(ZMS_NAME_ID_OFFSET), "ZMS_NAME_ID_OFFSET is not power of 2");
-
-	uint32_t key_value_bit;
-	uint32_t key_value_ord;
-
-	key_value_bit = (id >> LOG2(ZMS_NAME_ID_OFFSET)) & 1;
-	key_value_ord = id & (ZMS_NAME_ID_OFFSET - 1);
-
-	hash = ((key_value_ord << 1) | key_value_bit);
-#else
 	/*
 	 * 1. Settings subsystem is storing the name ID and the linked list node ID
 	 *    with only one bit difference at BIT(0).
@@ -94,7 +57,6 @@ static inline size_t zms_lookup_cache_pos(zms_id_t id)
 	key_value_ll = id & BIT(0);
 
 	hash = (key_value_hash << 2) | (key_value_bit << 1) | key_value_ll;
-#endif /* CONFIG_SETTINGS_ZMS_LEGACY */
 #elif defined(CONFIG_ZMS_ID_64BIT)
 	/* 64-bit integer hash function found by https://github.com/skeeto/hash-prospector. */
 	uint64_t hash = id;

--- a/subsys/fs/zms/zms_priv.h
+++ b/subsys/fs/zms/zms_priv.h
@@ -28,7 +28,6 @@
 #endif
 
 #define ZMS_LOOKUP_CACHE_NO_ADDR GENMASK64(63, 0)
-#define ZMS_HEAD_ID              GENMASK(31, 0)
 
 #define ZMS_VERSION_MASK        GENMASK(7, 0)
 #define ZMS_GET_VERSION(x)      FIELD_GET(ZMS_VERSION_MASK, x)
@@ -36,14 +35,28 @@
 #define ZMS_MAGIC_NUMBER        0x42 /* murmur3a hash of "ZMS" (MSB) */
 #define ZMS_MAGIC_NUMBER_MASK   GENMASK(15, 8)
 #define ZMS_GET_MAGIC_NUMBER(x) FIELD_GET(ZMS_MAGIC_NUMBER_MASK, x)
+#define ZMS_ATE_FORMAT_MASK     GENMASK(19, 16)
+#define ZMS_GET_ATE_FORMAT(x)   FIELD_GET(ZMS_ATE_FORMAT_MASK, x)
 #define ZMS_MIN_ATE_NUM         5
 
 #define ZMS_INVALID_SECTOR_NUM -1
-#define ZMS_DATA_IN_ATE_SIZE   8
+
+#define ZMS_ATE_FORMAT_ID_32BIT 0
+#define ZMS_ATE_FORMAT_ID_64BIT 1
+
+#if !defined(CONFIG_ZMS_ID_64BIT)
+#define ZMS_DEFAULT_ATE_FORMAT ZMS_ATE_FORMAT_ID_32BIT
+#define ZMS_HEAD_ID            GENMASK(31, 0)
+#else
+#define ZMS_DEFAULT_ATE_FORMAT ZMS_ATE_FORMAT_ID_64BIT
+#define ZMS_HEAD_ID            GENMASK64(63, 0)
+#endif /* CONFIG_ZMS_ID_64BIT */
 
 /**
  * @ingroup zms_data_structures
  * ZMS Allocation Table Entry (ATE) structure
+ *
+ * @note This structure depends on @kconfig{CONFIG_ZMS_ID_64BIT}.
  */
 struct zms_ate {
 	/** crc8 check of the entry */
@@ -52,6 +65,8 @@ struct zms_ate {
 	uint8_t cycle_cnt;
 	/** data len within sector */
 	uint16_t len;
+
+#if ZMS_DEFAULT_ATE_FORMAT == ZMS_ATE_FORMAT_ID_32BIT
 	/** data id */
 	uint32_t id;
 	union {
@@ -75,6 +90,22 @@ struct zms_ate {
 			};
 		};
 	};
+
+#elif ZMS_DEFAULT_ATE_FORMAT == ZMS_ATE_FORMAT_ID_64BIT
+	/** data id */
+	uint64_t id;
+	union {
+		/** data field used to store small sized data */
+		uint8_t data[4];
+		/** data offset within sector */
+		uint32_t offset;
+		/** Used to store metadata information such as storage version. */
+		uint32_t metadata;
+	};
+#endif /* ZMS_DEFAULT_ATE_FORMAT */
+
 } __packed;
+
+#define ZMS_DATA_IN_ATE_SIZE SIZEOF_FIELD(struct zms_ate, data)
 
 #endif /* __ZMS_PRIV_H_ */

--- a/subsys/fs/zms/zms_priv.h
+++ b/subsys/fs/zms/zms_priv.h
@@ -28,21 +28,22 @@
 #endif
 
 #define ZMS_LOOKUP_CACHE_NO_ADDR GENMASK64(63, 0)
+#define ZMS_HEAD_ID              GENMASK(31, 0)
 
 #define ZMS_VERSION_MASK        GENMASK(7, 0)
 #define ZMS_GET_VERSION(x)      FIELD_GET(ZMS_VERSION_MASK, x)
 #define ZMS_DEFAULT_VERSION     1
+#define ZMS_MAGIC_NUMBER        0x42 /* murmur3a hash of "ZMS" (MSB) */
 #define ZMS_MAGIC_NUMBER_MASK   GENMASK(15, 8)
 #define ZMS_GET_MAGIC_NUMBER(x) FIELD_GET(ZMS_MAGIC_NUMBER_MASK, x)
 #define ZMS_MIN_ATE_NUM         5
 
 #define ZMS_INVALID_SECTOR_NUM -1
+#define ZMS_DATA_IN_ATE_SIZE   8
 
 /**
  * @ingroup zms_data_structures
  * ZMS Allocation Table Entry (ATE) structure
- *
- * @note This structure depends on @kconfig{CONFIG_ZMS_ID_64BIT}.
  */
 struct zms_ate {
 	/** crc8 check of the entry */
@@ -51,8 +52,6 @@ struct zms_ate {
 	uint8_t cycle_cnt;
 	/** data len within sector */
 	uint16_t len;
-
-#if !defined(CONFIG_ZMS_ID_64BIT)
 	/** data id */
 	uint32_t id;
 	union {
@@ -76,31 +75,6 @@ struct zms_ate {
 			};
 		};
 	};
-#else
-	/** data id */
-	uint64_t id;
-	union {
-		/** data field used to store small sized data */
-		uint8_t data[4];
-		/** data offset within sector */
-		uint32_t offset;
-		/** Used to store metadata information such as storage version. */
-		uint32_t metadata;
-	};
-#endif /* CONFIG_ZMS_ID_64BIT */
-
 } __packed;
-
-#define ZMS_DATA_IN_ATE_SIZE SIZEOF_FIELD(struct zms_ate, data)
-
-#if !defined(CONFIG_ZMS_ID_64BIT)
-#define ZMS_HEAD_ID      GENMASK(31, 0)
-#define ZMS_MAGIC_NUMBER 0x42 /* murmur3a hash of "ZMS" (MSB) */
-
-#else
-#define ZMS_HEAD_ID      GENMASK64(63, 0)
-#define ZMS_MAGIC_NUMBER 0xb8 /* murmur3a hash of "ZMS64" (MSB) */
-
-#endif /* CONFIG_ZMS_ID_64BIT */
 
 #endif /* __ZMS_PRIV_H_ */

--- a/tests/subsys/fs/zms/src/main.c
+++ b/tests/subsys/fs/zms/src/main.c
@@ -578,18 +578,17 @@ ZTEST_F(zms, test_zms_gc_corrupt_close_ate)
 	int err;
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES);
-	memset(&close_ate, 0xff, sizeof(struct zms_ate));
-	close_ate.id = ZMS_HEAD_ID;
+	close_ate.id = 0xffffffff;
 	close_ate.offset = fixture->fs.sector_size - sizeof(struct zms_ate) * 5;
 	close_ate.len = 0;
+	close_ate.metadata = 0xffffffff;
 	close_ate.cycle_cnt = 1;
 	close_ate.crc8 = 0xff; /* Incorrect crc8 */
 
-	memset(&empty_ate, 0, sizeof(struct zms_ate));
-	empty_ate.id = ZMS_HEAD_ID;
+	empty_ate.id = 0xffffffff;
+	empty_ate.offset = 0;
 	empty_ate.len = 0xffff;
-	empty_ate.metadata =
-		FIELD_PREP(ZMS_MAGIC_NUMBER_MASK, ZMS_MAGIC_NUMBER) | ZMS_DEFAULT_VERSION;
+	empty_ate.metadata = 0x4201;
 	empty_ate.cycle_cnt = 1;
 	empty_ate.crc8 =
 		crc8_ccitt(0xff, (uint8_t *)&empty_ate + SIZEOF_FIELD(struct zms_ate, crc8),
@@ -650,7 +649,7 @@ ZTEST_F(zms, test_zms_gc_corrupt_ate)
 	struct zms_ate close_ate;
 	int err;
 
-	close_ate.id = ZMS_HEAD_ID;
+	close_ate.id = 0xffffffff;
 	close_ate.offset = fixture->fs.sector_size / 2;
 	close_ate.len = 0;
 	close_ate.crc8 =
@@ -896,46 +895,4 @@ ZTEST_F(zms, test_zms_cache_hash_quality)
 #else
 	ztest_test_skip();
 #endif
-}
-
-/*
- * Test 64 bit ZMS ID support.
- */
-ZTEST_F(zms, test_zms_id_64bit)
-{
-	int err;
-	ssize_t len;
-	uint64_t data;
-	uint64_t filling_id = 0xdeadbeefULL;
-
-	Z_TEST_SKIP_IFNDEF(CONFIG_ZMS_ID_64BIT);
-
-	err = zms_mount(&fixture->fs);
-	zassert_true(err == 0, "zms_mount call failure: %d", err);
-
-	/* Fill the first sector with writes of different IDs */
-
-	while (fixture->fs.data_wra + sizeof(data) + sizeof(struct zms_ate) <=
-	       fixture->fs.ate_wra) {
-		data = filling_id;
-		len = zms_write(&fixture->fs, (zms_id_t)filling_id, &data, sizeof(data));
-		zassert_true(len == sizeof(data), "zms_write failed: %d", len);
-
-		/* Choose the next ID so that its lower 32 bits stay invariant.
-		 * The purpose is to test that ZMS doesn't mistakenly cast the
-		 * 64 bit ID to a 32 bit one somewhere.
-		 */
-		filling_id += BIT64(32);
-	}
-
-	/* Read back the written entries and check that they're all unique */
-
-	for (uint64_t id = 0xdeadbeefULL; id < filling_id; id += BIT64(32)) {
-		len = zms_read_hist(&fixture->fs, (zms_id_t)id, &data, sizeof(data), 0);
-		zassert_true(len == sizeof(data), "zms_read_hist unexpected failure: %d", len);
-		zassert_equal(data, id, "read unexpected data: %llx instead of %llx", data, id);
-
-		len = zms_read_hist(&fixture->fs, (zms_id_t)id, &data, sizeof(data), 1);
-		zassert_true(len == -ENOENT, "zms_read_hist unexpected failure: %d", len);
-	}
 }

--- a/tests/subsys/fs/zms/src/main.c
+++ b/tests/subsys/fs/zms/src/main.c
@@ -578,17 +578,19 @@ ZTEST_F(zms, test_zms_gc_corrupt_close_ate)
 	int err;
 
 	Z_TEST_SKIP_IFNDEF(CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES);
-	close_ate.id = 0xffffffff;
+	memset(&close_ate, 0xff, sizeof(struct zms_ate));
+	close_ate.id = ZMS_HEAD_ID;
 	close_ate.offset = fixture->fs.sector_size - sizeof(struct zms_ate) * 5;
 	close_ate.len = 0;
-	close_ate.metadata = 0xffffffff;
 	close_ate.cycle_cnt = 1;
 	close_ate.crc8 = 0xff; /* Incorrect crc8 */
 
-	empty_ate.id = 0xffffffff;
-	empty_ate.offset = 0;
+	memset(&empty_ate, 0, sizeof(struct zms_ate));
+	empty_ate.id = ZMS_HEAD_ID;
 	empty_ate.len = 0xffff;
-	empty_ate.metadata = 0x4201;
+	empty_ate.metadata = FIELD_PREP(ZMS_VERSION_MASK, ZMS_DEFAULT_VERSION) |
+			     FIELD_PREP(ZMS_MAGIC_NUMBER_MASK, ZMS_MAGIC_NUMBER) |
+			     FIELD_PREP(ZMS_ATE_FORMAT_MASK, ZMS_DEFAULT_ATE_FORMAT);
 	empty_ate.cycle_cnt = 1;
 	empty_ate.crc8 =
 		crc8_ccitt(0xff, (uint8_t *)&empty_ate + SIZEOF_FIELD(struct zms_ate, crc8),
@@ -649,7 +651,7 @@ ZTEST_F(zms, test_zms_gc_corrupt_ate)
 	struct zms_ate close_ate;
 	int err;
 
-	close_ate.id = 0xffffffff;
+	close_ate.id = ZMS_HEAD_ID;
 	close_ate.offset = fixture->fs.sector_size / 2;
 	close_ate.len = 0;
 	close_ate.crc8 =
@@ -895,4 +897,46 @@ ZTEST_F(zms, test_zms_cache_hash_quality)
 #else
 	ztest_test_skip();
 #endif
+}
+
+/*
+ * Test 64 bit ZMS ID support.
+ */
+ZTEST_F(zms, test_zms_id_64bit)
+{
+	int err;
+	ssize_t len;
+	uint64_t data;
+	uint64_t filling_id = 0xdeadbeefULL;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_ZMS_ID_64BIT);
+
+	err = zms_mount(&fixture->fs);
+	zassert_true(err == 0, "zms_mount call failure: %d", err);
+
+	/* Fill the first sector with writes of different IDs */
+
+	while (fixture->fs.data_wra + sizeof(data) + sizeof(struct zms_ate) <=
+	       fixture->fs.ate_wra) {
+		data = filling_id;
+		len = zms_write(&fixture->fs, (zms_id_t)filling_id, &data, sizeof(data));
+		zassert_true(len == sizeof(data), "zms_write failed: %d", len);
+
+		/* Choose the next ID so that its lower 32 bits stay invariant.
+		 * The purpose is to test that ZMS doesn't mistakenly cast the
+		 * 64 bit ID to a 32 bit one somewhere.
+		 */
+		filling_id += BIT64(32);
+	}
+
+	/* Read back the written entries and check that they're all unique */
+
+	for (uint64_t id = 0xdeadbeefULL; id < filling_id; id += BIT64(32)) {
+		len = zms_read_hist(&fixture->fs, (zms_id_t)id, &data, sizeof(data), 0);
+		zassert_true(len == sizeof(data), "zms_read_hist unexpected failure: %d", len);
+		zassert_equal(data, id, "read unexpected data: %llx instead of %llx", data, id);
+
+		len = zms_read_hist(&fixture->fs, (zms_id_t)id, &data, sizeof(data), 1);
+		zassert_true(len == -ENOENT, "zms_read_hist unexpected failure: %d", len);
+	}
 }

--- a/tests/subsys/fs/zms/testcase.yaml
+++ b/tests/subsys/fs/zms/testcase.yaml
@@ -27,3 +27,9 @@ tests:
     platform_allow:
       - native_sim
       - qemu_x86
+  filesystem.zms.id_64bit:
+    extra_configs:
+      - CONFIG_ZMS_ID_64BIT=y
+      - CONFIG_ZMS_LOOKUP_CACHE=y
+      - CONFIG_ZMS_LOOKUP_CACHE_SIZE=64
+    platform_allow: qemu_x86

--- a/tests/subsys/fs/zms/testcase.yaml
+++ b/tests/subsys/fs/zms/testcase.yaml
@@ -27,10 +27,3 @@ tests:
     platform_allow:
       - native_sim
       - qemu_x86
-  filesystem.zms.id_64bit:
-    extra_configs:
-      - CONFIG_ZMS_ID_64BIT=y
-      - CONFIG_ZMS_LOOKUP_CACHE=y
-      - CONFIG_ZMS_LOOKUP_CACHE_SIZE=64
-      - CONFIG_FLASH_SIMULATOR_DOUBLE_WRITES=y
-    platform_allow: qemu_x86


### PR DESCRIPTION
Fixes undeclared `uint32_t hash` in: `[nrf noup] zms: add lookup cache hash function for legacy ZMS`

Also includes a re-cherry-pick of upstream PR 94330 to stabilize the ZMS ABI.