### PR TITLE
[nrf fromtree] boards: nordic: nrf54lm20dk: Add aliases for MCUboot b…

### DIFF
--- a/boards/nordic/nrf54lm20dk/nrf54lm20a_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20a_cpuapp_common.dtsi
@@ -20,6 +20,11 @@
 		zephyr,flash = &cpuapp_rram;
 		zephyr,ieee802154 = &ieee802154;
 	};
+
+	aliases {
+		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
+	};
 };
 
 &cpuapp_sram {


### PR DESCRIPTION
…utton/LED

Adds aliases so that these can be used by MCUboot


(cherry picked from commit b6e09135cb6675e876992f117257b46d20e3e4a5)