### PR TITLE
dts: bindings: comparator: nordic: Change ext analog inputs type to int

### DIFF
--- a/doc/releases/migration-guide-4.3.rst
+++ b/doc/releases/migration-guide-4.3.rst
@@ -58,6 +58,17 @@ Device Drivers and Devicetree
 
 .. zephyr-keep-sorted-start re(^\w)
 
+Comparator
+==========
+
+* :dtcompatible:`nordic,nrf-comp` and :dtcompatible:`nordic,nrf-lpcomp` ``psel`` and ``extrefsel``
+  properties type has been changed to integer. The value of these properties is in the range
+  of :c:macro:`NRF_COMP_AIN0` to :c:macro:`NRF_COMP_AIN_VDDH_DIV5`, where :c:macro:`NRF_COMP_AIN0`
+  to :c:macro:`NRF_COMP_AIN7` represent the external inputs AIN0 to AIN7,
+  :c:macro:`NRF_COMP_AIN_VDD_DIV2` represents internal reference VDD/2,
+  and :c:macro:`NRF_COMP_AIN_VDDH_DIV5` represents VDDH/5.
+  The old ``string`` properties type is deprecated.
+
 Phy
 ===
 

--- a/drivers/comparator/comparator_nrf_comp.c
+++ b/drivers/comparator/comparator_nrf_comp.c
@@ -19,8 +19,7 @@
 #define SHIM_NRF_COMP_DT_INST_REFSEL_IS_AREF(inst) \
 	DT_INST_ENUM_HAS_VALUE(inst, refsel, aref)
 
-#define SHIM_NRF_COMP_DT_INST_EXTREFSEL(inst) \
-	_CONCAT(COMP_NRF_COMP_EXTREFSEL_, DT_INST_STRING_TOKEN(inst, extrefsel))
+#define SHIM_NRF_COMP_DT_INST_EXTREFSEL(inst) DT_INST_PROP(inst, extrefsel)
 
 #define SHIM_NRF_COMP_DT_INST_MAIN_MODE_IS_SE(inst) \
 	DT_INST_ENUM_HAS_VALUE(inst, main_mode, se)
@@ -43,8 +42,7 @@
 #define SHIM_NRF_COMP_DT_INST_ISOURCE(inst) \
 	_CONCAT(COMP_NRF_COMP_ISOURCE_, DT_INST_STRING_TOKEN(inst, isource))
 
-#define SHIM_NRF_COMP_DT_INST_PSEL(inst) \
-	_CONCAT(COMP_NRF_COMP_PSEL_, DT_INST_STRING_TOKEN(inst, psel))
+#define SHIM_NRF_COMP_DT_INST_PSEL(inst) DT_INST_PROP(inst, psel)
 
 #if defined(COMP_HYST_HYST_Hyst40mV)
 #define NRF_COMP_HYST_ENABLED NRF_COMP_HYST_40MV
@@ -73,35 +71,50 @@ BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_TH_DOWN(0) < 64);
 BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_TH_UP(0) < 64);
 #endif
 
-#if NRF_COMP_HAS_AIN_AS_PIN
-BUILD_ASSERT((COMP_NRF_COMP_PSEL_AIN0 == 0));
-BUILD_ASSERT((COMP_NRF_COMP_PSEL_AIN7 == 7));
-BUILD_ASSERT((COMP_NRF_COMP_EXTREFSEL_AIN0 == 0));
-BUILD_ASSERT((COMP_NRF_COMP_EXTREFSEL_AIN7 == 7));
+#if (NRF_COMP_HAS_AIN_AS_PIN)
+BUILD_ASSERT(NRF_COMP_AIN0 == 0);
+BUILD_ASSERT(NRF_COMP_AIN7 == 7);
 #else
-#ifndef COMP_PSEL_PSEL_AnalogInput4
-BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_PSEL(0) != COMP_NRF_COMP_PSEL_AIN4);
+BUILD_ASSERT((NRF_COMP_AIN0 == NRF_COMP_INPUT_0) &&
+	     (NRF_COMP_AIN1 == NRF_COMP_INPUT_1) &&
+	     (NRF_COMP_AIN2 == NRF_COMP_INPUT_2) &&
+	     (NRF_COMP_AIN3 == NRF_COMP_INPUT_3) &&
+#if defined(COMP_PSEL_PSEL_AnalogInput4)
+	     (NRF_COMP_AIN4 == NRF_COMP_INPUT_4) &&
 #endif
-
-#ifndef COMP_PSEL_PSEL_AnalogInput5
-BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_PSEL(0) != COMP_NRF_COMP_PSEL_AIN5);
+#if defined(COMP_PSEL_PSEL_AnalogInput5)
+	     (NRF_COMP_AIN5 == NRF_COMP_INPUT_5) &&
 #endif
-
-#ifndef COMP_PSEL_PSEL_AnalogInput6
-BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_PSEL(0) != COMP_NRF_COMP_PSEL_AIN6);
+#if defined(COMP_PSEL_PSEL_AnalogInput6)
+	     (NRF_COMP_AIN6 == NRF_COMP_INPUT_6) &&
 #endif
-
-#ifndef COMP_PSEL_PSEL_AnalogInput7
-BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_PSEL(0) != COMP_NRF_COMP_PSEL_AIN7);
+#if defined(COMP_PSEL_PSEL_AnalogInput7)
+	     (NRF_COMP_AIN7 == NRF_COMP_INPUT_7) &&
 #endif
+	     (NRF_COMP_AIN0 == NRF_COMP_EXT_REF_0) &&
+	     (NRF_COMP_AIN1 == NRF_COMP_EXT_REF_1) &&
+	     (NRF_COMP_AIN2 == NRF_COMP_EXT_REF_2) &&
+	     (NRF_COMP_AIN3 == NRF_COMP_EXT_REF_3) &&
+#if defined(COMP_EXTREFSEL_EXTREFSEL_AnalogReference4)
+	     (NRF_COMP_AIN4 == NRF_COMP_EXT_REF_4) &&
 #endif
-
-#ifndef COMP_PSEL_PSEL_VddDiv2
-BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_PSEL(0) != COMP_NRF_COMP_PSEL_VDD_DIV2);
+#if defined(COMP_EXTREFSEL_EXTREFSEL_AnalogReference5)
+	     (NRF_COMP_AIN5 == NRF_COMP_EXT_REF_5) &&
 #endif
-
-#ifndef COMP_PSEL_PSEL_VddhDiv5
-BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_PSEL(0) != COMP_NRF_COMP_PSEL_VDDH_DIV5);
+#if defined(COMP_EXTREFSEL_EXTREFSEL_AnalogReference6)
+	     (NRF_COMP_AIN6 == NRF_COMP_EXT_REF_6) &&
+#endif
+#if defined(COMP_EXTREFSEL_EXTREFSEL_AnalogReference7)
+	     (NRF_COMP_AIN7 == NRF_COMP_EXT_REF_7) &&
+#endif
+#if defined(COMP_PSEL_PSEL_VddDiv2)
+	     (NRF_COMP_VDD_DIV2 == NRF_COMP_VDD_DIV2) &&
+#endif
+#if defined(COMP_PSEL_PSEL_VddhDiv5)
+	     (NRF_COMP_VDDH_DIV5 == NRF_COMP_VDDH_DIV5) &&
+#endif
+	     1,
+	     "Definitions from nrf-comp.h do not match those from HAL");
 #endif
 
 #ifndef COMP_MODE_SP_Normal
@@ -119,24 +132,6 @@ BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_ISOURCE(0) != COMP_NRF_COMP_ISOURCE_5UA);
 
 #ifndef COMP_ISOURCE_ISOURCE_Ien10uA
 BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_ISOURCE(0) != COMP_NRF_COMP_ISOURCE_10UA);
-#endif
-#endif
-
-#if SHIM_NRF_COMP_DT_INST_REFSEL_IS_AREF(0)
-#ifndef COMP_EXTREFSEL_EXTREFSEL_AnalogReference4
-BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_EXTREFSEL(0) != COMP_NRF_COMP_EXTREFSEL_AIN4);
-#endif
-
-#ifndef COMP_EXTREFSEL_EXTREFSEL_AnalogReference5
-BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_EXTREFSEL(0) != COMP_NRF_COMP_EXTREFSEL_AIN5);
-#endif
-
-#ifndef COMP_EXTREFSEL_EXTREFSEL_AnalogReference6
-BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_EXTREFSEL(0) != COMP_NRF_COMP_EXTREFSEL_AIN6);
-#endif
-
-#ifndef COMP_EXTREFSEL_EXTREFSEL_AnalogReference7
-BUILD_ASSERT(SHIM_NRF_COMP_DT_INST_EXTREFSEL(0) != COMP_NRF_COMP_EXTREFSEL_AIN7);
 #endif
 #endif
 
@@ -246,69 +241,69 @@ static int shim_nrf_comp_pm_callback(const struct device *dev, enum pm_device_ac
 }
 
 #if (NRF_COMP_HAS_AIN_AS_PIN)
-static int shim_nrf_comp_psel_to_nrf(enum comp_nrf_comp_psel shim,
+static int shim_nrf_comp_psel_to_nrf(uint8_t shim,
 				     nrf_comp_input_t *nrf)
 {
 	if (shim >= ARRAY_SIZE(shim_nrf_comp_ain_map)) {
 		return -EINVAL;
 	}
 
-	*nrf = shim_nrf_comp_ain_map[(uint32_t)shim];
+	*nrf = shim_nrf_comp_ain_map[shim];
 	return 0;
 }
 #else
-static int shim_nrf_comp_psel_to_nrf(enum comp_nrf_comp_psel shim,
+static int shim_nrf_comp_psel_to_nrf(uint8_t shim,
 				     nrf_comp_input_t *nrf)
 {
 	switch (shim) {
-	case COMP_NRF_COMP_PSEL_AIN0:
+	case NRF_COMP_AIN0:
 		*nrf = NRF_COMP_INPUT_0;
 		break;
 
-	case COMP_NRF_COMP_PSEL_AIN1:
+	case NRF_COMP_AIN1:
 		*nrf = NRF_COMP_INPUT_1;
 		break;
 
-	case COMP_NRF_COMP_PSEL_AIN2:
+	case NRF_COMP_AIN2:
 		*nrf = NRF_COMP_INPUT_2;
 		break;
 
-	case COMP_NRF_COMP_PSEL_AIN3:
+	case NRF_COMP_AIN3:
 		*nrf = NRF_COMP_INPUT_3;
 		break;
 
 #if defined(COMP_PSEL_PSEL_AnalogInput4)
-	case COMP_NRF_COMP_PSEL_AIN4:
+	case NRF_COMP_AIN4:
 		*nrf = NRF_COMP_INPUT_4;
 		break;
 #endif
 
 #if defined(COMP_PSEL_PSEL_AnalogInput5)
-	case COMP_NRF_COMP_PSEL_AIN5:
+	case NRF_COMP_AIN5:
 		*nrf = NRF_COMP_INPUT_5;
 		break;
 #endif
 
 #if defined(COMP_PSEL_PSEL_AnalogInput6)
-	case COMP_NRF_COMP_PSEL_AIN6:
+	case NRF_COMP_AIN6:
 		*nrf = NRF_COMP_INPUT_6;
 		break;
 #endif
 
 #if defined(COMP_PSEL_PSEL_AnalogInput7)
-	case COMP_NRF_COMP_PSEL_AIN7:
+	case NRF_COMP_AIN7:
 		*nrf = NRF_COMP_INPUT_7;
 		break;
 #endif
 
 #if defined(COMP_PSEL_PSEL_VddDiv2)
-	case COMP_NRF_COMP_PSEL_VDD_DIV2:
+	case NRF_COMP_AIN_VDD_DIV2:
 		*nrf = NRF_COMP_VDD_DIV2;
 		break;
 #endif
 
 #if defined(COMP_PSEL_PSEL_VddhDiv5)
-	case COMP_NRF_COMP_PSEL_VDDH_DIV5:
+	case NRF_COMP_AIN_VDDH_DIV5:
 		*nrf = NRF_COMP_VDDH_DIV5;
 		break;
 #endif
@@ -382,57 +377,57 @@ static int shim_nrf_comp_isource_to_nrf(enum comp_nrf_comp_isource shim,
 #endif
 
 #if (NRF_COMP_HAS_AIN_AS_PIN)
-static int shim_nrf_comp_extrefsel_to_nrf(enum comp_nrf_comp_extrefsel shim,
+static int shim_nrf_comp_extrefsel_to_nrf(uint8_t shim,
 					  nrf_comp_ext_ref_t *nrf)
 {
 	if (shim >= ARRAY_SIZE(shim_nrf_comp_ain_map)) {
 		return -EINVAL;
 	}
 
-	*nrf = shim_nrf_comp_ain_map[(uint32_t)shim];
+	*nrf = shim_nrf_comp_ain_map[shim];
 	return 0;
 }
 #else
-static int shim_nrf_comp_extrefsel_to_nrf(enum comp_nrf_comp_extrefsel shim,
+static int shim_nrf_comp_extrefsel_to_nrf(uint8_t shim,
 					  nrf_comp_ext_ref_t *nrf)
 {
 	switch (shim) {
-	case COMP_NRF_COMP_EXTREFSEL_AIN0:
+	case NRF_COMP_AIN0:
 		*nrf = NRF_COMP_EXT_REF_0;
 		break;
 
-	case COMP_NRF_COMP_EXTREFSEL_AIN1:
+	case NRF_COMP_AIN1:
 		*nrf = NRF_COMP_EXT_REF_1;
 		break;
 
-	case COMP_NRF_COMP_EXTREFSEL_AIN2:
+	case NRF_COMP_AIN2:
 		*nrf = NRF_COMP_EXT_REF_2;
 		break;
 
-	case COMP_NRF_COMP_EXTREFSEL_AIN3:
+	case NRF_COMP_AIN3:
 		*nrf = NRF_COMP_EXT_REF_3;
 		break;
 
 #if defined(COMP_EXTREFSEL_EXTREFSEL_AnalogReference4)
-	case COMP_NRF_COMP_EXTREFSEL_AIN4:
+	case NRF_COMP_AIN4:
 		*nrf = NRF_COMP_EXT_REF_4;
 		break;
 #endif
 
 #if defined(COMP_EXTREFSEL_EXTREFSEL_AnalogReference5)
-	case COMP_NRF_COMP_EXTREFSEL_AIN5:
+	case NRF_COMP_AIN5:
 		*nrf = NRF_COMP_EXT_REF_5;
 		break;
 #endif
 
 #if defined(COMP_EXTREFSEL_EXTREFSEL_AnalogReference6)
-	case COMP_NRF_COMP_EXTREFSEL_AIN6:
+	case NRF_COMP_AIN6:
 		*nrf = NRF_COMP_EXT_REF_6;
 		break;
 #endif
 
 #if defined(COMP_EXTREFSEL_EXTREFSEL_AnalogReference7)
-	case COMP_NRF_COMP_EXTREFSEL_AIN7:
+	case NRF_COMP_AIN7:
 		*nrf = NRF_COMP_EXT_REF_7;
 		break;
 #endif

--- a/drivers/comparator/comparator_nrf_lpcomp.c
+++ b/drivers/comparator/comparator_nrf_lpcomp.c
@@ -21,14 +21,12 @@
 #define SHIM_NRF_LPCOMP_DT_INST_REFSEL_IS_AREF(inst) \
 	DT_INST_ENUM_HAS_VALUE(inst, refsel, aref)
 
-#define SHIM_NRF_LPCOMP_DT_INST_EXTREFSEL(inst) \
-	_CONCAT(COMP_NRF_LPCOMP_EXTREFSEL_, DT_INST_STRING_TOKEN(inst, extrefsel))
+#define SHIM_NRF_LPCOMP_DT_INST_EXTREFSEL(inst) DT_INST_PROP(inst, extrefsel)
 
 #define SHIM_NRF_LPCOMP_DT_INST_ENABLE_HYST(inst) \
 	DT_INST_PROP(inst, enable_hyst)
 
-#define SHIM_NRF_LPCOMP_DT_INST_PSEL(inst) \
-	_CONCAT(COMP_NRF_LPCOMP_PSEL_, DT_INST_STRING_TOKEN(inst, psel))
+#define SHIM_NRF_LPCOMP_DT_INST_PSEL(inst) DT_INST_PROP(inst, psel)
 
 struct shim_nrf_lpcomp_data {
 	nrfx_lpcomp_config_t config;
@@ -40,10 +38,20 @@ struct shim_nrf_lpcomp_data {
 };
 
 #if (NRF_LPCOMP_HAS_AIN_AS_PIN)
-BUILD_ASSERT(COMP_NRF_LPCOMP_PSEL_AIN0 == 0);
-BUILD_ASSERT(COMP_NRF_LPCOMP_PSEL_AIN7 == 7);
-BUILD_ASSERT(COMP_NRF_LPCOMP_EXTREFSEL_AIN0 == 0);
-BUILD_ASSERT(COMP_NRF_LPCOMP_EXTREFSEL_AIN1 == 1);
+BUILD_ASSERT(NRF_COMP_AIN0 == 0);
+BUILD_ASSERT(NRF_COMP_AIN7 == 7);
+#else
+BUILD_ASSERT((NRF_COMP_AIN0 == NRF_LPCOMP_INPUT_0) &&
+	     (NRF_COMP_AIN1 == NRF_LPCOMP_INPUT_1) &&
+	     (NRF_COMP_AIN2 == NRF_LPCOMP_INPUT_2) &&
+	     (NRF_COMP_AIN3 == NRF_LPCOMP_INPUT_3) &&
+	     (NRF_COMP_AIN4 == NRF_LPCOMP_INPUT_4) &&
+	     (NRF_COMP_AIN5 == NRF_LPCOMP_INPUT_5) &&
+	     (NRF_COMP_AIN6 == NRF_LPCOMP_INPUT_6) &&
+	     (NRF_COMP_AIN7 == NRF_LPCOMP_INPUT_7) &&
+	     (NRF_COMP_AIN0 == NRF_LPCOMP_EXT_REF_REF0) &&
+	     (NRF_COMP_AIN1 == NRF_LPCOMP_EXT_REF_REF1),
+	     "Definitions from nrf-comp.h do not match those from HAL");
 #endif
 
 #if (LPCOMP_REFSEL_RESOLUTION == 8)
@@ -126,50 +134,50 @@ static int shim_nrf_lpcomp_pm_callback(const struct device *dev, enum pm_device_
 }
 
 #if (NRF_LPCOMP_HAS_AIN_AS_PIN)
-static int shim_nrf_lpcomp_psel_to_nrf(enum comp_nrf_lpcomp_psel shim,
+static int shim_nrf_lpcomp_psel_to_nrf(uint8_t shim,
 				       nrf_lpcomp_input_t *nrf)
 {
 	if (shim >= ARRAY_SIZE(shim_nrf_comp_ain_map)) {
 		return -EINVAL;
 	}
 
-	*nrf = shim_nrf_comp_ain_map[(uint32_t)shim];
+	*nrf = shim_nrf_comp_ain_map[shim];
 	return 0;
 }
 #else
-static int shim_nrf_lpcomp_psel_to_nrf(enum comp_nrf_lpcomp_psel shim,
+static int shim_nrf_lpcomp_psel_to_nrf(uint8_t shim,
 				       nrf_lpcomp_input_t *nrf)
 {
 	switch (shim) {
-	case COMP_NRF_LPCOMP_PSEL_AIN0:
+	case  NRF_COMP_AIN0:
 		*nrf = NRF_LPCOMP_INPUT_0;
 		break;
 
-	case COMP_NRF_LPCOMP_PSEL_AIN1:
+	case  NRF_COMP_AIN1:
 		*nrf = NRF_LPCOMP_INPUT_1;
 		break;
 
-	case COMP_NRF_LPCOMP_PSEL_AIN2:
+	case  NRF_COMP_AIN2:
 		*nrf = NRF_LPCOMP_INPUT_2;
 		break;
 
-	case COMP_NRF_LPCOMP_PSEL_AIN3:
+	case  NRF_COMP_AIN3:
 		*nrf = NRF_LPCOMP_INPUT_3;
 		break;
 
-	case COMP_NRF_LPCOMP_PSEL_AIN4:
+	case  NRF_COMP_AIN4:
 		*nrf = NRF_LPCOMP_INPUT_4;
 		break;
 
-	case COMP_NRF_LPCOMP_PSEL_AIN5:
+	case  NRF_COMP_AIN5:
 		*nrf = NRF_LPCOMP_INPUT_5;
 		break;
 
-	case COMP_NRF_LPCOMP_PSEL_AIN6:
+	case  NRF_COMP_AIN6:
 		*nrf = NRF_LPCOMP_INPUT_6;
 		break;
 
-	case COMP_NRF_LPCOMP_PSEL_AIN7:
+	case  NRF_COMP_AIN7:
 		*nrf = NRF_LPCOMP_INPUT_7;
 		break;
 
@@ -182,7 +190,7 @@ static int shim_nrf_lpcomp_psel_to_nrf(enum comp_nrf_lpcomp_psel shim,
 #endif
 
 #if (NRF_LPCOMP_HAS_AIN_AS_PIN)
-static int shim_nrf_lpcomp_extrefsel_to_nrf(enum comp_nrf_lpcomp_extrefsel shim,
+static int shim_nrf_lpcomp_extrefsel_to_nrf(uint8_t shim,
 					    nrf_lpcomp_ext_ref_t *nrf)
 {
 	if (shim >= ARRAY_SIZE(shim_nrf_comp_ain_map)) {
@@ -193,15 +201,15 @@ static int shim_nrf_lpcomp_extrefsel_to_nrf(enum comp_nrf_lpcomp_extrefsel shim,
 	return 0;
 }
 #else
-static int shim_nrf_lpcomp_extrefsel_to_nrf(enum comp_nrf_lpcomp_extrefsel shim,
+static int shim_nrf_lpcomp_extrefsel_to_nrf(uint8_t shim,
 					    nrf_lpcomp_ext_ref_t *nrf)
 {
 	switch (shim) {
-	case COMP_NRF_LPCOMP_EXTREFSEL_AIN0:
+	case  NRF_COMP_AIN0:
 		*nrf = NRF_LPCOMP_EXT_REF_REF0;
 		break;
 
-	case COMP_NRF_LPCOMP_EXTREFSEL_AIN1:
+	case  NRF_COMP_AIN1:
 		*nrf = NRF_LPCOMP_EXT_REF_REF1;
 		break;
 

--- a/dts/bindings/comparator/nordic,nrf-comp.yaml
+++ b/dts/bindings/comparator/nordic,nrf-comp.yaml
@@ -25,7 +25,7 @@ description: |
     &comp {
             status = "okay";
             main-mode = "SE";
-            psel = "AIN0";
+            psel = <NRF_COMP_AIN0>;
             refsel = "INT_1V2";
             sp-mode = "NORMAL";
             th-up = <36>;
@@ -39,7 +39,7 @@ description: |
     &comp {
             ...
             refsel = "AREF";
-            extrefsel = "AIN1";
+            extrefsel = <NRF_COMP_AIN1>;
             ...
     };
 
@@ -49,8 +49,8 @@ description: |
     &comp {
             status = "okay";
             main-mode = "DIFF";
-            psel = "AIN0";
-            extrefsel = "AIN1";
+            psel = <NRF_COMP_AIN0>;
+            extrefsel = <NRF_COMP_AIN1>;
             sp-mode = "NORMAL";
             enable-hyst;
             isource = "DISABLED";
@@ -68,30 +68,10 @@ properties:
       - "DIFF"
 
   psel:
-    type: string
-    enum:
-      - "AIN0"
-      - "AIN1"
-      - "AIN2"
-      - "AIN3"
-      - "AIN4"
-      - "AIN5"
-      - "AIN6"
-      - "AIN7"
-      - "VDD_DIV2"
-      - "VDDH_DIV5"
+    type: int
 
   extrefsel:
-    type: string
-    enum:
-      - "AIN0"
-      - "AIN1"
-      - "AIN2"
-      - "AIN3"
-      - "AIN4"
-      - "AIN5"
-      - "AIN6"
-      - "AIN7"
+    type: int
 
   refsel:
     type: string

--- a/dts/bindings/comparator/nordic,nrf-lpcomp.yaml
+++ b/dts/bindings/comparator/nordic,nrf-lpcomp.yaml
@@ -21,7 +21,7 @@ description: |
 
     &comp {
             status = "okay";
-            psel = "AIN0";
+            psel = <NRF_COMP_AIN0>;
             refsel = "VDD_4_8";
             enable-hyst;
     };
@@ -32,7 +32,7 @@ description: |
     &comp {
             ...
             refsel = "AREF";
-            extrefsel = "AIN1";
+            extrefsel = <NRF_COMP_AIN1>;
             ...
     };
 
@@ -42,22 +42,10 @@ include: base.yaml
 
 properties:
   psel:
-    type: string
-    enum:
-      - "AIN0"
-      - "AIN1"
-      - "AIN2"
-      - "AIN3"
-      - "AIN4"
-      - "AIN5"
-      - "AIN6"
-      - "AIN7"
+    type: int
 
   extrefsel:
-    type: string
-    enum:
-      - "AIN0"
-      - "AIN1"
+    type: int
 
   refsel:
     type: string

--- a/include/zephyr/drivers/comparator/nrf_comp.h
+++ b/include/zephyr/drivers/comparator/nrf_comp.h
@@ -7,55 +7,12 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_COMP_NRF_COMP_H_
 #define ZEPHYR_INCLUDE_DRIVERS_COMP_NRF_COMP_H_
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
 #include <zephyr/drivers/comparator.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/** Positive input selection */
-enum comp_nrf_comp_psel {
-	/** AIN0 external input */
-	COMP_NRF_COMP_PSEL_AIN0,
-	/** AIN1 external input */
-	COMP_NRF_COMP_PSEL_AIN1,
-	/** AIN2 external input */
-	COMP_NRF_COMP_PSEL_AIN2,
-	/** AIN3 external input */
-	COMP_NRF_COMP_PSEL_AIN3,
-	/** AIN4 external input */
-	COMP_NRF_COMP_PSEL_AIN4,
-	/** AIN5 external input */
-	COMP_NRF_COMP_PSEL_AIN5,
-	/** AIN6 external input */
-	COMP_NRF_COMP_PSEL_AIN6,
-	/** AIN7 external input */
-	COMP_NRF_COMP_PSEL_AIN7,
-	/** VDD / 2 */
-	COMP_NRF_COMP_PSEL_VDD_DIV2,
-	/** VDDH / 5 */
-	COMP_NRF_COMP_PSEL_VDDH_DIV5,
-};
-
-/** External reference selection */
-enum comp_nrf_comp_extrefsel {
-	/** AIN0 external input */
-	COMP_NRF_COMP_EXTREFSEL_AIN0,
-	/** AIN1 external input */
-	COMP_NRF_COMP_EXTREFSEL_AIN1,
-	/** AIN2 external input */
-	COMP_NRF_COMP_EXTREFSEL_AIN2,
-	/** AIN3 external input */
-	COMP_NRF_COMP_EXTREFSEL_AIN3,
-	/** AIN4 external input */
-	COMP_NRF_COMP_EXTREFSEL_AIN4,
-	/** AIN5 external input */
-	COMP_NRF_COMP_EXTREFSEL_AIN5,
-	/** AIN6 external input */
-	COMP_NRF_COMP_EXTREFSEL_AIN6,
-	/** AIN7 external input */
-	COMP_NRF_COMP_EXTREFSEL_AIN7,
-};
 
 /** Reference selection */
 enum comp_nrf_comp_refsel {
@@ -103,14 +60,14 @@ enum comp_nrf_comp_isource {
  * @note Hysteresis up in volts = ((th_up + 1) / 64) * ref
  */
 struct comp_nrf_comp_se_config {
-	/** Positive input selection */
-	enum comp_nrf_comp_psel psel;
+	/** Positive input selection defined by the NRF_COMP_AIN defines */
+	uint8_t psel;
 	/** Speed mode selection */
 	enum comp_nrf_comp_sp_mode sp_mode;
 	/** Current source configuration */
 	enum comp_nrf_comp_isource isource;
-	/** External reference selection */
-	enum comp_nrf_comp_extrefsel extrefsel;
+	/** External reference input selection defined by the NRF_COMP_AIN defines */
+	uint8_t extrefsel;
 	/** Reference selection */
 	enum comp_nrf_comp_refsel refsel;
 	/** Hysteresis down threshold configuration */
@@ -133,14 +90,14 @@ int comp_nrf_comp_configure_se(const struct device *dev,
 
 /** Differential mode configuration structure */
 struct comp_nrf_comp_diff_config {
-	/** Positive input selection */
-	enum comp_nrf_comp_psel psel;
+	/** Positive input selection defined by the NRF_COMP_AIN defines */
+	uint8_t psel;
 	/** Speed mode selection */
 	enum comp_nrf_comp_sp_mode sp_mode;
 	/** Current source configuration */
 	enum comp_nrf_comp_isource isource;
-	/** Negative input selection */
-	enum comp_nrf_comp_extrefsel extrefsel;
+	/** Negative input selection defined by the NRF_COMP_AIN defines */
+	uint8_t extrefsel;
 	/** Hysteresis configuration */
 	bool enable_hyst;
 };

--- a/include/zephyr/drivers/comparator/nrf_lpcomp.h
+++ b/include/zephyr/drivers/comparator/nrf_lpcomp.h
@@ -7,39 +7,12 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_COMP_NRF_LPCOMP_H_
 #define ZEPHYR_INCLUDE_DRIVERS_COMP_NRF_LPCOMP_H_
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
 #include <zephyr/drivers/comparator.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/** Positive input selection */
-enum comp_nrf_lpcomp_psel {
-	/** AIN0 external input */
-	COMP_NRF_LPCOMP_PSEL_AIN0,
-	/** AIN1 external input */
-	COMP_NRF_LPCOMP_PSEL_AIN1,
-	/** AIN2 external input */
-	COMP_NRF_LPCOMP_PSEL_AIN2,
-	/** AIN3 external input */
-	COMP_NRF_LPCOMP_PSEL_AIN3,
-	/** AIN4 external input */
-	COMP_NRF_LPCOMP_PSEL_AIN4,
-	/** AIN5 external input */
-	COMP_NRF_LPCOMP_PSEL_AIN5,
-	/** AIN6 external input */
-	COMP_NRF_LPCOMP_PSEL_AIN6,
-	/** AIN7 external input */
-	COMP_NRF_LPCOMP_PSEL_AIN7,
-};
-
-/** External reference selection */
-enum comp_nrf_lpcomp_extrefsel {
-	/** AIN0 external input */
-	COMP_NRF_LPCOMP_EXTREFSEL_AIN0,
-	/** AIN1 external input */
-	COMP_NRF_LPCOMP_EXTREFSEL_AIN1,
-};
 
 /** Reference selection */
 enum comp_nrf_lpcomp_refsel {
@@ -83,10 +56,10 @@ enum comp_nrf_lpcomp_refsel {
  * @note extrefsel is only used if refsel == COMP_NRF_LPCOMP_REFSEL_AREF
  */
 struct comp_nrf_lpcomp_config {
-	/** Positive input selection */
-	enum comp_nrf_lpcomp_psel psel;
-	/** External reference selection */
-	enum comp_nrf_lpcomp_extrefsel extrefsel;
+	/** Positive input selection defined by the NRF_COMP_AIN defines */
+	uint8_t psel;
+	/** External reference input selection defined by the NRF_COMP_AIN defines */
+	uint8_t extrefsel;
 	/** Reference selection */
 	enum comp_nrf_lpcomp_refsel refsel;
 	/** Hysteresis configuration */

--- a/include/zephyr/dt-bindings/comparator/nrf-comp.h
+++ b/include/zephyr/dt-bindings/comparator/nrf-comp.h
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_COMP_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_COMP_H_
+
+#define NRF_COMP_AIN0 0 /** AIN0 external input */
+#define NRF_COMP_AIN1 1 /** AIN1 external input */
+#define NRF_COMP_AIN2 2 /** AIN2 external input */
+#define NRF_COMP_AIN3 3 /** AIN3 external input */
+#define NRF_COMP_AIN4 4 /** AIN4 external input */
+#define NRF_COMP_AIN5 5 /** AIN5 external input */
+#define NRF_COMP_AIN6 6 /** AIN6 external input */
+#define NRF_COMP_AIN7 7 /** AIN7 external input */
+#define NRF_COMP_AIN_VDD_DIV2 8 /** VDD / 2 */
+#define NRF_COMP_AIN_VDDH_DIV5 9 /** VDDH / 5 */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_NRF_COMP_H_ */

--- a/samples/boards/nordic/system_off/boards/nrf54l15dk_nrf54l15_cpuapp_comparator.overlay
+++ b/samples/boards/nordic/system_off/boards/nrf54l15dk_nrf54l15_cpuapp_comparator.overlay
@@ -1,6 +1,8 @@
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	compatible = "nordic,nrf-lpcomp";
-	psel = "AIN4";
+	psel = <NRF_COMP_AIN4>;
 	refsel = "VDD_4_8";
 	status = "okay";
 };

--- a/tests/boards/nrf/comp/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/boards/nrf/comp/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 / {
 	aliases {
 		test-comp = &comp;
@@ -30,9 +32,9 @@
 
 &comp {
 	status = "okay";
-	psel = "AIN4";
+	psel = <NRF_COMP_AIN4>;
 	refsel = "AREF";
-	extrefsel = "AIN3";
+	extrefsel = <NRF_COMP_AIN3>;
 	sp-mode = "NORMAL";
 	th-up = <36>;
 	th-down = <30>;

--- a/tests/boards/nrf/comp/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/boards/nrf/comp/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 / {
 	aliases {
 		test-comp = &comp;
@@ -30,9 +32,9 @@
 
 &comp {
 	status = "okay";
-	psel = "AIN4";
+	psel = <NRF_COMP_AIN4>;
 	refsel = "AREF";
-	extrefsel = "AIN3";
+	extrefsel = <NRF_COMP_AIN3>;
 	sp-mode = "NORMAL";
 	th-up = <36>;
 	th-down = <30>;

--- a/tests/boards/nrf/comp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/boards/nrf/comp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 / {
 	aliases {
 		test-comp = &comp;
@@ -25,9 +27,9 @@
 
 &comp {
 	status = "okay";
-	psel = "AIN5";
+	psel = <NRF_COMP_AIN5>;
 	refsel = "AREF";
-	extrefsel = "AIN1";
+	extrefsel = <NRF_COMP_AIN1>;
 	sp-mode = "HIGH";
 	th-up = <36>;
 	th-down = <30>;

--- a/tests/boards/nrf/comp/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/boards/nrf/comp/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 / {
 	aliases {
 		test-comp = &comp;
@@ -29,9 +31,9 @@
 
 &comp {
 	status = "okay";
-	psel = "AIN4";
+	psel = <NRF_COMP_AIN4>;
 	refsel = "AREF";
-	extrefsel = "AIN3";
+	extrefsel = <NRF_COMP_AIN3>;
 	sp-mode = "NORMAL";
 	th-up = <36>;
 	th-down = <30>;

--- a/tests/boards/nrf/comp/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/boards/nrf/comp/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -5,6 +5,8 @@
  * AIN4 (P1.06) tied to VDD
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 / {
 	aliases {
 		test-comp = &comp;
@@ -22,9 +24,9 @@
 
 &comp {
 	status = "okay";
-	psel = "AIN4";
+	psel = <NRF_COMP_AIN4>;
 	refsel = "AREF";
-	extrefsel = "AIN3";
+	extrefsel = <NRF_COMP_AIN3>;
 	sp-mode = "NORMAL";
 	th-up = <36>;
 	th-down = <30>;

--- a/tests/boards/nrf/comp/src/test.c
+++ b/tests/boards/nrf/comp/src/test.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/ztest.h>
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
 #include <zephyr/drivers/comparator/nrf_comp.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/kernel.h>
@@ -13,14 +14,11 @@ static const struct device *test_dev = DEVICE_DT_GET(DT_ALIAS(test_comp));
 static const struct gpio_dt_spec test_pin_1 = GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), first_gpios);
 static const struct gpio_dt_spec test_pin_2 = GPIO_DT_SPEC_GET(DT_PATH(zephyr_user), second_gpios);
 
-#define TEST_COMP_SE_PSEL_AIN _CONCAT(COMP_NRF_COMP_PSEL_AIN, \
-				      CONFIG_TEST_COMP_SE_PSEL_AIN_INDEX)
-#define TEST_COMP_SE_EXTREFSEL_AIN _CONCAT(COMP_NRF_COMP_EXTREFSEL_AIN, \
-					   CONFIG_TEST_COMP_SE_EXTREFSEL_AIN_INDEX)
-#define TEST_COMP_DIFF_PSEL_AIN _CONCAT(COMP_NRF_COMP_PSEL_AIN, \
-					CONFIG_TEST_COMP_DIFF_PSEL_AIN_INDEX)
-#define TEST_COMP_DIFF_EXTREFSEL_AIN _CONCAT(COMP_NRF_COMP_EXTREFSEL_AIN, \
-					     CONFIG_TEST_COMP_DIFF_EXTREFSEL_AIN_INDEX)
+#define TEST_COMP_SE_PSEL_AIN      _CONCAT(NRF_COMP_AIN, CONFIG_TEST_COMP_SE_PSEL_AIN_INDEX)
+#define TEST_COMP_SE_EXTREFSEL_AIN _CONCAT(NRF_COMP_AIN, CONFIG_TEST_COMP_SE_EXTREFSEL_AIN_INDEX)
+#define TEST_COMP_DIFF_PSEL_AIN    _CONCAT(NRF_COMP_AIN, CONFIG_TEST_COMP_DIFF_PSEL_AIN_INDEX)
+#define TEST_COMP_DIFF_EXTREFSEL_AIN                                                               \
+	_CONCAT(NRF_COMP_AIN, CONFIG_TEST_COMP_DIFF_EXTREFSEL_AIN_INDEX)
 
 struct comp_nrf_comp_se_config comp_se_config = {
 	.psel = TEST_COMP_SE_PSEL_AIN,

--- a/tests/drivers/build_all/comparator/nrf_comp/diff.overlay
+++ b/tests/drivers/build_all/comparator/nrf_comp/diff.overlay
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	main-mode = "DIFF";
-	psel = "AIN0";
-	extrefsel = "AIN1";
+	psel = <NRF_COMP_AIN0>;
+	extrefsel = <NRF_COMP_AIN1>;
 	sp-mode = "HIGH";
 	isource = "DISABLED";
 	status = "okay";

--- a/tests/drivers/build_all/comparator/nrf_comp/se.overlay
+++ b/tests/drivers/build_all/comparator/nrf_comp/se.overlay
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	main-mode = "SE";
-	psel = "AIN0";
+	psel = <NRF_COMP_AIN0>;
 	refsel = "INT_1V2";
 	sp-mode = "HIGH";
 	th-up = <36>;

--- a/tests/drivers/build_all/comparator/nrf_comp/se_aref.overlay
+++ b/tests/drivers/build_all/comparator/nrf_comp/se_aref.overlay
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	main-mode = "SE";
-	psel = "AIN0";
-	extrefsel = "AIN1";
+	psel = <NRF_COMP_AIN0>;
+	extrefsel = <NRF_COMP_AIN1>;
 	refsel = "AREF";
 	sp-mode = "HIGH";
 	th-up = <36>;

--- a/tests/drivers/build_all/comparator/nrf_lpcomp/ext_ref.overlay
+++ b/tests/drivers/build_all/comparator/nrf_lpcomp/ext_ref.overlay
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	compatible = "nordic,nrf-lpcomp";
-	psel = "AIN0";
+	psel = <NRF_COMP_AIN0>;
 	refsel = "VDD_4_8";
 	status = "okay";
 };

--- a/tests/drivers/build_all/comparator/nrf_lpcomp/int_ref.overlay
+++ b/tests/drivers/build_all/comparator/nrf_lpcomp/int_ref.overlay
@@ -4,10 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	compatible = "nordic,nrf-lpcomp";
-	psel = "AIN0";
+	psel = <NRF_COMP_AIN0>;
 	refsel = "AREF";
-	extrefsel = "AIN1";
+	extrefsel = <NRF_COMP_AIN1>;
 	status = "okay";
 };

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -5,9 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	main-mode = "SE";
-	psel = "AIN4"; /* P1.11 */
+	psel = <NRF_COMP_AIN4>; /* P1.11 */
 	refsel = "INT_1V2";
 	sp-mode = "HIGH";
 	th-up = <63>;

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -5,9 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	main-mode = "SE";
-	psel = "AIN4"; /* P1.11 */
+	psel = <NRF_COMP_AIN4>; /* P1.11 */
 	refsel = "INT_1V2";
 	sp-mode = "HIGH";
 	th-up = <63>;

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	main-mode = "SE";
-	psel = "AIN0"; /* P0.04 */
+	psel = <NRF_COMP_AIN0>; /* P0.04 */
 	refsel = "VDD";
 	sp-mode = "HIGH";
 	th-up = <34>;

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	main-mode = "SE";
-	psel = "AIN2"; /* P1.02 */
+	psel = <NRF_COMP_AIN2>; /* P1.02 */
 	refsel = "INT_1V2";
 	sp-mode = "HIGH";
 	th-up = <63>;

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	main-mode = "SE";
-	psel = "AIN4"; /* P1.11 */
+	psel = <NRF_COMP_AIN4>; /* P1.11 */
 	refsel = "INT_1V2";
 	sp-mode = "HIGH";
 	th-up = <63>;

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_comp/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	main-mode = "SE";
-	psel = "AIN1"; /* P1.31 */
+	psel = <NRF_COMP_AIN1>; /* P1.31 */
 	refsel = "INT_1V2";
 	sp-mode = "HIGH";
 	th-up = <63>;

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/bl54l15_dvk_nrf54l15_cpuapp.overlay
@@ -5,9 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	compatible = "nordic,nrf-lpcomp";
-	psel = "AIN4"; /* P1.11 */
+	psel = <NRF_COMP_AIN4>; /* P1.11 */
 	refsel = "VDD_4_8";
 	status = "okay";
 };

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/bl54l15u_dvk_nrf54l15_cpuapp.overlay
@@ -5,9 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	compatible = "nordic,nrf-lpcomp";
-	psel = "AIN4"; /* P1.11 */
+	psel = <NRF_COMP_AIN4>; /* P1.11 */
 	refsel = "VDD_4_8";
 	status = "okay";
 };

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	compatible = "nordic,nrf-lpcomp";
-	psel = "AIN0"; /* P0.04 */
+	psel = <NRF_COMP_AIN0>; /* P0.04 */
 	refsel = "VDD_4_8";
 	status = "okay";
 };

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	compatible = "nordic,nrf-lpcomp";
-	psel = "AIN2"; /* P1.02 */
+	psel = <NRF_COMP_AIN2>; /* P1.02 */
 	refsel = "VDD_4_8";
 	status = "okay";
 };

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf54l15dk_nrf54l15_cpuapp.overlay
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	compatible = "nordic,nrf-lpcomp";
-	psel = "AIN4"; /* P1.11 */
+	psel = <NRF_COMP_AIN4>; /* P1.11 */
 	refsel = "VDD_4_8";
 	status = "okay";
 };

--- a/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
+++ b/tests/drivers/comparator/gpio_loopback/snippets/nrf_lpcomp/boards/nrf54lm20dk_nrf54lm20a_cpuapp.overlay
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/dt-bindings/comparator/nrf-comp.h>
+
 &comp {
 	compatible = "nordic,nrf-lpcomp";
-	psel = "AIN1"; /* P1.31 */
+	psel = <NRF_COMP_AIN1>; /* P1.31 */
 	refsel = "VDD_4_8";
 	status = "okay";
 };


### PR DESCRIPTION
Unify external analog inputs type to be consistent in COMP, LPCOMP and SAADC nordic drivers.