### PR TITLE
[nrf fromtree] dts: arm: nrf54h20_cpurad: disable unsuppported s2ram …

### DIFF
--- a/dts/arm/nordic/nrf54h20_cpurad.dtsi
+++ b/dts/arm/nordic/nrf54h20_cpurad.dtsi
@@ -21,6 +21,7 @@ wdt011: &cpurad_wdt011 {};
 /delete-node/ &cpuapp_ram0;
 /delete-node/ &cpuppr;
 /delete-node/ &cpuflpr;
+/delete-node/ &s2ram;
 
 / {
 	chosen {


### PR DESCRIPTION
…state

The s2ram power state is a "suspend-to-ram" state which is not supported by the radio core, so delete it from the overlay.



(cherry picked from commit 91c8c07179d386bbb6ed6af2531f61de77ac773d)