### PR TITLE
[nrf fromtree] soc: nordic: common: uicr: Add GRTC fast clkout

### DIFF
--- a/soc/nordic/common/uicr/gen_periphconf_entries.py
+++ b/soc/nordic/common/uicr/gen_periphconf_entries.py
@@ -395,6 +395,12 @@ def lookup_tables_get(soc: Soc) -> SocLookupTables:
                 NrfPsel(fun=NrfFun.TDM_FSYNC_M, port=2, pin=7): Ctrlsel.CAN_TDM_SERIAL2,
                 NrfPsel(fun=NrfFun.TDM_FSYNC_S, port=2, pin=7): Ctrlsel.CAN_TDM_SERIAL2,
             },
+            # GRTC
+            0x5F99_C000: {
+                NrfPsel(fun=NrfFun.GRTC_CLKOUT_FAST, port=1, pin=8): Ctrlsel.CAN_TDM_SERIAL2,
+                NrfPsel(fun=NrfFun.GRTC_CLKOUT_FAST, port=2, pin=5): Ctrlsel.CAN_TDM_SERIAL2,
+                NrfPsel(fun=NrfFun.GRTC_CLKOUT_FAST, port=9, pin=0): Ctrlsel.SERIAL0,
+            },
             # GPIOTE0 (RAD)
             0x5302_7000: {
                 # P1


### PR DESCRIPTION
Add the mapping for the GRTC_CLKOUT_FAST pinctrl mapping to the periphconf generation. This allows clocking out the 16MHz clock with a user selectable divider.


(cherry picked from commit 19f709910fe53fcff64fb36fd02c0a56f6042365)