### PR TITLE
[nrf fromlist] samples: boards: nordic: spis_wakeup: Fix sample on nr…

### DIFF
--- a/samples/boards/nordic/spis_wakeup/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/samples/boards/nordic/spis_wakeup/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -57,6 +57,7 @@
 	pinctrl-names = "default", "sleep";
 	wake-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
 	memory-regions = <&cpuapp_dma_region>;
+	zephyr,pm-device-runtime-auto;
 	/delete-property/ rx-delay-supported;
 	/delete-property/ rx-delay;
 };


### PR DESCRIPTION
…f54h20

Add missing property to spi130 node.
Add `zephyr,pm-device-runtime-auto` since the sample enables PM.

Upstream PR #: 97044