### PR TITLE
Fix nrf71 soc.c non secure initialsation issue downstream

### DIFF
--- a/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
+++ b/boards/nordic/nrf7120dk/nrf7120_cpuapp_common.dtsi
@@ -66,6 +66,8 @@
 	status = "okay";
 	firmware-lmacinitpc = <&wifi_lmac_rom>;
 	firmware-umacinitpc = <&wifi_umac_rom>;
+	firmware-lmacrompatchaddr = <&wifi_lmac_rom_entry>;
+	firmware-umacrompatchaddr = <&wifi_umac_rom_entry>;
 	ipcconfig-commandmbox = <&ipc_shm_cpuapp_cpuuma_0>;
 	ipcconfig-eventmbox = <&ipc_shm_cpuuma_cpuapp_0>;
 	ipcconfig-sparembox = <&ipc_shm_sparembox>;

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -189,13 +189,29 @@
 			};
 		};
 
-		/* Wi-Fi ROM regions */
+		/* Wi-Fi ROM regions (mask-programmed, not field-flashable) */
 		wifi_lmac_rom: memory@28080000 {
+			compatible = "mmio-sram";
 			reg = <0x28080000 DT_SIZE_K(320)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			/* Default entry point when no ROM patch is applied. */
+			wifi_lmac_rom_entry: entry@28080172 {
+				reg = <0x28080172>;
+			};
 		};
 
 		wifi_umac_rom: memory@28180000 {
+			compatible = "mmio-sram";
 			reg = <0x28180000 DT_SIZE_K(512)>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			/* Default entry point when no ROM patch is applied. */
+			wifi_umac_rom_entry: entry@2818011c {
+				reg = <0x2818011c>;
+			};
 		};
 
 		/* Memory-mapped aperture for MSPI. */

--- a/dts/vendor/nordic/nrf7120_enga.dtsi
+++ b/dts/vendor/nordic/nrf7120_enga.dtsi
@@ -22,6 +22,7 @@
 			compatible = "arm,cortex-m33f";
 			reg = <0>;
 			device_type = "cpu";
+			clocks = <&hfpll>;
 			clock-frequency = <DT_FREQ_M(256)>;
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -37,6 +38,7 @@
 			compatible = "nordic,vpr", "riscv";
 			reg = <1>;
 			device_type = "cpu";
+			clocks = <&hfpll>;
 			clock-frequency = <DT_FREQ_M(256)>;
 			riscv,isa-base = "rv32e";
 			riscv,isa-extensions = "e", "m", "c", "zicsr";

--- a/modules/trusted-firmware-m/nordic/nrf7120_cpuapp/CMakeLists.txt
+++ b/modules/trusted-firmware-m/nordic/nrf7120_cpuapp/CMakeLists.txt
@@ -10,6 +10,10 @@ add_subdirectory(${Trusted\ Firmware\ M_SOURCE_DIR}/platform/ext/target/nordic_n
 
 add_subdirectory(.. common)
 
+cmake_path(SET NRF71_SOC_DIR ${ZEPHYR_BASE}/soc/nordic/nrf71)
+target_include_directories(platform_s PRIVATE ${NRF71_SOC_DIR})
+target_sources(platform_s PRIVATE ${NRF71_SOC_DIR}/wicr_setup.c)
+
 install(FILES       ${CMAKE_CURRENT_LIST_DIR}/ns/cpuarch_ns.cmake
         DESTINATION ${INSTALL_PLATFORM_NS_DIR}
         RENAME      cpuarch.cmake)

--- a/soc/nordic/nrf71/CMakeLists.txt
+++ b/soc/nordic/nrf71/CMakeLists.txt
@@ -3,6 +3,19 @@
 
 zephyr_library_sources(soc.c)
 
+if(CONFIG_BUILD_WITH_TFM)
+  set_property(TARGET zephyr_property_target APPEND PROPERTY TFM_CMAKE_OPTIONS
+    -DZEPHYR_BASE=${ZEPHYR_BASE}
+  )
+endif()
+
+# WICR programming requires MRAMC (secure-only peripheral).
+# For TF-M builds, wicr_setup.c is compiled into the secure image
+# from modules/trusted-firmware-m/nordic/nrf7120_cpuapp/CMakeLists.txt.
+if(CONFIG_SOC_NRF7120_WICR_SETUP AND NOT CONFIG_BUILD_WITH_TFM)
+  zephyr_library_sources(wicr_setup.c)
+endif()
+
 zephyr_include_directories(.)
 
 # Ensure that image size aligns with 16 bytes so that MRAMC finalizes all writes

--- a/soc/nordic/nrf71/Kconfig
+++ b/soc/nordic/nrf71/Kconfig
@@ -29,6 +29,15 @@ config SOC_NRF7120_ENGA_CPUFLPR
 
 if SOC_SERIES_NRF71
 
+config SOC_NRF7120_WICR_SETUP
+	bool
+	default y if DT_HAS_NORDIC_NRF_WICR_ENABLED
+	select NRFX_MRAMC if !BUILD_WITH_TFM
+	help
+	  Program the Wi-Fi Information Configuration Registers (WICR) at boot.
+	  WICR is an NVM region for configuring Wi-Fi related settings and
+	  values.
+
 config SOC_NRF71_WIFI_DAP
 	bool "nRF71 Wi-Fi Debug access port for debugging"
 	help

--- a/soc/nordic/nrf71/soc.c
+++ b/soc/nordic/nrf71/soc.c
@@ -39,6 +39,8 @@
 #include <hal/nrf_mpc.h>
 #include <hal/nrf_lfxo.h>
 
+#include <wicr_setup.h>
+
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 
 #define LFXO_NODE DT_NODELABEL(lfxo)
@@ -195,6 +197,14 @@ void soc_early_init_hook(void)
 	mpc_configuration();
 	grtc_configuration();
 	ipct_configuration();
+#endif
+
+#if defined(CONFIG_SOC_NRF7120_WICR_SETUP)
+	int ret = wicr_setup();
+
+	if (ret != 0) {
+		LOG_ERR("WICR programming failed: %d", ret);
+	}
 #endif
 
 #if defined(CONFIG_SOC_NRF71_WIFI_BOOT)

--- a/soc/nordic/nrf71/soc.c
+++ b/soc/nordic/nrf71/soc.c
@@ -12,17 +12,15 @@
  * for the Nordic Semiconductor nRF71 family processor.
  */
 
-#ifdef __NRF_TFM__
 #include <zephyr/autoconf.h>
-#endif
 
 #include <zephyr/kernel.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 #include <zephyr/logging/log.h>
-
-#ifndef __NRF_TFM__
 #include <zephyr/cache.h>
+#ifndef __ZEPHYR__
+#include <hal/nrf_cache.h>
 #endif
 
 #if defined(NRF_APPLICATION)
@@ -123,7 +121,6 @@ static void set_mpc_region_override(NRF_MPC_Type *mpc,
 	nrf_mpc_override_config_set(mpc, index, &override->config);
 }
 
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 static void mpc_configuration(void)
 {
 	ARRAY_FOR_EACH(mpc00_region_overrides, i) {
@@ -134,7 +131,6 @@ static void mpc_configuration(void)
 		set_mpc_region_override(NRF_MPC03, i, &mpc03_region_overrides[i]);
 	}
 }
-#endif
 
 /**
  * Return the SPU instance that can be used to configure the
@@ -167,7 +163,8 @@ static void ipct_configuration(void)
 #endif /* CONFIG_TRUSTED_EXECUTION_NONSECURE */
 
 #if defined(CONFIG_SOC_NRF71_WIFI_BOOT)
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(__NRF_TFM__)
+#if (defined(NRF_APPLICATION) && !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)) || \
+	!defined(__ZEPHYR__)
 static void wifi_setup(void)
 {
 	/* Kickstart the LMAC processor */
@@ -186,11 +183,9 @@ void soc_early_init_hook(void)
 #endif
 
 	/* Update the SystemCoreClock global variable with current core clock
-	 * retrieved from hardware state.
+	 * retrieved from the DT.
 	 */
-#if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) || defined(__NRF_TFM__)
-	/* Currently not supported for non-secure */
-	SystemCoreClockUpdate();
+	SystemCoreClock = NRF_PERIPH_GET_FREQUENCY(DT_NODELABEL(cpu));
 
 #if !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)
 	/* Skip for tf-m, configuration exist in target_cfg_71.c */
@@ -199,6 +194,8 @@ void soc_early_init_hook(void)
 	ipct_configuration();
 #endif
 
+#if (defined(NRF_APPLICATION) && !defined(CONFIG_TRUSTED_EXECUTION_NONSECURE)) || \
+	!defined(__ZEPHYR__)
 #if defined(CONFIG_SOC_NRF7120_WICR_SETUP)
 	int ret = wicr_setup();
 
@@ -220,15 +217,12 @@ void soc_early_init_hook(void)
 	nrf_lfxo_cload_set(NRF_LFXO,
 			(uint8_t)(DT_PROP(LFXO_NODE, load_capacitance_femtofarad) / 1000));
 #endif
-#endif /* !CONFIG_TRUSTED_EXECUTION_NONSECURE || __NRF_TFM__ */
+#endif /* (NRF_APPLICATION && !CONFIG_TRUSTED_EXECUTION_NONSECURE) || !__ZEPHYR__  */
 
-#ifdef __NRF_TFM__
-	/* TF-M enables the instruction cache from target_cfg_71.c, so we
-	 * don't need to enable it here.
-	 */
-#else
-	/* Enable ICACHE */
+#ifdef __ZEPHYR__
 	sys_cache_instr_enable();
+#elif defined(NRF_ICACHE)
+	nrf_cache_enable(NRF_ICACHE);
 #endif
 }
 

--- a/soc/nordic/nrf71/wicr_setup.c
+++ b/soc/nordic/nrf71/wicr_setup.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <errno.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <zephyr/autoconf.h>
+#include <zephyr/devicetree.h>
+
+#include <nrfx_mramc.h>
+#include "wicr_setup.h"
+
+#define WICR_NODE DT_NODELABEL(wicr)
+#define WICR_BASE DT_REG_ADDR(WICR_NODE)
+#define MRAM_CONFIGNVR_WICR_PAGE 0
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+#endif
+
+/* When out-of-tree patch is included, it defines the LMAC and UMAC patch
+ * addresses and takes precedence over the devicetree values.
+ */
+#ifdef NRF71_WIFI_LMAC_PATCH_ADDR
+#define WICR_LMAC_PATCH_ADDR NRF71_WIFI_LMAC_PATCH_ADDR
+#else
+#define WICR_LMAC_PATCH_ADDR \
+	DT_REG_ADDR(DT_PHANDLE(WICR_NODE, firmware_lmacrompatchaddr))
+#endif /* NRF71_WIFI_LMAC_PATCH_ADDR */
+
+#ifdef NRF71_WIFI_UMAC_PATCH_ADDR
+#define WICR_UMAC_PATCH_ADDR NRF71_WIFI_UMAC_PATCH_ADDR
+#else
+#define WICR_UMAC_PATCH_ADDR \
+	DT_REG_ADDR(DT_PHANDLE(WICR_NODE, firmware_umacrompatchaddr))
+#endif /* NRF71_WIFI_UMAC_PATCH_ADDR */
+
+struct wicr_word {
+	uint16_t offset;
+	uint32_t value;
+};
+
+static const struct wicr_word wicr_words[] = {
+	{0x000, DT_REG_ADDR(DT_PHANDLE(WICR_NODE, firmware_lmacinitpc))},
+	{0x004, DT_REG_ADDR(DT_PHANDLE(WICR_NODE, firmware_umacinitpc))},
+	{0x008, WICR_LMAC_PATCH_ADDR},
+	{0x00C, WICR_UMAC_PATCH_ADDR},
+	{0x080, DT_REG_ADDR(DT_PHANDLE(WICR_NODE, ipcconfig_commandmbox))},
+	{0x084, DT_REG_SIZE(DT_PHANDLE(WICR_NODE, ipcconfig_commandmbox))},
+	{0x088, DT_REG_ADDR(DT_PHANDLE(WICR_NODE, ipcconfig_eventmbox))},
+	{0x08C, DT_REG_SIZE(DT_PHANDLE(WICR_NODE, ipcconfig_eventmbox))},
+	{0x090, DT_REG_ADDR(DT_PHANDLE(WICR_NODE, ipcconfig_sparembox))},
+	{0x094, DT_REG_SIZE(DT_PHANDLE(WICR_NODE, ipcconfig_sparembox))},
+};
+
+int wicr_setup(void)
+{
+	bool write_enabled = false;
+	int err = 0;
+
+	for (size_t i = 0; i < ARRAY_SIZE(wicr_words); i++) {
+		volatile uint32_t *reg = (uint32_t *)(WICR_BASE + wicr_words[i].offset);
+
+		/* Skip unchanged values to avoid MRAM wear. */
+		if (*reg == wicr_words[i].value) {
+			continue;
+		}
+
+		if (!write_enabled) {
+			nrfx_mramc_confignvr_perm_set(true, MRAM_CONFIGNVR_WICR_PAGE);
+			write_enabled = true;
+		}
+
+		*reg = wicr_words[i].value;
+
+		if (*reg != wicr_words[i].value) {
+			err = -EIO;
+			break;
+		}
+	}
+
+	if (write_enabled) {
+		nrfx_mramc_confignvr_perm_set(false, MRAM_CONFIGNVR_WICR_PAGE);
+	}
+
+	return err;
+}

--- a/soc/nordic/nrf71/wicr_setup.h
+++ b/soc/nordic/nrf71/wicr_setup.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef _NORDICSEMI_NRF71_WICR_SETUP_H_
+#define _NORDICSEMI_NRF71_WICR_SETUP_H_
+
+/**
+ * Configure the nRF71 Wi-Fi Information Configuration Registers.
+ *
+ * @retval 0      WICR configuration completed successfully.
+ * @retval -EIO   A WICR value could not be verified after writing.
+ */
+int wicr_setup(void);
+
+#endif /* _NORDICSEMI_NRF71_WICR_SETUP_H_ */


### PR DESCRIPTION
The soc.c non-secure build initialisation was using NRF_TFM, which is meant to be for sdk-nrf only. New ifdef function is updated to replace the secure initialisation condition. So that now power related, wifi, wicr setup is done in secure environment for non secure build.

Also updated SystemCoreClock as global variable with retrival from the DT. SystemCoreClock setting will be done in non secure environment aligning to other nordic soc.

Corresponds to:
https://github.com/nrfconnect/sdk-trusted-firmware-m/pull/268

Manifest PR:
https://github.com/nrfconnect/sdk-nrf/pull/30578

manifest-pr-skip