### PR TITLE
[nrf fromtree] Soc flash nrf mramc read secure mem downstream

### DIFF
--- a/drivers/flash/soc_flash_nrf_mramc.c
+++ b/drivers/flash/soc_flash_nrf_mramc.c
@@ -12,6 +12,7 @@
 
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 #include "tfm_ioctl_core_api.h"
+#include <soc_secure.h>
 #else
 #include <nrfx_mramc.h>
 #endif
@@ -180,6 +181,10 @@ static int nrf_mramc_read(const struct device *dev, off_t offset, void *data, si
 	/* Buffer read number of bytes and store in data pointer.
 	 */
 #if defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
+	if (soc_secure_flash_range_is_secure((uintptr_t)addr, len)) {
+		LOG_DBG("read secure mem: %x:%zu", addr, len);
+		return soc_secure_mem_read(data, (void *)addr, len);
+	}
 	memcpy(data, (void *)addr, len);
 #else
 	nrfx_mramc_buffer_read(data, addr, len);


### PR DESCRIPTION
The noup commit is to support the dts method of getting address of slot0_ns_partition. And also soc_secure_flash_range_is_secure() function unavailable in downstream.

similar to commit that done for soc_flash_nrf and soc_flash_nrf_rram: https://github.com/nrfconnect/sdk-zephyr/commit/9fb02fe66fa005b5a12fe69bf72d4616c1c70c2e

manifest-pr-skip
Manifest update PR in sdk-nrf: https://github.com/nrfconnect/sdk-nrf/pull/30752