### PR TITLE
[nrf noup] tests: arm_irq_vector_table: remove SSF_CLIENT_SYS_INIT

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpuapp.conf
+++ b/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpuapp.conf
@@ -2,4 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_POWER_DOMAIN=n
-CONFIG_SSF_CLIENT_SYS_INIT=n

--- a/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpurad.conf
+++ b/tests/arch/arm/arm_irq_vector_table/boards/nrf54h20dk_nrf54h20_cpurad.conf
@@ -2,4 +2,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
 CONFIG_POWER_DOMAIN=n
-CONFIG_SSF_CLIENT_SYS_INIT=n


### PR DESCRIPTION
SSF was removed.

This is basically a revert of 8c97493e725979a39138d9a13956ac2c8a5c04bf
but it does not apply cleanly.
Both can be dropped at next upmerge.