### PR TITLE
[nrf fromtree] boards: nrf9280pdk: Add missing overlays for rev. 0.2.0

### DIFF
--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp_iron_0_2_0.overlay
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuapp_iron_0_2_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf9280pdk_nrf9280-pinctrl_0_2_0.dtsi"

--- a/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuppr_xip_0_2_0.overlay
+++ b/boards/nordic/nrf9280pdk/nrf9280pdk_nrf9280_cpuppr_xip_0_2_0.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "nrf9280pdk_nrf9280-pinctrl_0_2_0.dtsi"


### PR DESCRIPTION
Added missing cpuapp/iron and cpuppr/xip overlays for rev. 0.2.0.

(cherry picked from commit 9d10d67bcb15a70e3db91893aec2585399ca2dc0)