### PR TITLE
[Backport ncs-v3.3-branch] [nrf fromtree] samples: drivers: watchdog nrf gswdt configuration fix

### DIFF
--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -49,6 +49,13 @@
 #define WDT_ALLOW_CALLBACK 0
 #define WDT_OPT            0
 #endif
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_gswdt)
+#if !defined(CONFIG_NRFS_GSWDT_SERVICE_ENABLED)
+#define WDT_MAX_WINDOW  6000U
+#endif
+#define WDT_ALLOW_CALLBACK 0
+#define WDT_OPT            0
+#endif
 
 #ifndef WDT_ALLOW_CALLBACK
 #define WDT_ALLOW_CALLBACK 1


### PR DESCRIPTION
Backport 3bf0b37ff7856a1cd60d07621a83d38c95168f0c from #4247.