### PR TITLE
[nrf noup] ci: cancel in-progress manifest PR workflows

### DIFF
--- a/.github/workflows/manifest-PR.yml
+++ b/.github/workflows/manifest-PR.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   call-manifest-pr-action:
     runs-on: ubuntu-latest


### PR DESCRIPTION
If a PR is merged while a manifest-PR workflow is running, the running workflow should be canceled in favor of the new workflow triggered by the merge. This can help prevent race conditions between workflow instances both writing to the same sdk-nrf branch.