### PR TITLE
[nrf fromlist] tests: kernel: sleep: Adjustments for NRF54H20 PPR

### DIFF
--- a/tests/kernel/sleep/src/usleep.c
+++ b/tests/kernel/sleep/src/usleep.c
@@ -42,6 +42,11 @@
  * loaded to its comparator.
  */
 #define MAXIMUM_SHORTEST_TICKS 2
+#elif defined(CONFIG_SOC_NRF54H20_CPUPPR) && (CONFIG_SYS_CLOCK_TICKS_PER_SEC > 16384)
+/* Similar for nRF54H20 cpuppr (RISC-V core), it has a slow CPU clock
+ * compared to other cores, causing the increased overhead.
+ */
+#define MAXIMUM_SHORTEST_TICKS 4
 #else
 #define MAXIMUM_SHORTEST_TICKS 1
 #endif


### PR DESCRIPTION
Adjusting the max shortest ticks value for slow PPR core.

Upstream PR #: 95650