### PR TITLE
soc: ironside: Add UUID and HWREVISION info to boot report

### DIFF
--- a/soc/nordic/ironside/include/nrf_ironside/boot_report.h
+++ b/soc/nordic/ironside/include/nrf_ironside/boot_report.h
@@ -116,6 +116,10 @@
 #define IRONSIDE_BOOT_REPORT_LOCAL_DOMAIN_CONTEXT_SIZE (16UL)
 /** Length of the random data buffer in bytes. */
 #define IRONSIDE_BOOT_REPORT_RANDOM_DATA_SIZE (32UL)
+/** Length of the uuid buffer in bytes. */
+#define SECDOM_BOOT_REPORT_UUID_SIZE (16UL)
+/** Length of the hwrevision buffer in bytes. */
+#define SECDOM_BOOT_REPORT_HWREVISION_SIZE (4UL)
 
 /** @brief Initialization/boot status description contained in the boot report. */
 struct ironside_boot_report_init_status {
@@ -207,8 +211,12 @@ struct ironside_boot_report {
 	struct ironside_boot_report_init_context init_context;
 	/** CSPRNG data */
 	uint8_t random_data[IRONSIDE_BOOT_REPORT_RANDOM_DATA_SIZE];
+	/** Device Info data : 128-bit Universally Unique IDentifier (UUID) */
+	uint8_t device_info_uuid[SECDOM_BOOT_REPORT_UUID_SIZE];
+	/** Device Info data : hardware revision */
+	uint8_t device_info_hwrevision[SECDOM_BOOT_REPORT_HWREVISION_SIZE];
 	/** Reserved for Future Use */
-	uint32_t rfu2[64];
+	uint32_t rfu2[59];
 };
 
 /**


### PR DESCRIPTION
- UUID and HWREVISION are added to the boot report to make them available to other cores.