### PR TITLE
[nrf fromtree] dts: nrf54h20: Add zephyr,pm-device-runtime-auto; to uart instances

### DIFF
--- a/dts/vendor/nordic/nrf54h20.dtsi
+++ b/dts/vendor/nordic/nrf54h20.dtsi
@@ -708,6 +708,7 @@
 				power-domains = <&gpd NRF_GPD_FAST_ACTIVE1>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			spi121: spi@8e7000 {
@@ -1066,6 +1067,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			i2c131: i2c@9a6000 {
@@ -1200,6 +1202,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			i2c133: i2c@9b6000 {
@@ -1246,6 +1249,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			dppic135: dppic@9c1000 {
@@ -1334,6 +1338,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			i2c135: i2c@9c6000 {
@@ -1380,6 +1385,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			dppic136: dppic@9d1000 {
@@ -1514,6 +1520,7 @@
 				nordic,clockpin-enable = <NRF_FUN_UART_TX>;
 				endtx-stoptx-supported;
 				frame-timeout-supported;
+				zephyr,pm-device-runtime-auto;
 			};
 
 			tdm130: tdm@992000 {


### PR DESCRIPTION
The uart driver for nRF54h20 doesn't call pm_device_runtime_enable().
During an uart driver init `pm_device_driver_init()` return early,
because the `pm_device_is_powered()` returns `false`. Power domains,
where uarts are instantiated, are disabled: `pm->domain->pm_base->state`
is not equal to `PM_DEVICE_STATE_ACTIVE`.
    
At the end of the day, an uart instance is left disabled.
    
This is a workaround to make the uart usable when CONFIG_PM,
CONFIG_PM_DEVICE and CONFIG_PM_DEVICE_RUNTIME are enabled.

(cherry picked from commit eaede77351a75cca14acafc470eae6beb03d5852)
    
Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>