### PR TITLE
[noup] VPR pin control support

### DIFF
--- a/drivers/misc/nordic_vpr_launcher/Kconfig
+++ b/drivers/misc/nordic_vpr_launcher/Kconfig
@@ -6,6 +6,8 @@ config NORDIC_VPR_LAUNCHER
 	default y
 	depends on DT_HAS_NORDIC_NRF_VPR_COPROCESSOR_ENABLED && \
 		   $(dt_compat_any_has_prop,$(DT_COMPAT_NORDIC_NRF_VPR_COPROCESSOR),execution-memory)
+	select PINCTRL if \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_NORDIC_NRF_VPR_COPROCESSOR),pinctrl-0)
 	help
 	  When enabled, the VPR coprocessors will be automatically launched
 	  during system initialization.

--- a/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
+++ b/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
@@ -13,6 +13,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+#include <zephyr/drivers/pinctrl.h>
+#endif
 
 #include <hal/nrf_vpr.h>
 #if (DT_ANY_INST_HAS_BOOL_STATUS_OKAY(enable_secure) || \
@@ -38,6 +41,9 @@ struct nordic_vpr_launcher_config {
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block)
 	int32_t ram_block_id;
 #endif
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+	const struct pinctrl_dev_config *pcfg;
+#endif
 };
 
 static int nordic_vpr_launcher_init(const struct device *dev)
@@ -48,6 +54,18 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 	if (config->exec_addr == 0) {
 		return 0;
 	}
+
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+	/* Apply the pin configuration (routing, drive, pull) for VPR-owned pins. */
+	if (config->pcfg != NULL) {
+		int ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+
+		if (ret < 0) {
+			LOG_ERR("Failed to apply pinctrl state (%d)", ret);
+			return ret;
+		}
+	}
+#endif
 
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(source_memory)
 	if (config->size > 0U) {
@@ -104,6 +122,8 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 				  DT_REG_SIZE(DT_INST_PHANDLE(inst, source_memory))),              \
 				 "Execution memory exceeds source memory size");))                 \
                                                                                                    \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pinctrl_0), (PINCTRL_DT_INST_DEFINE(inst);))        \
+                                                                                                   \
 	static const struct nordic_vpr_launcher_config config##inst = {                            \
 		.vpr = (NRF_VPR_Type *)DT_INST_REG_ADDR(inst),                                     \
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, execution_memory),                          \
@@ -115,6 +135,8 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 			    .size = DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)),))        \
 		IF_ENABLED(DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block),                \
 			   (.ram_block_id = DT_INST_PROP_OR(inst, hibernation_ram_block, -1),))    \
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pinctrl_0),                                 \
+			   (.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),))                        \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, nordic_vpr_launcher_init, NULL, NULL, &config##inst,           \

--- a/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
+++ b/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
@@ -13,6 +13,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+#include <zephyr/drivers/pinctrl.h>
+#endif
 
 #include <hal/nrf_vpr.h>
 #if (DT_ANY_INST_HAS_BOOL_STATUS_OKAY(enable_secure) || \
@@ -38,6 +41,9 @@ struct nordic_vpr_launcher_config {
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block)
 	int32_t ram_block_id;
 #endif
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+	const struct pinctrl_dev_config *pcfg;
+#endif
 };
 
 /* Determine if all code that will be copied is 8 byte aligned. If yes then optimized
@@ -58,6 +64,18 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 	if (config->exec_addr == 0) {
 		return 0;
 	}
+
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+	/* Apply the pin configuration (routing, drive, pull) for VPR-owned pins. */
+	if (config->pcfg != NULL) {
+		int ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+
+		if (ret < 0) {
+			LOG_ERR("Failed to apply pinctrl state (%d)", ret);
+			return ret;
+		}
+	}
+#endif
 
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(source_memory)
 	if (config->size > 0U) {
@@ -123,6 +141,8 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 				  DT_REG_SIZE(DT_INST_PHANDLE(inst, source_memory))),              \
 				 "Execution memory exceeds source memory size");))                 \
                                                                                                    \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pinctrl_0), (PINCTRL_DT_INST_DEFINE(inst);))        \
+                                                                                                   \
 	static const struct nordic_vpr_launcher_config config##inst = {                            \
 		.vpr = (NRF_VPR_Type *)DT_INST_REG_ADDR(inst),                                     \
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, execution_memory),                          \
@@ -134,6 +154,8 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 			    .size = DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)),))        \
 		IF_ENABLED(DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block),                \
 			   (.ram_block_id = DT_INST_PROP_OR(inst, hibernation_ram_block, -1),))    \
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pinctrl_0),                                 \
+			   (.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),))                        \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, nordic_vpr_launcher_init, NULL, NULL, &config##inst,           \

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -114,11 +114,11 @@ static const nrf_gpio_pin_drive_t drive_modes[NRF_DRIVE_COUNT] = {
 	defined(CONFIG_MSPI_HPF) || \
 	DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0)
 #if defined(CONFIG_SOC_SERIES_NRF54L)
-#define NRF_PSEL_SDP_MSPI(psel) \
+#define NRF_PSEL_VPR_VIO(psel) \
 	nrf_gpio_pin_control_select(psel, NRF_GPIO_PIN_SEL_VPR);
-#elif defined(CONFIG_SOC_SERIES_NRF54H)
-/* On nRF54H, pin routing is controlled by secure domain, via UICR. */
-#define NRF_PSEL_SDP_MSPI(psel)
+#elif defined(CONFIG_SOC_SERIES_NRF54H) || defined(CONFIG_SOC_SERIES_NRF92)
+/* On nRF54H and nRF92, pin routing is controlled by secure domain, via UICR. */
+#define NRF_PSEL_VPR_VIO(psel)
 #endif
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || ... */
 
@@ -511,7 +511,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_mspi) */
-#if defined(NRF_PSEL_SDP_MSPI)
+#if defined(NRF_PSEL_VPR_VIO)
 		case NRF_FUN_SDP_MSPI_CS0:
 		case NRF_FUN_SDP_MSPI_CS1:
 		case NRF_FUN_SDP_MSPI_CS2:
@@ -526,11 +526,12 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 		case NRF_FUN_SDP_MSPI_DQ5:
 		case NRF_FUN_SDP_MSPI_DQ6:
 		case NRF_FUN_SDP_MSPI_DQ7:
-			NRF_PSEL_SDP_MSPI(psel);
+		case NRF_FUN_VPR_VIO:
+			NRF_PSEL_VPR_VIO(psel);
 			dir = NRF_GPIO_PIN_DIR_OUTPUT;
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
-#endif /* defined(NRF_PSEL_SDP_MSPI) */
+#endif /* defined(NRF_PSEL_VPR_VIO) */
 #if defined(NRF_PSEL_TWIS)
 		case NRF_FUN_TWIS_SCL:
 			NRF_PSEL_TWIS(reg, SCL) = psel;

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -268,6 +268,8 @@
 #define NRF_FUN_TPIU_DATA2       82U
 /** TPIU DATA3 */
 #define NRF_FUN_TPIU_DATA3       83U
+/** VPR VIO (pin controlled by a VPR through its VIO interface) */
+#define NRF_FUN_VPR_VIO          84U
 
 /** @} */
 

--- a/modules/hal_nordic/ironside/se/scripts/periphconf/builder.py
+++ b/modules/hal_nordic/ironside/se/scripts/periphconf/builder.py
@@ -1048,6 +1048,7 @@ class NrfFun(int, enum.Enum):
     TPIU_DATA1 = 81
     TPIU_DATA2 = 82
     TPIU_DATA3 = 83
+    VPR_VIO = 84
 
     # Value used to ignore the function field and only check (port, pin)
     IGNORE = -1


### PR DESCRIPTION
- Allow pins to be assigned to the VPR cores in a generic way (not MSPI specific)
- Allow pin configuration for VPR cores using devicetree.