### PR TITLE
[nrf fromtree] tests: drivers: uart: Disable fast instance in uart_mi…

### DIFF
--- a/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
+++ b/tests/drivers/uart/uart_mix_fifo_poll/boards/nrf54h20dk_nrf54h20_cpuapp.overlay
@@ -11,7 +11,8 @@
 };
 
 &dut2 {
-	status = "okay";
+	/* Change to "okay" to test fast uart instance. */
+	status = "disabled";
 	memory-regions = <&dma_fast_region>;
 };
 


### PR DESCRIPTION
…x_fifo_poll

All uart_mix_fifo_poll test configurations defined in tests.yaml, when run on nrf54h20dk/nrf54h20/cpuapp platform, test both slow uart13x and fast uart120 instances.

Disable testing on fast instance as testing it:
- doubles the test execution time,
- due to unique GPIO constraints requires a dedicated setup,
- testing slow instance only seems to be good enough.

Keep configuration for fast instance so user can manually switch between slow, fast and both uart instances enabled.


(cherry picked from commit 2f58776b90fa20f1768013ae750906b805e38a14)