### PR TITLE
[nrf fromtree] mgmt: Allow to block confirming non-acive slots

### DIFF
--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -117,6 +117,20 @@ config MCUMGR_GRP_IMG_REJECT_DIRECT_XIP_MISMATCHED_SLOT
 	  The base address can be set, to an image binary header, with imgtool,
 	  using the --rom-fixed command line option.
 
+config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_SLOT
+	bool "Allow to confirm non-active slots of any image"
+	depends on MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT || \
+		   MCUBOOT_BOOTLOADER_MODE_RAM_LOAD_WITH_REVERT || \
+		   MCUBOOT_BOOTLOADER_MODE_SWAP_SCRATCH || \
+		   MCUBOOT_BOOTLOADER_MODE_SWAP_USING_MOVE || \
+		   MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET
+	default y
+	help
+	  Allows to confirm non-active slot of any image.
+	  Normally it should not be allowed to confirm any slots via MCUmgr
+	  commands, to prevent confirming something that is broken and was not
+	  verified to boot correctly.
+
 config MCUMGR_GRP_IMG_FRUGAL_LIST
 	bool "Omit zero, empty or false values from status list"
 	help

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/Kconfig
@@ -118,18 +118,22 @@ config MCUMGR_GRP_IMG_REJECT_DIRECT_XIP_MISMATCHED_SLOT
 	  using the --rom-fixed command line option.
 
 config MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_SLOT
-	bool "Allow to confirm non-active slots of any image"
+	bool "Allow to confirm non-active slots of any image" if !MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY
 	depends on MCUBOOT_BOOTLOADER_MODE_DIRECT_XIP_WITH_REVERT || \
 		   MCUBOOT_BOOTLOADER_MODE_RAM_LOAD_WITH_REVERT || \
 		   MCUBOOT_BOOTLOADER_MODE_SWAP_SCRATCH || \
 		   MCUBOOT_BOOTLOADER_MODE_SWAP_USING_MOVE || \
-		   MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET
+		   MCUBOOT_BOOTLOADER_MODE_SWAP_USING_OFFSET || \
+		   MCUBOOT_BOOTLOADER_MODE_OVERWRITE_ONLY
 	default y
 	help
 	  Allows to confirm non-active slot of any image.
 	  Normally it should not be allowed to confirm any slots via MCUmgr
 	  commands, to prevent confirming something that is broken and was not
 	  verified to boot correctly.
+	  Option always enabled in the overwrite mode, because the permanent
+	  update, that uses the confirm flag, is the intended way to provide
+	  updates.
 
 config MCUMGR_GRP_IMG_FRUGAL_LIST
 	bool "Omit zero, empty or false values from status list"

--- a/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/grp/img_mgmt/src/img_mgmt_state.c
@@ -685,7 +685,7 @@ int img_mgmt_set_next_boot_slot(int slot, bool confirm)
 	 * verified to actually be bootable, a new policy was introduced,
 	 * that applies to both active and inactive images.
 	 */
-#ifndef MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_SLOT
+#ifndef CONFIG_MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_SLOT
 	if (confirm && slot != active_slot) {
 		return IMG_MGMT_ERR_IMAGE_CONFIRMATION_DENIED;
 	}
@@ -751,7 +751,7 @@ int img_mgmt_set_next_boot_slot(int slot, bool confirm)
 		return IMG_MGMT_ERR_IMAGE_SETTING_TEST_TO_ACTIVE_DENIED;
 	}
 
-#ifndef MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_SLOT
+#ifndef CONFIG_MCUMGR_GRP_IMG_ALLOW_CONFIRM_NON_ACTIVE_SLOT
 	if (slot != active_slot && confirm) {
 		return IMG_MGMT_ERR_IMAGE_CONFIRMATION_DENIED;
 	}


### PR DESCRIPTION
In Direct XIP with revert, it should be possible to block confirmation of the non-active slot, so only a bootable binaries are marked as valid.

Upstream PR #: 95467
Upstream PR #: 96606