### PR TITLE
[nfr fromlist] dts: nordic: nrf7120: Add default memory region for vt…

### DIFF
--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -85,6 +85,16 @@
 		#size-cells = <1>;
 		ranges;
 
+		vtf_region_default: memory@200fdfe0 {
+			#address-cells = <1>;
+			#size-cells = <1>;
+			reg = <0x200fdfe0 0x0020>;
+			ranges = <0x0 0x200fdfe0 0x0020>;
+			compatible = "zephyr,memory-region", "mmio-sram";
+			zephyr,memory-region = "NRF_VTF_REGION";
+			status = "disabled";
+		};
+
 		nordic_reserved: memory@200fe000 {
 			#address-cells = <1>;
 			#size-cells = <1>;


### PR DESCRIPTION
…f monitoring

Upstream PR #: 114380

vtf monitoring requires a default address that can be accessed from app and wifi cores. vtf_region_default is set to be top unallocated memory in RAM03.


manifest-pr-skip