### PR TITLE
[ncs-v3.3-branch] [nrf fromtree] mgmt: mcumgr: transport: serial: Add minimum receive size

### DIFF
--- a/subsys/mgmt/mcumgr/transport/src/serial_util.c
+++ b/subsys/mgmt/mcumgr/transport/src/serial_util.c
@@ -37,6 +37,11 @@ static int mcumgr_serial_extract_len(struct mcumgr_serial_rx_ctxt *rx_ctxt)
 	}
 
 	rx_ctxt->pkt_len = net_buf_pull_be16(rx_ctxt->nb);
+
+	if (rx_ctxt->pkt_len <= sizeof(uint16_t)) {
+		return -EINVAL;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Adds a minimum check to ensure that received messages do hold some data


(cherry picked from commit f7fc3e779a59c68c96eaf63a6b03ac7489f5e4a5)