### PR TITLE
[nrf fromtree] dts: vendor: nordic: nrf54l: Reserve 1kB of RAM for fl…

### DIFF
--- a/dts/vendor/nordic/nrf54l05_cpuflpr.dtsi
+++ b/dts/vendor/nordic/nrf54l05_cpuflpr.dtsi
@@ -9,12 +9,12 @@
 
 / {
 	soc {
-		cpuflpr_sram: memory@20010000 {
+		cpuflpr_sram: memory@2000fc00 {
 			compatible = "mmio-sram";
-			reg = <0x20010000 DT_SIZE_K(32)>;
+			reg = <0x2000fc00 DT_SIZE_K(32)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x20010000 DT_SIZE_K(32)>;
+			ranges = <0x0 0x2000fc00 DT_SIZE_K(32)>;
 		};
 	};
 };

--- a/dts/vendor/nordic/nrf54l10_cpuflpr.dtsi
+++ b/dts/vendor/nordic/nrf54l10_cpuflpr.dtsi
@@ -9,12 +9,12 @@
 
 / {
 	soc {
-		cpuflpr_sram: memory@20020000 {
+		cpuflpr_sram: memory@2001fc00 {
 			compatible = "mmio-sram";
-			reg = <0x20020000 DT_SIZE_K(64)>;
+			reg = <0x2001fc00 DT_SIZE_K(64)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x20020000 DT_SIZE_K(64)>;
+			ranges = <0x0 0x2001fc00 DT_SIZE_K(64)>;
 		};
 	};
 };

--- a/dts/vendor/nordic/nrf54l15_cpuflpr.dtsi
+++ b/dts/vendor/nordic/nrf54l15_cpuflpr.dtsi
@@ -7,15 +7,15 @@
 #include <nordic/nrf54l15.dtsi>
 #include <riscv/nordic/nrf54l_05_10_15_cpuflpr.dtsi>
 
-/* 188 + 68 = 256KB */
+/* 159 + 96 + 1 = 256KB */
 / {
 	soc {
-		cpuflpr_sram: memory@20028000 {
+		cpuflpr_sram: memory@20027c00 {
 			compatible = "mmio-sram";
-			reg = <0x20028000 DT_SIZE_K(96)>;
+			reg = <0x20027c00 DT_SIZE_K(96)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			ranges = <0x0 0x2002f000 DT_SIZE_K(96)>;
+			ranges = <0x0 0x20027c00 DT_SIZE_K(96)>;
 		};
 	};
 };

--- a/snippets/nordic/nordic-flpr/soc/nrf54l05_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54l05_cpuapp.overlay
@@ -5,10 +5,10 @@
 
 / {
 	soc {
-		cpuflpr_sram_code_data: memory@20010000 {
+		cpuflpr_sram_code_data: memory@2000fc00 {
 			compatible = "mmio-sram";
-			reg = <0x20010000 DT_SIZE_K(32)>;
-			ranges = <0x0 0x20010000 DT_SIZE_K(32)>;
+			reg = <0x2000fc00 DT_SIZE_K(32)>;
+			ranges = <0x0 0x2000fc00 DT_SIZE_K(32)>;
 			status = "reserved";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -21,8 +21,8 @@
 };
 
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(64)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(64)>;
+	reg = <0x20000000 DT_SIZE_K(63)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(63)>;
 };
 
 &cpuapp_rram {

--- a/snippets/nordic/nordic-flpr/soc/nrf54l10_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54l10_cpuapp.overlay
@@ -5,10 +5,10 @@
 
 / {
 	soc {
-		cpuflpr_sram_code_data: memory@20020000 {
+		cpuflpr_sram_code_data: memory@2001fc00 {
 			compatible = "mmio-sram";
-			reg = <0x20020000 DT_SIZE_K(64)>;
-			ranges = <0x0 0x20020000 DT_SIZE_K(64)>;
+			reg = <0x2001fc00 DT_SIZE_K(64)>;
+			ranges = <0x0 0x2001fc00 DT_SIZE_K(64)>;
 			status = "reserved";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -21,8 +21,8 @@
 };
 
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(128)>;
-	ranges = <0x0 0x20000000 DT_SIZE_K(128)>;
+	reg = <0x20000000 DT_SIZE_K(127)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(127)>;
 };
 
 &cpuapp_rram {

--- a/snippets/nordic/nordic-flpr/soc/nrf54l15_cpuapp.overlay
+++ b/snippets/nordic/nordic-flpr/soc/nrf54l15_cpuapp.overlay
@@ -5,10 +5,10 @@
 
 / {
 	soc {
-		cpuflpr_sram_code_data: memory@20028000 {
+		cpuflpr_sram_code_data: memory@20027c00 {
 			compatible = "mmio-sram";
-			reg = <0x20028000 DT_SIZE_K(96)>;
-			ranges = <0x0 0x20028000 0x18000>;
+			reg = <0x20027c00 DT_SIZE_K(96)>;
+			ranges = <0x0 0x20027c00 DT_SIZE_K(96)>;
 			status = "reserved";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -21,8 +21,8 @@
 };
 
 &cpuapp_sram {
-	reg = <0x20000000 DT_SIZE_K(160)>;
-	ranges = <0x0 0x20000000 0x28000>;
+	reg = <0x20000000 DT_SIZE_K(159)>;
+	ranges = <0x0 0x20000000 DT_SIZE_K(159)>;
 };
 
 &cpuapp_rram {


### PR DESCRIPTION
…pr hiberantion

Like in nrf54lm20, reserve last 1kB from RAM for FLPR hibernation if FLPR is in use. Hibernation is the default and recommended sleep mode. Align nordic-flpr snippet.


(cherry picked from commit 630cd71bc606710a0cd369963032b4041ccee399)