### PR TITLE
[nrf noup] boards: nordic: remove misleading SPI22/UART30 conflict comment

### DIFF
--- a/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
+++ b/boards/nordic/nrf54l15dk/nrf54l15dk_nrf54l15_cpuflpr.dts
@@ -64,10 +64,6 @@
 	status = "okay";
 };
 
-/*
- * Note this SPI instance conflicts with UART30. Disable or reconfigure pinctrl for UART30
- * to use this SPI instance.
- */
 nordic_expansion_spi: &spi22 {
 	cs-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi22_default>;

--- a/boards/nordic/nrf54l15dk/nrf54l_05_10_15_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l15dk/nrf54l_05_10_15_cpuapp_common.dtsi
@@ -140,10 +140,6 @@
 	status = "okay";
 };
 
-/*
- * Note this SPI instance conflicts with UART30. Disable or reconfigure pinctrl for UART30
- * to use this SPI instance.
- */
 nordic_expansion_spi: &spi22 {
 	cs-gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi22_default>;

--- a/boards/nordic/nrf54lm20dk/nrf54lm20_a_b_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20_a_b_cpuapp_common.dtsi
@@ -148,10 +148,6 @@ zephyr_udc0: &usbhs {
 	status = "okay";
 };
 
-/*
- * Note this SPI instance conflicts with UART30. Disable or reconfigure pinctrl for UART30
- * to use this SPI instance.
- */
 nordic_expansion_spi: &spi22 {
 	cs-gpios = <&gpio3 2 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi22_default>;

--- a/boards/nordic/nrf54lm20dk/nrf54lm20_a_b_cpuflpr_common.dtsi
+++ b/boards/nordic/nrf54lm20dk/nrf54lm20_a_b_cpuflpr_common.dtsi
@@ -54,10 +54,6 @@
 	status = "okay";
 };
 
-/*
- * Note this SPI instance conflicts with UART30. Disable or reconfigure pinctrl for UART30
- * to use this SPI instance.
- */
 nordic_expansion_spi: &spi22 {
 	cs-gpios = <&gpio3 2 GPIO_ACTIVE_LOW>;
 	pinctrl-0 = <&spi22_default>;


### PR DESCRIPTION
The comment claimed spi22 conflicts with uart30, but per the SoC dtsi, spi22 shares its peripheral ID with uart22 (0xc8000), while uart30 shares with spi30 (0x104000) - the pins do not even overlap. This is one instance of the nRF54L series' general shared-peripheral-ID limitation, so drop the inaccurate, board-local comment instead of narrowing it to a single pair.