### PR TITLE
[nrf noup] dts: choose a psa-rng for entropy for 54lm20a

### DIFF
--- a/dts/arm/nordic/nrf54l_05_10_15_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54l_05_10_15_cpuapp.dtsi
@@ -26,7 +26,7 @@ nvic: &cpuapp_nvic {};
 	};
 
 	rng: rng {
-		status = "okay";
+		status = "disabled";
 		compatible = "nordic,nrf-cracen-ctrdrbg";
 	};
 

--- a/dts/arm/nordic/nrf54lm20a_enga_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf54lm20a_enga_cpuapp.dtsi
@@ -17,7 +17,7 @@ nvic: &cpuapp_nvic {};
 
 / {
 	chosen {
-		zephyr,entropy = &rng;
+		zephyr,entropy = &psa_rng;
 	};
 
 	soc {
@@ -28,11 +28,11 @@ nvic: &cpuapp_nvic {};
 
 	psa_rng: psa-rng {
 		compatible = "zephyr,psa-crypto-rng";
-		status = "disabled";
+		status = "okay";
 	};
 
 	rng: rng {
-		status = "okay";
+		status = "disabled";
 		compatible = "nordic,nrf-cracen-ctrdrbg";
 	};
 };


### PR DESCRIPTION
Set PSA as the entropy source for nRF54lm20a target. PSA is the only NCS-supported interface to CRACEN. There is no other entropy source in 54lm20a than CRACEN.

The commit also disables `rng` compatible with
`nrf-cracen-ctrdrbg`, the nrfx based interface to CRACEN that is used in upstream Zephyr. Only one CRACEN interface may be enabled.