### PR TITLE
[nrf noup] soc: nrf54h: work around missing power domain handling

### DIFF
--- a/soc/nordic/nrf54h/Kconfig
+++ b/soc/nordic/nrf54h/Kconfig
@@ -95,6 +95,11 @@ config SOC_NRF54H20_CPURAD_ENABLE_CHECK_VTOR
 	help
 	  Verify that VTOR is not 0xFFFFFFFF before booting the Radiocore.
 
+config SOC_NRF54H20_DISABLE_ALL_GPIO_RETENTION_WORKAROUND
+	bool "Disable all GPIO pin retention on boot"
+	default y
+	depends on SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD
+
 config SOC_NRF54H20_CPURAD
 	select SOC_NRF54H20_CPURAD_COMMON
 

--- a/soc/nordic/nrf54h/soc.c
+++ b/soc/nordic/nrf54h/soc.c
@@ -14,6 +14,7 @@
 #include <zephyr/logging/log_frontend_stmesp.h>
 #endif
 
+#include <hal/nrf_gpio.h>
 #include <hal/nrf_hsfll.h>
 #include <hal/nrf_lrcconf.h>
 #include <hal/nrf_spu.h>
@@ -172,6 +173,17 @@ void soc_early_init_hook(void)
 	     DT_NODE_HAS_STATUS(DT_NODELABEL(nfct), reserved)) &&
 	    DT_PROP_OR(DT_NODELABEL(nfct), nfct_pins_as_gpios, 0)) {
 		nrf_nfct_pad_config_enable_set(NRF_NFCT, false);
+	}
+
+	/* This is a workaround for not yet having upstream patches for properly handling
+	 * pin retention. It should be removed as part of the next upmerge.
+	 */
+	if (IS_ENABLED(CONFIG_SOC_NRF54H20_DISABLE_ALL_GPIO_RETENTION_WORKAROUND)) {
+		NRF_GPIO_Type *gpio_regs[GPIO_COUNT] = GPIO_REG_LIST;
+
+		for (int i = 0; i < NRFX_ARRAY_SIZE(gpio_regs); i++) {
+			nrf_gpio_port_retain_set(gpio_regs[i], 0);
+		}
 	}
 }
 


### PR DESCRIPTION
The upcoming release of IronSide SE no longer disables RETAIN
in all GPIO instances on boot, so the application must be able
to handle the hardware default state of RETAIN being enabled.

The GPIO retention is properly handled by changes that are
currently only upstream and will be pulled in by the next upmerge.
This patch exists a workaround to be able to integrate
IronSide SE before the proper solution is pulled in.