### PR TITLE
[nrf fromtree] drivers: mspi_dw: Add option to offload handling of FIFOs

### DIFF
--- a/drivers/mspi/Kconfig.dw
+++ b/drivers/mspi/Kconfig.dw
@@ -12,6 +12,15 @@ config MSPI_DW
 
 if MSPI_DW
 
+config MSPI_DW_HANDLE_FIFOS_IN_SYSTEM_WORKQUEUE
+	bool "Handle FIFO in system workqueue"
+	help
+	  When the driver does not use DMA for transferring data to/from the
+	  SSI FIFOs, handling of those may take a significant amount of time.
+	  It may be destructive for some applications if that time is spent
+	  in the interrupt context. This option allows offloading the job to
+	  the system workqueue.
+
 config MSPI_DW_TXD_DIV
 	int "Designware SSI TX Drive edge divisor"
 	default 4

--- a/tests/drivers/mspi/flash/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/mspi/flash/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		mspi0 = &exmif;
+	};
+};
+
+&gpio6 {
+	status = "okay";
+};
+
+&exmif {
+	status = "okay";
+};
+
+&mx25uw63 {
+	status = "okay";
+};

--- a/tests/drivers/mspi/flash/testcase.yaml
+++ b/tests/drivers/mspi/flash/testcase.yaml
@@ -1,16 +1,18 @@
 # Copyright (c) 2024 Ambiq Micro Inc. <www.ambiq.com>
 # SPDX-License-Identifier: Apache-2.0
 
+common:
+  tags:
+    - drivers
+    - mspi
+    - flash
+  harness: ztest
+
 tests:
   drivers.mspi.flash:
-    tags:
-      - drivers
-      - mspi
-      - flash
     filter: dt_compat_enabled("zephyr,mspi-emul-flash")
       or dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("jedec,mspi-nor")
       or dt_compat_enabled("mspi-atxp032") or dt_compat_enabled("mspi-is25xX0xx")
-    harness: ztest
     platform_allow:
       - native_sim
       - apollo3p_evb
@@ -20,15 +22,17 @@ tests:
       - apollo3p_evb
       - apollo510_evb
   drivers.mspi.flash.xip_read:
-    tags:
-      - drivers
-      - mspi
-      - flash
     filter: dt_compat_enabled("mspi-is25xX0xx")
-    harness: ztest
     platform_allow:
       - apollo510_evb
     integration_platforms:
       - apollo510_evb
     extra_configs:
       - CONFIG_FLASH_MSPI_XIP_READ=y
+  drivers.mspi.flash.mspi_dw_system_workqueue:
+    filter: dt_alias_exists("mspi0") and dt_compat_enabled("jedec,mspi-nor")
+      and CONFIG_MSPI_DW
+    integration_platforms:
+      - nrf54h20dk/nrf54h20/cpuapp
+    extra_configs:
+      - CONFIG_MSPI_DW_HANDLE_FIFOS_IN_SYSTEM_WORKQUEUE=y


### PR DESCRIPTION
Provide a Kconfig option that allows offloading handling of the SSI FIFOs, which the driver normally executes in the interrupt handler, to the system workqueue.