### PR TITLE
[nrf fromlist] boards: nordic: nrf54l15dk: Extend ext memory node wit…

### DIFF
--- a/boards/nordic/nrf54l15dk/nrf54l_05_10_15_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l_05_10_15_cpuapp_common.dtsi
@@ -134,6 +134,7 @@
 		has-dpd;
 		t-enter-dpd = <10000>;
 		t-exit-dpd = <35000>;
+		reset-gpios = <&gpio2 0 GPIO_ACTIVE_LOW>;
 	};
 };
 


### PR DESCRIPTION
…h reset GPIO

Extend external memory node with 'reset-gpios' property.
When this property is defined, driver will reset the memory at startup.

Upstream PR #: 94843