### PR TITLE
[nrf fromlist] drivers: i2c: nrfx_twis: fix missing SoC header include

### DIFF
--- a/drivers/i2c/i2c_nrfx_twis.c
+++ b/drivers/i2c/i2c_nrfx_twis.c
@@ -10,7 +10,7 @@
 #include <zephyr/linker/devicetree_regions.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/pm/device.h>
-
+#include <soc.h>
 #include <nrfx_twis.h>
 #include <string.h>
 


### PR DESCRIPTION
In case of nRF TWIS i2c shim, SoC header include is needed for memory region property presence checker macro.

Upstream PR #: 96413