### PR TITLE
[nrf fromlist] drivers: pwm: nrfx: set idle out on pwm_resume

### DIFF
--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -335,6 +335,10 @@ static int pwm_resume(const struct device *dev)
 		bool inverted = initially_inverted & BIT(i);
 
 		seq_values_ptr_get(dev)[i] = PWM_NRFX_CH_VALUE(0, inverted);
+
+#if NRF_PWM_HAS_IDLEOUT
+		nrfy_pwm_channel_idle_set(data->pwm.p_reg, i, inverted);
+#endif
 	}
 
 	return 0;


### PR DESCRIPTION
pwm_resume applies the pinctrl from devicetree, sets the gpio to the idle value, respecting the nordic,inverted flag in the pinctrl nodes. However, the IDLEOUT register is not set on socs which include this register. The IDLEOUT register takes precedent over the GPIO setting, it must thus be set to match the pin polarity, otherwise glitches will be observed when PWM goes idle, see issue #114343.

This commit adds setting the channel idle state as part of pwm_resume. An nrfy function is used since the nrfx_pwm driver sets this idle states on nrfx_pwm_init, which is run before pinctrl is set, and thus before the driver is able to get the nordic,inverted setting, since it reads this by reading the pin out setting set by pinctrl.

Signed-off-by: Bjarki Arge Andreasen <bjarki.andreasen@nordicsemi.no>

Upstream PR #: 115315