### PR TITLE
[nrf noup] drivers: ironside: re-ring bell to fix notify-before-dequeue

### DIFF
--- a/modules/hal_nordic/ironside/se/Kconfig
+++ b/modules/hal_nordic/ironside/se/Kconfig
@@ -50,6 +50,19 @@ config IRONSIDE_SE_CALL_MINIMAL
 
 endchoice
 
+config IRONSIDE_SE_CALL_RESPONSE_TIMEOUT_MS
+	int "IronSide call response timeout (ms)"
+	default 1000
+	depends on IRONSIDE_SE_CALL_ZEPHYR
+	help
+	  Time to wait for a response before posting the request again,
+	  in milliseconds. This is a workaround for IronSide SE versions
+	  that notify the client before dequeuing the request: a request
+	  posted in that window is skipped and would otherwise never be
+	  answered. Posting the request again is harmless because the
+	  enqueue is idempotent. Set to 0 to wait forever and disable the
+	  workaround on IronSide SE versions that include the fix.
+
 config IRONSIDE_SE_CALL_INIT_PRIORITY
 	int "IronSide calls' driver initialization priority"
 	default 41

--- a/modules/hal_nordic/ironside/se/call.c
+++ b/modules/hal_nordic/ironside/se/call.c
@@ -112,6 +112,11 @@ struct ironside_se_call_buf *ironside_se_call_alloc(void)
 void ironside_se_call_dispatch(struct ironside_se_call_buf *buf)
 {
 	const uint32_t buf_bit = BIT(buf - bufs);
+#if CONFIG_IRONSIDE_SE_CALL_RESPONSE_TIMEOUT_MS > 0
+	const k_timeout_t rsp_timeout = K_MSEC(CONFIG_IRONSIDE_SE_CALL_RESPONSE_TIMEOUT_MS);
+#else
+	const k_timeout_t rsp_timeout = K_FOREVER;
+#endif
 	int err;
 
 	buf->status = IRONSIDE_SE_CALL_STATUS_REQ;
@@ -121,10 +126,13 @@ void ironside_se_call_dispatch(struct ironside_se_call_buf *buf)
 
 	k_event_clear(&rsp_evts, buf_bit);
 
-	err = mbox_send_dt(&mbox_tx, NULL);
-	__ASSERT_NO_MSG(err == 0);
-
-	k_event_wait(&rsp_evts, buf_bit, false, K_FOREVER);
+	/* Post the request, re-posting on timeout; see
+	 * CONFIG_IRONSIDE_SE_CALL_RESPONSE_TIMEOUT_MS.
+	 */
+	do {
+		err = mbox_send_dt(&mbox_tx, NULL);
+		__ASSERT_NO_MSG(err == 0);
+	} while (k_event_wait(&rsp_evts, buf_bit, false, rsp_timeout) == 0);
 }
 
 void ironside_se_call_release(struct ironside_se_call_buf *buf)


### PR DESCRIPTION
IronSide SE servers predating NCSDK-39877 notify the client before dequeuing the request. In that window the Zephyr client can complete the call and post a new request in the same buffer (release, alloc, write, ring the bell) before the server dequeues. The server's ironside_call_recv scan then skips the buffer because it still looks queued, so the new request is never enqueued and the client blocks forever in k_event_wait(K_FOREVER).

Wait CONFIG_IRONSIDE_SE_CALL_RESPONSE_TIMEOUT_MS instead of forever and re-ring the bell on timeout. Once the server has (belatedly) dequeued, the re-ring makes it rescan and pick up the pending request. Re-ringing a healthy or merely slow server is harmless because the server-side enqueue is idempotent. Set the timeout to 0 to restore the wait-forever behaviour on servers known to include the NCSDK-39877 fix.

new commit message:
>Some IronSide SE versions notify the client before dequeuing the
request. A request posted in that window is skipped and would otherwise
never be answered, leaving the client waiting forever.

>Wait CONFIG_IRONSIDE_SE_CALL_RESPONSE_TIMEOUT_MS instead of forever and
post the request again on timeout. Posting again is harmless because the
enqueue is idempotent. Set the timeout to 0 to wait forever on IronSide
SE versions that include the fix.

Ref: NCSDK-39877