### PR TITLE
nRF54h20 pm s2ram resume redirect (bootloader -> App)

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -343,12 +343,19 @@ zephyr_udc0: &usbhs {
 
 /* Trim this RAM block for making room on all run-time common S2RAM cpu context. */
 &cpuapp_ram0 {
-	reg = <0x22000000 (DT_SIZE_K(32)-32)>;
-	ranges = <0x0 0x22000000 (0x8000-0x20)>;
+	reg = <0x22000000 (DT_SIZE_K(32) - 36)>;
+	ranges = <0x0 0x22000000 (0x8000 - 0x24)>;
 };
 
 / {
 	soc {
+		/* run-time common mcuboot S2RAM support section */
+		mcuboot_s2ram: cpuapp_s2ram@22007fdc  {
+			compatible = "zephyr,memory-region", "mmio-sram";
+			reg = <0x22007fdc 4>;
+			zephyr,memory-region = "mcuboot_s2ram_context";
+		};
+
 		/* run-time common S2RAM cpu context RAM */
 		pm_s2ram: cpuapp_s2ram@22007fe0  {
 			compatible = "zephyr,memory-region", "mmio-sram";

--- a/soc/nordic/nrf54h/CMakeLists.txt
+++ b/soc/nordic/nrf54h/CMakeLists.txt
@@ -8,7 +8,9 @@ if(CONFIG_ARM)
   endif()
 endif()
 
-zephyr_library_sources_ifdef(CONFIG_PM_S2RAM pm_s2ram.c)
+if(NOT CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE)
+  zephyr_library_sources_ifdef(CONFIG_PM_S2RAM pm_s2ram.c)
+endif()
 
 zephyr_include_directories(.)
 

--- a/soc/nordic/nrf54h/Kconfig
+++ b/soc/nordic/nrf54h/Kconfig
@@ -100,6 +100,11 @@ config SOC_NRF54H20_DISABLE_ALL_GPIO_RETENTION_WORKAROUND
 	default y
 	depends on SOC_NRF54H20_CPUAPP || SOC_NRF54H20_CPURAD
 
+config SOC_NRF54H20_PM_S2RAM_OVERRIDE
+	bool "Override `pm_s2ram` implementation"
+	help
+	  Override Nordic s2ram implementation.
+
 config SOC_NRF54H20_CPURAD
 	select SOC_NRF54H20_CPURAD_COMMON
 

--- a/soc/nordic/nrf54h/pm_s2ram.c
+++ b/soc/nordic/nrf54h/pm_s2ram.c
@@ -219,10 +219,24 @@ static void fpu_restore(_fpu_context_t *backup)
 #endif /* !defined(CONFIG_FPU_SHARING) */
 #endif /* defined(CONFIG_FPU) */
 
+#if DT_NODE_EXISTS(DT_NODELABEL(mcuboot_s2ram)) &&\
+	DT_NODE_HAS_COMPAT(DT_NODELABEL(mcuboot_s2ram), zephyr_memory_region)
+/* Linker section name is given by `zephyr,memory-region` property of
+ * `zephyr,memory-region` compatible DT node with nodelabel `mcuboot_s2ram`.
+ */
+__attribute__((section(DT_PROP(DT_NODELABEL(mcuboot_s2ram), zephyr_memory_region))))
+volatile struct mcuboot_resume_s _mcuboot_resume;
+
+#define SET_MCUBOOT_RESUME_MAGIC() _mcuboot_resume.magic = MCUBOOT_S2RAM_RESUME_MAGIC
+#else
+#define SET_MCUBOOT_RESUME_MAGIC()
+#endif
+
 int soc_s2ram_suspend(pm_s2ram_system_off_fn_t system_off)
 {
 	int ret;
 
+	SET_MCUBOOT_RESUME_MAGIC();
 	scb_save(&backup_data.scb_context);
 #if defined(CONFIG_FPU)
 #if !defined(CONFIG_FPU_SHARING)

--- a/soc/nordic/nrf54h/pm_s2ram.h
+++ b/soc/nordic/nrf54h/pm_s2ram.h
@@ -10,6 +10,12 @@
 #ifndef _ZEPHYR_SOC_ARM_NORDIC_NRF_PM_S2RAM_H_
 #define _ZEPHYR_SOC_ARM_NORDIC_NRF_PM_S2RAM_H_
 
+#define MCUBOOT_S2RAM_RESUME_MAGIC 0x75832419
+
+struct mcuboot_resume_s {
+	uint32_t magic; /* magic value to identify valid structure */
+};
+
 /**
  * @brief Save CPU state on suspend
  *


### PR DESCRIPTION
Added infrastructure needed for redirect execution to the Application reset vector in case SoC gets woke-up from S2RAM and MCUboot is the first code entity. Thanks to that bootloader can implement its own routine for resume support (CONFIG_SOC_NRF54H20_PM_S2RAM_OVERRIDE) which overrides `zephyr/soc/nordic/nrf54h/pm_s2ram.c` implementation in case of MCUboot.

Introduce additional source of true using additional check over independent source (variable with magic value).