### PR TITLE
[nrf noup] soc/nordic/nrf54h20/pm_s2ram: extend mcuboot_resume_s

### DIFF
--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp.dts
@@ -345,23 +345,23 @@ zephyr_udc0: &usbhs {
 
 /* Trim this RAM block for making room on all run-time common S2RAM cpu context. */
 &cpuapp_ram0 {
-	reg = <0x22000000 (DT_SIZE_K(32) - 52)>;
-	ranges = <0x0 0x22000000 (0x8000 - 0x34)>;
+	reg = <0x22000000 (DT_SIZE_K(32) - 56)>;
+	ranges = <0x0 0x22000000 (0x8000 - 0x38)>;
 };
 
 / {
 	soc {
 		/* temporary stack for S2RAM resume logic */
-		pm_s2ram_stack: cpuapp_s2ram_stack@22007fcc  {
+		pm_s2ram_stack: cpuapp_s2ram_stack@22007fc8  {
 			compatible = "zephyr,memory-region", "mmio-sram";
-			reg = <0x22007fcc 16>;
+			reg = <0x22007fc8 16>;
 			zephyr,memory-region = "pm_s2ram_stack";
 		};
 
 		/* run-time common mcuboot S2RAM support section */
-		mcuboot_s2ram: cpuapp_s2ram@22007fdc  {
+		mcuboot_s2ram: cpuapp_s2ram@22007fd8  {
 			compatible = "zephyr,memory-region", "mmio-sram";
-			reg = <0x22007fdc 4>;
+			reg = <0x22007fd8 8>;
 			zephyr,memory-region = "mcuboot_s2ram_context";
 		};
 

--- a/soc/nordic/nrf54h/pm_s2ram.h
+++ b/soc/nordic/nrf54h/pm_s2ram.h
@@ -14,6 +14,7 @@
 
 struct mcuboot_resume_s {
 	uint32_t magic; /* magic value to identify valid structure */
+	uint32_t slot_info;
 };
 
 /**


### PR DESCRIPTION
!nrf_squash: [nrf noup] soc/nordic/nf54h/pm_s2ram: S2RAM resume hardening

Extended mcuboot_resume_s suture by slot_info field intended to be used by MCUboot for recognize proper boot slot in direct-xp mode.