### PR TITLE
[nrf fromtree] scripts: requirements: Use gitlint-core for loose requirements

### DIFF
--- a/scripts/requirements-actions.in
+++ b/scripts/requirements-actions.in
@@ -6,7 +6,7 @@ clang-format>=15.0.0
 elasticsearch<9
 exceptiongroup>=1.0.0rc8
 gcovr==6.0
-gitlint>=0.19.1
+gitlint-core>=0.19.1
 gitpython>=3.1.41
 ijson
 intelhex

--- a/scripts/requirements-actions.txt
+++ b/scripts/requirements-actions.txt
@@ -345,14 +345,10 @@ gitdb==4.0.12 \
     --hash=sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571 \
     --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
     # via gitpython
-gitlint==0.19.1 \
-    --hash=sha256:26bb085959148d99fbbc178b4e56fda6c3edd7646b7c2a24d8ee1f8e036ed85d \
-    --hash=sha256:b5b70fb894e80849b69abbb65ee7dbb3520fc3511f202a6e6b6ddf1a71ee8f61
-    # via -r requirements-actions.in
 gitlint-core==0.19.1 \
     --hash=sha256:7bf977b03ff581624a9e03f65ebb8502cc12dfaa3e92d23e8b2b54bbdaa29992 \
     --hash=sha256:f41effd1dcbc06ffbfc56b6888cce72241796f517b46bd9fd4ab1b145056988c
-    # via gitlint
+    # via -r requirements-actions.in
 gitpython==3.1.44 \
     --hash=sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110 \
     --hash=sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269

--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -3,7 +3,7 @@
 # used by ci/check_compliance
 # zephyr-keep-sorted-start
 clang-format>=15.0.0
-gitlint
+gitlint-core
 junitparser>=4.0.1
 lxml>=5.3.0
 pykwalify

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -10,7 +10,7 @@ gitpython>=3.1.41
 plotly
 
 # helper for developers - check git commit messages
-gitlint
+gitlint-core
 
 # helper for developers
 junit2html


### PR DESCRIPTION
Gitlint-core has loose requirements and not conflicting with scancode-toolkit v32.4.1 (click==8.1.3 vs click>=8.2.0).


(cherry picked from commit 67b4063a207ab87c28851513246b28433ef101ed)