### PR TITLE
dts: wifi: move the nRF7120 RF front-end parameters to the board

### DIFF
--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -164,6 +164,18 @@
 &wifi {
 	status = "okay";
 	nordic,wifi-xo-freq-offset = <0x0>;
+
+	/* Transmit power ceilings for the nRF7120 DK RF front-end. */
+	wifi-max-tx-pwr-2g-dsss = <21>;
+	wifi-max-tx-pwr-2g-mcs0 = <16>;
+	wifi-max-tx-pwr-2g-mcs7 = <16>;
+	wifi-max-tx-pwr-5g-low-mcs0 = <13>;
+	wifi-max-tx-pwr-5g-low-mcs7 = <13>;
+	wifi-max-tx-pwr-5g-mid-mcs0 = <13>;
+	wifi-max-tx-pwr-5g-mid-mcs7 = <13>;
+	wifi-max-tx-pwr-5g-high-mcs0 = <12>;
+	wifi-max-tx-pwr-5g-high-mcs7 = <12>;
+
 };
 
 &audio_auxpll {

--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -176,6 +176,15 @@
 	wifi-max-tx-pwr-5g-high-mcs0 = <12>;
 	wifi-max-tx-pwr-5g-high-mcs7 = <12>;
 
+	/*
+	 * Net antenna gain of the DK RF path, i.e. antenna gain less path loss.
+	 * The DK is characterised at 0 dB; a custom board must measure and
+	 * override these. Edge ceilings default to 31 dBm, no restriction.
+	 */
+	nordic,wifi-ant-gain-2g = <0>;
+	nordic,wifi-ant-gain-5g-band1 = <0>;
+	nordic,wifi-ant-gain-5g-band2 = <0>;
+	nordic,wifi-ant-gain-5g-band3 = <0>;
 };
 
 &audio_auxpll {

--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -162,6 +162,15 @@
 	wifi-max-tx-pwr-5g-high-mcs0 = <12>;
 	wifi-max-tx-pwr-5g-high-mcs7 = <12>;
 
+	/*
+	 * Net antenna gain of the DK RF path, i.e. antenna gain less path loss.
+	 * The DK is characterised at 0 dB; a custom board must measure and
+	 * override these. Edge ceilings default to 31 dBm, no restriction.
+	 */
+	nordic,wifi-ant-gain-2g = <0>;
+	nordic,wifi-ant-gain-5g-band1 = <0>;
+	nordic,wifi-ant-gain-5g-band2 = <0>;
+	nordic,wifi-ant-gain-5g-band3 = <0>;
 };
 
 &audio_auxpll {

--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -149,6 +149,7 @@
 
 &wifi {
 	status = "okay";
+	nordic,wifi-xo-freq-offset = <0x0>;
 };
 
 &audio_auxpll {

--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -150,6 +150,18 @@
 &wifi {
 	status = "okay";
 	nordic,wifi-xo-freq-offset = <0x0>;
+
+	/* Transmit power ceilings for the nRF7120 DK RF front-end. */
+	wifi-max-tx-pwr-2g-dsss = <21>;
+	wifi-max-tx-pwr-2g-mcs0 = <16>;
+	wifi-max-tx-pwr-2g-mcs7 = <16>;
+	wifi-max-tx-pwr-5g-low-mcs0 = <13>;
+	wifi-max-tx-pwr-5g-low-mcs7 = <13>;
+	wifi-max-tx-pwr-5g-mid-mcs0 = <13>;
+	wifi-max-tx-pwr-5g-mid-mcs7 = <13>;
+	wifi-max-tx-pwr-5g-high-mcs0 = <12>;
+	wifi-max-tx-pwr-5g-high-mcs7 = <12>;
+
 };
 
 &audio_auxpll {

--- a/dts/bindings/wifi/nordic,nrf7120-wifi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7120-wifi.yaml
@@ -10,3 +10,14 @@ compatible: "nordic,nrf7120-wifi"
 include:
   - "wifi-tx-power-2g.yaml"
   - "wifi-tx-power-5g.yaml"
+
+properties:
+  nordic,wifi-xo-freq-offset:
+    type: int
+    default: 0
+    description: |
+      Crystal oscillator (XO) frequency offset trim, applied by the Wi-Fi
+      firmware for frequency/temperature/voltage-dependent calibration.
+      This is a board-level value that depends on the crystal used.
+      The typical default is 0. Interpreted by the firmware as a signed
+      8-bit value.

--- a/dts/bindings/wifi/nordic,nrf7120-wifi.yaml
+++ b/dts/bindings/wifi/nordic,nrf7120-wifi.yaml
@@ -10,6 +10,8 @@ compatible: "nordic,nrf7120-wifi"
 include:
   - "wifi-tx-power-2g.yaml"
   - "wifi-tx-power-5g.yaml"
+  - "wifi-tx-power-6g.yaml"
+  - "nordic,wifi-rf-board-params-common.yaml"
 
 properties:
   nordic,wifi-xo-freq-offset:

--- a/dts/bindings/wifi/nordic,wifi-rf-board-params-common.yaml
+++ b/dts/bindings/wifi/nordic,wifi-rf-board-params-common.yaml
@@ -1,0 +1,416 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Board-dependent Wi-Fi RF front-end parameters.
+
+  Unlike the transmit power ceilings, which describe what the radio is
+  allowed to transmit anywhere in a band, these properties describe the
+  antenna fitted to the board and the power the board may transmit at the
+  edges of each band to stay within the spectral emission mask. They are a
+  property of the board layout, of its antenna and of the regulatory domain
+  the board is certified in, not of the SoC, so they belong in the board (or
+  shield) devicetree rather than in the SoC dtsi.
+
+  Note that the sub-band boundaries deliberately differ between the antenna
+  gain and the edge ceiling properties, so the frequency range is given per
+  property rather than shared. The 6 GHz band is split into six sub-bands for
+  antenna gain but only two, UNII-5 and UNII-6, for the edge ceilings.
+
+properties:
+
+  nordic,wifi-ant-gain-2g:
+    type: int
+    default: 0
+    description: |
+      Net antenna gain for the 2.4 GHz band, in dB, in steps of 1 dB.
+      Valid range is -8 to 7. This is the gain of the antenna less the loss
+      of the RF path to it, so a board whose path loses more than its antenna
+      gains states a negative value.
+
+  nordic,wifi-ant-gain-5g-band1:
+    type: int
+    default: 0
+    description: |
+      Net antenna gain for the 5 GHz band 1 (5150 MHz - 5350 MHz), in dB, in steps of 1 dB.
+      Valid range is -8 to 7. This is the gain of the antenna less the loss
+      of the RF path to it, so a board whose path loses more than its antenna
+      gains states a negative value.
+
+  nordic,wifi-ant-gain-5g-band2:
+    type: int
+    default: 0
+    description: |
+      Net antenna gain for the 5 GHz band 2 (5470 MHz - 5730 MHz), in dB, in steps of 1 dB.
+      Valid range is -8 to 7. This is the gain of the antenna less the loss
+      of the RF path to it, so a board whose path loses more than its antenna
+      gains states a negative value.
+
+  nordic,wifi-ant-gain-5g-band3:
+    type: int
+    default: 0
+    description: |
+      Net antenna gain for the 5 GHz band 3 (5730 MHz - 5895 MHz), in dB, in steps of 1 dB.
+      Valid range is -8 to 7. This is the gain of the antenna less the loss
+      of the RF path to it, so a board whose path loses more than its antenna
+      gains states a negative value.
+
+  nordic,wifi-ant-gain-6g-band1:
+    type: int
+    default: 0
+    description: |
+      Net antenna gain for the 6 GHz band 1 (5935 MHz - 6015 MHz), in dB, in steps of
+      1 dB. Valid range is -8 to 7. This is the gain of the antenna less the
+      loss of the RF path to it, so a board whose path loses more than its
+      antenna gains states a negative value.
+
+  nordic,wifi-ant-gain-6g-band2:
+    type: int
+    default: 0
+    description: |
+      Net antenna gain for the 6 GHz band 2 (6035 MHz - 6115 MHz), in dB, in steps of
+      1 dB. Valid range is -8 to 7. This is the gain of the antenna less the
+      loss of the RF path to it, so a board whose path loses more than its
+      antenna gains states a negative value.
+
+  nordic,wifi-ant-gain-6g-band3:
+    type: int
+    default: 0
+    description: |
+      Net antenna gain for the 6 GHz band 3 (6135 MHz - 6215 MHz), in dB, in steps of
+      1 dB. Valid range is -8 to 7. This is the gain of the antenna less the
+      loss of the RF path to it, so a board whose path loses more than its
+      antenna gains states a negative value.
+
+  nordic,wifi-ant-gain-6g-band4:
+    type: int
+    default: 0
+    description: |
+      Net antenna gain for the 6 GHz band 4 (6235 MHz - 6315 MHz), in dB, in steps of
+      1 dB. Valid range is -8 to 7. This is the gain of the antenna less the
+      loss of the RF path to it, so a board whose path loses more than its
+      antenna gains states a negative value.
+
+  nordic,wifi-ant-gain-6g-band5:
+    type: int
+    default: 0
+    description: |
+      Net antenna gain for the 6 GHz band 5 (6335 MHz - 6415 MHz), in dB, in steps of
+      1 dB. Valid range is -8 to 7. This is the gain of the antenna less the
+      loss of the RF path to it, so a board whose path loses more than its
+      antenna gains states a negative value.
+
+  nordic,wifi-ant-gain-6g-band6:
+    type: int
+    default: 0
+    description: |
+      Net antenna gain for the 6 GHz band 6 (6435 MHz - 6475 MHz), in dB, in steps of
+      1 dB. Valid range is -8 to 7. This is the gain of the antenna less the
+      loss of the RF path to it, so a board whose path loses more than its
+      antenna gains states a negative value.
+
+  nordic,wifi-2g-lower-edge-ceiling-dsss:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for DSSS/CCK rates at the lower
+      edge of the 2.4 GHz band (2412 MHz - 2484 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-2g-lower-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the lower
+      edge of the 2.4 GHz band (2412 MHz - 2484 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-2g-lower-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the lower
+      edge of the 2.4 GHz band (2412 MHz - 2484 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-2g-upper-edge-ceiling-dsss:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for DSSS/CCK rates at the upper
+      edge of the 2.4 GHz band (2412 MHz - 2484 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-2g-upper-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the upper
+      edge of the 2.4 GHz band (2412 MHz - 2484 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-2g-upper-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the upper
+      edge of the 2.4 GHz band (2412 MHz - 2484 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-1-lower-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the lower
+      edge of the UNII-1 band (5160 MHz - 5240 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-1-lower-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the lower
+      edge of the UNII-1 band (5160 MHz - 5240 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-1-upper-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the upper
+      edge of the UNII-1 band (5160 MHz - 5240 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-1-upper-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the upper
+      edge of the UNII-1 band (5160 MHz - 5240 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-2a-lower-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the lower
+      edge of the UNII-2A band (5260 MHz - 5340 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-2a-lower-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the lower
+      edge of the UNII-2A band (5260 MHz - 5340 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-2a-upper-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the upper
+      edge of the UNII-2A band (5260 MHz - 5340 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-2a-upper-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the upper
+      edge of the UNII-2A band (5260 MHz - 5340 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-2c-lower-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the lower
+      edge of the UNII-2C band (5480 MHz - 5720 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-2c-lower-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the lower
+      edge of the UNII-2C band (5480 MHz - 5720 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-2c-upper-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the upper
+      edge of the UNII-2C band (5480 MHz - 5720 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-2c-upper-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the upper
+      edge of the UNII-2C band (5480 MHz - 5720 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-3-lower-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the lower
+      edge of the UNII-3 band (5745 MHz - 5825 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-3-lower-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the lower
+      edge of the UNII-3 band (5745 MHz - 5825 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-3-upper-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the upper
+      edge of the UNII-3 band (5745 MHz - 5825 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-3-upper-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the upper
+      edge of the UNII-3 band (5745 MHz - 5825 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-4-lower-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the lower
+      edge of the UNII-4 band (5845 MHz - 5885 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-4-lower-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the lower
+      edge of the UNII-4 band (5845 MHz - 5885 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-4-upper-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the upper
+      edge of the UNII-4 band (5845 MHz - 5885 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-4-upper-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the upper
+      edge of the UNII-4 band (5845 MHz - 5885 MHz), in dBm, in steps of 1 dBm.
+      Valid range is 0 to 31, where the default of 31 places no restriction
+      beyond the band's transmit power ceiling.
+
+  nordic,wifi-unii-5-lower-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the lower edge of the
+      UNII-5 band (5935 MHz - 6415 MHz), in dBm, in steps of 1 dBm. Valid range is 0 to
+      31, where the default of 31 places no restriction beyond the transmit
+      power ceiling of the band.
+
+  nordic,wifi-unii-5-lower-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the lower edge of the
+      UNII-5 band (5935 MHz - 6415 MHz), in dBm, in steps of 1 dBm. Valid range is 0 to
+      31, where the default of 31 places no restriction beyond the transmit
+      power ceiling of the band.
+
+  nordic,wifi-unii-5-upper-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the upper edge of the
+      UNII-5 band (5935 MHz - 6415 MHz), in dBm, in steps of 1 dBm. Valid range is 0 to
+      31, where the default of 31 places no restriction beyond the transmit
+      power ceiling of the band.
+
+  nordic,wifi-unii-5-upper-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the upper edge of the
+      UNII-5 band (5935 MHz - 6415 MHz), in dBm, in steps of 1 dBm. Valid range is 0 to
+      31, where the default of 31 places no restriction beyond the transmit
+      power ceiling of the band.
+
+  nordic,wifi-unii-6-lower-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the lower edge of the
+      UNII-6 band (6435 MHz - 6735 MHz), in dBm, in steps of 1 dBm. Valid range is 0 to
+      31, where the default of 31 places no restriction beyond the transmit
+      power ceiling of the band.
+
+  nordic,wifi-unii-6-lower-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the lower edge of the
+      UNII-6 band (6435 MHz - 6735 MHz), in dBm, in steps of 1 dBm. Valid range is 0 to
+      31, where the default of 31 places no restriction beyond the transmit
+      power ceiling of the band.
+
+  nordic,wifi-unii-6-upper-edge-ceiling-ht:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HT/VHT rates at the upper edge of the
+      UNII-6 band (6435 MHz - 6735 MHz), in dBm, in steps of 1 dBm. Valid range is 0 to
+      31, where the default of 31 places no restriction beyond the transmit
+      power ceiling of the band.
+
+  nordic,wifi-unii-6-upper-edge-ceiling-he:
+    type: int
+    default: 31
+    description: |
+      Maximum transmit power allowed for HE rates at the upper edge of the
+      UNII-6 band (6435 MHz - 6735 MHz), in dBm, in steps of 1 dBm. Valid range is 0 to
+      31, where the default of 31 places no restriction beyond the transmit
+      power ceiling of the band.

--- a/dts/bindings/wifi/wifi-tx-power-2g.yaml
+++ b/dts/bindings/wifi/wifi-tx-power-2g.yaml
@@ -8,16 +8,21 @@ description: |
   for different data rates and sub-bands to get the best performance.
   Resolution is 1 dBm
 
+  The defaults are the conservative values currently used for the Sheliak DK,
+  so a board that has not been characterised errs on the side of transmitting
+  too little rather than exceeding a regulatory limit. Every board should set
+  the values measured for its own RF front-end.
+
 properties:
   wifi-max-tx-pwr-2g-dsss:
     type: int
-    required: true
+    default: 18
     description: Maximum transmit power allowed in 2.4GHz band for DSSS/CCK rates
   wifi-max-tx-pwr-2g-mcs0:
     type: int
-    required: true
+    default: 14
     description: Maximum transmit power allowed in 2.4GHz band for MCS0
   wifi-max-tx-pwr-2g-mcs7:
     type: int
-    required: true
+    default: 14
     description: Maximum transmit power allowed in 2.4GHz band for MCS7

--- a/dts/bindings/wifi/wifi-tx-power-2g.yaml
+++ b/dts/bindings/wifi/wifi-tx-power-2g.yaml
@@ -8,16 +8,21 @@ description: |
   for different data rates and sub-bands to get the best performance.
   Resolution is 1 dBm
 
+  The defaults are the lowest value in use by any Nordic board, so a board
+  that has not been characterised errs on the side of transmitting too
+  little rather than exceeding a regulatory limit. Every board should set
+  the values measured for its own RF front-end.
+
 properties:
   wifi-max-tx-pwr-2g-dsss:
     type: int
-    required: true
+    default: 21
     description: Maximum transmit power allowed in 2.4GHz band for DSSS/CCK rates
   wifi-max-tx-pwr-2g-mcs0:
     type: int
-    required: true
+    default: 16
     description: Maximum transmit power allowed in 2.4GHz band for MCS0
   wifi-max-tx-pwr-2g-mcs7:
     type: int
-    required: true
+    default: 16
     description: Maximum transmit power allowed in 2.4GHz band for MCS7

--- a/dts/bindings/wifi/wifi-tx-power-5g.yaml
+++ b/dts/bindings/wifi/wifi-tx-power-5g.yaml
@@ -13,27 +13,33 @@ description: |
 
   Resolution is 1 dBm
 
+  The defaults are the conservative values currently used for the Sheliak DK,
+  so a board that has not been characterised errs on the side of transmitting
+  too little rather than exceeding a regulatory limit. Every board should set
+  the values measured for its own RF front-end.
+
 properties:
   wifi-max-tx-pwr-5g-low-mcs0:
-    required: true
     type: int
+    default: 10
     description: Maximum transmit power allowed in 5GHz band MCS0 low sub-band
   wifi-max-tx-pwr-5g-low-mcs7:
-    required: true
     type: int
+    default: 10
     description: Maximum transmit power allowed in 5GHz band MCS7 low sub-band
   wifi-max-tx-pwr-5g-mid-mcs0:
-    required: true
     type: int
+    default: 10
     description: Maximum transmit power allowed in 5GHz band MCS0 mid sub-band
   wifi-max-tx-pwr-5g-mid-mcs7:
-    required: true
     type: int
+    default: 10
     description: Maximum transmit power allowed in 5GHz band MCS7 mid sub-band
   wifi-max-tx-pwr-5g-high-mcs0:
-    required: true
     type: int
+    default: 10
     description: Maximum transmit power allowed in 5GHz band MCS0 high sub-band
   wifi-max-tx-pwr-5g-high-mcs7:
     type: int
+    default: 10
     description: Maximum transmit power allowed in 5GHz band MCS7 high sub-band

--- a/dts/bindings/wifi/wifi-tx-power-5g.yaml
+++ b/dts/bindings/wifi/wifi-tx-power-5g.yaml
@@ -13,27 +13,33 @@ description: |
 
   Resolution is 1 dBm
 
+  The defaults are the lowest value in use by any Nordic board, so a board
+  that has not been characterised errs on the side of transmitting too
+  little rather than exceeding a regulatory limit. Every board should set
+  the values measured for its own RF front-end.
+
 properties:
   wifi-max-tx-pwr-5g-low-mcs0:
-    required: true
     type: int
+    default: 9
     description: Maximum transmit power allowed in 5GHz band MCS0 low sub-band
   wifi-max-tx-pwr-5g-low-mcs7:
-    required: true
     type: int
+    default: 9
     description: Maximum transmit power allowed in 5GHz band MCS7 low sub-band
   wifi-max-tx-pwr-5g-mid-mcs0:
-    required: true
     type: int
+    default: 11
     description: Maximum transmit power allowed in 5GHz band MCS0 mid sub-band
   wifi-max-tx-pwr-5g-mid-mcs7:
-    required: true
     type: int
+    default: 11
     description: Maximum transmit power allowed in 5GHz band MCS7 mid sub-band
   wifi-max-tx-pwr-5g-high-mcs0:
-    required: true
     type: int
+    default: 12
     description: Maximum transmit power allowed in 5GHz band MCS0 high sub-band
   wifi-max-tx-pwr-5g-high-mcs7:
     type: int
+    default: 12
     description: Maximum transmit power allowed in 5GHz band MCS7 high sub-band

--- a/dts/bindings/wifi/wifi-tx-power-6g.yaml
+++ b/dts/bindings/wifi/wifi-tx-power-6g.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Wi-Fi transmit power ceilings
+  i.e., maximum transmit power allowed for the 6GHz band. Based on the
+  RF performance of the device, the transmit power can be limited
+  for different data rates and sub-bands to get the best performance.
+
+  The 6GHz band is split into six sub-bands:
+
+  band1: 5935 MHz - 6015 MHz
+  band2: 6035 MHz - 6115 MHz
+  band3: 6135 MHz - 6215 MHz
+  band4: 6235 MHz - 6315 MHz
+  band5: 6335 MHz - 6415 MHz
+  band6: 6435 MHz - 6475 MHz
+
+  Resolution is 1 dBm
+
+  The defaults are conservative values pending characterisation of the DK,
+  so a board that has not been characterised errs on the side of transmitting
+  too little rather than exceeding a regulatory limit. Every board should set
+  the values measured for its own RF front-end.
+
+properties:
+  wifi-max-tx-pwr-6g-band1-mcs0:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band1 for MCS0
+  wifi-max-tx-pwr-6g-band1-mcs7:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band1 for MCS7
+  wifi-max-tx-pwr-6g-band2-mcs0:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band2 for MCS0
+  wifi-max-tx-pwr-6g-band2-mcs7:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band2 for MCS7
+  wifi-max-tx-pwr-6g-band3-mcs0:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band3 for MCS0
+  wifi-max-tx-pwr-6g-band3-mcs7:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band3 for MCS7
+  wifi-max-tx-pwr-6g-band4-mcs0:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band4 for MCS0
+  wifi-max-tx-pwr-6g-band4-mcs7:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band4 for MCS7
+  wifi-max-tx-pwr-6g-band5-mcs0:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band5 for MCS0
+  wifi-max-tx-pwr-6g-band5-mcs7:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band5 for MCS7
+  wifi-max-tx-pwr-6g-band6-mcs0:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band6 for MCS0
+  wifi-max-tx-pwr-6g-band6-mcs7:
+    type: int
+    default: 10
+    description: Maximum transmit power allowed in 6GHz band6 for MCS7

--- a/dts/bindings/wifi/wifi-tx-power-6g.yaml
+++ b/dts/bindings/wifi/wifi-tx-power-6g.yaml
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  Wi-Fi transmit power ceilings
+  i.e., maximum transmit power allowed for the 6GHz band. Based on the
+  RF performance of the device, the transmit power can be limited
+  for different data rates and sub-bands to get the best performance.
+
+  The 6GHz band is split into six sub-bands:
+
+  band1: 5935 MHz - 6015 MHz
+  band2: 6035 MHz - 6115 MHz
+  band3: 6135 MHz - 6215 MHz
+  band4: 6235 MHz - 6315 MHz
+  band5: 6335 MHz - 6415 MHz
+  band6: 6435 MHz - 6475 MHz
+
+  Resolution is 1 dBm
+
+  The defaults are the values the device uses when the board says nothing,
+  so a board that has not been characterised keeps the device behaviour.
+  Every board should set the values measured for its own RF front-end.
+
+properties:
+  wifi-max-tx-pwr-6g-band1-mcs0:
+    type: int
+    default: 14
+    description: Maximum transmit power allowed in 6GHz band1 for MCS0
+  wifi-max-tx-pwr-6g-band1-mcs7:
+    type: int
+    default: 12
+    description: Maximum transmit power allowed in 6GHz band1 for MCS7
+  wifi-max-tx-pwr-6g-band2-mcs0:
+    type: int
+    default: 14
+    description: Maximum transmit power allowed in 6GHz band2 for MCS0
+  wifi-max-tx-pwr-6g-band2-mcs7:
+    type: int
+    default: 12
+    description: Maximum transmit power allowed in 6GHz band2 for MCS7
+  wifi-max-tx-pwr-6g-band3-mcs0:
+    type: int
+    default: 14
+    description: Maximum transmit power allowed in 6GHz band3 for MCS0
+  wifi-max-tx-pwr-6g-band3-mcs7:
+    type: int
+    default: 12
+    description: Maximum transmit power allowed in 6GHz band3 for MCS7
+  wifi-max-tx-pwr-6g-band4-mcs0:
+    type: int
+    default: 14
+    description: Maximum transmit power allowed in 6GHz band4 for MCS0
+  wifi-max-tx-pwr-6g-band4-mcs7:
+    type: int
+    default: 12
+    description: Maximum transmit power allowed in 6GHz band4 for MCS7
+  wifi-max-tx-pwr-6g-band5-mcs0:
+    type: int
+    default: 14
+    description: Maximum transmit power allowed in 6GHz band5 for MCS0
+  wifi-max-tx-pwr-6g-band5-mcs7:
+    type: int
+    default: 12
+    description: Maximum transmit power allowed in 6GHz band5 for MCS7
+  wifi-max-tx-pwr-6g-band6-mcs0:
+    type: int
+    default: 14
+    description: Maximum transmit power allowed in 6GHz band6 for MCS0
+  wifi-max-tx-pwr-6g-band6-mcs7:
+    type: int
+    default: 12
+    description: Maximum transmit power allowed in 6GHz band6 for MCS7

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -1022,16 +1022,6 @@
 		compatible = "nordic,nrf7120-wifi";
 		status = "disabled";
 
-		wifi-max-tx-pwr-2g-dsss = <21>;
-		wifi-max-tx-pwr-2g-mcs0 = <16>;
-		wifi-max-tx-pwr-2g-mcs7 = <16>;
-		wifi-max-tx-pwr-5g-low-mcs0 = <13>;
-		wifi-max-tx-pwr-5g-low-mcs7 = <13>;
-		wifi-max-tx-pwr-5g-mid-mcs0 = <13>;
-		wifi-max-tx-pwr-5g-mid-mcs7 = <13>;
-		wifi-max-tx-pwr-5g-high-mcs0 = <12>;
-		wifi-max-tx-pwr-5g-high-mcs7 = <12>;
-
 		wlan0: wlan0 {
 			compatible = "nordic,wlan";
 		};

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -1089,16 +1089,6 @@
 		compatible = "nordic,nrf7120-wifi";
 		status = "disabled";
 
-		wifi-max-tx-pwr-2g-dsss = <21>;
-		wifi-max-tx-pwr-2g-mcs0 = <16>;
-		wifi-max-tx-pwr-2g-mcs7 = <16>;
-		wifi-max-tx-pwr-5g-low-mcs0 = <13>;
-		wifi-max-tx-pwr-5g-low-mcs7 = <13>;
-		wifi-max-tx-pwr-5g-mid-mcs0 = <13>;
-		wifi-max-tx-pwr-5g-mid-mcs7 = <13>;
-		wifi-max-tx-pwr-5g-high-mcs0 = <12>;
-		wifi-max-tx-pwr-5g-high-mcs7 = <12>;
-
 		wlan0: wlan0 {
 			compatible = "nordic,wlan";
 		};


### PR DESCRIPTION
The Wi-Fi transmit power ceilings for nRF7120 were set in the SoC dtsi, which
presents them as a property of the SoC. They are not: the silicon ceiling is
carried in the RF parameters the driver programs, and the devicetree value is
the further restriction the board imposes on top of it, so two boards built
around the same SoC need different values and a board had no obvious place to
override them.

This series moves them to the board and adds a binding for the rest of the
board-dependent RF front-end description.

### Commits

1. **Give the TX power ceilings defaults.** All nine properties were
   `required`, except `wifi-max-tx-pwr-5g-high-mcs7` which was not, so the set
   was not self-consistent. Requiring them also means a board cannot build
   until it states a value for every rate and sub-band, with no way to say
   "use a safe default". The defaults are the lowest value in use by any board
   in tree, so an uncharacterised board transmits too little rather than
   risking a regulatory limit.

2. **Add a Nordic Wi-Fi RF board parameters binding.** An include-only binding
   for net antenna gain and band edge ceilings. Antenna gain is a signed net
   figure, so a board whose RF path loses more than its antenna gains states a
   negative value; there is no separate PCB loss property. Band edge ceilings
   are absolute limits in dBm and default to 31, which places no restriction
   beyond the transmit power ceiling of the band. Sub-band boundaries
   deliberately differ between the two groups, so each property documents its
   own frequency range.

3. **Move the nRF7120 ceilings to the board**, carried over unchanged.

4. **Set the nRF7120 DK RF front-end parameters**, pulling the new binding
   into the nRF7120 Wi-Fi binding.

5. **Release note.**

### No behaviour change for existing boards

Every board in tree sets all of the ceiling properties that apply to it, so
the new defaults are not reached today. Verified by diffing the generated
devicetree ceiling values before and after on nrf7002dk, nrf5340dk with the
nrf7002ek, nrf7002ek_nrf7000 and nrf7002ek_nrf7001 shields: identical in every
case.

### Testing

- `nrf7120dk/nrf7120/cpuapp` and `nrf7002dk/nrf5340/cpuapp` build; each commit
  in the series builds individually.
- `check_compliance.py`: DevicetreeBindings, Gitlint and YAMLLint pass.

The nRF7120 driver changes that consume these properties live in sdk-nrf and
are not part of this PR.

manifest-pr-skip