### PR TITLE
[nrf noup] ci: exclude Bluetooth Mesh from CI-dfu-test

### DIFF
--- a/.github/test-spec.yml
+++ b/.github/test-spec.yml
@@ -67,7 +67,6 @@
   - "dts/riscv/nordic/nrf54h*"
   - "include/dfu/**/*"
   - "include/mgmt/mcumgr/**/*"
-  - "include/zephyr/**/*"
   - "samples/subsys/mgmt/mcumgr/smp_svr/**/*"
   - "scripts/west_commands/build.py"
   - "scripts/west_commands/flash.py"
@@ -75,11 +74,16 @@
   - "scripts/west_commands/runners/nrf_common.py"
   - "scripts/west_commands/runners/nrfutil.py"
   - "soc/nordic/nrf54h/**/*"
-  - "subsys/bluetooth/**/*"
   - "subsys/dfu/**/*"
   - "subsys/logging/**/*"
   - "subsys/mgmt/mcumgr/**/*"
   - "subsys/tracing/**/*"
+  - any:
+      - "include/zephyr/**/*"
+      - "!include/zephyr/bluetooth/mesh/**/*"
+  - any:
+      - "subsys/bluetooth/**/*"
+      - "!subsys/bluetooth/mesh/**/*"
 
 "CI-tfm-test":
   - "boards/nordic/nrf5340dk/**/*"


### PR DESCRIPTION
CI-dfu-test triggered on any change under subsys/bluetooth and on the blanket include/zephyr glob, so Bluetooth Mesh changes enabled the whole DFU test scope.

Mesh implements its own firmware update stack, built on the BLOB Transfer and Firmware Update models under subsys/bluetooth/mesh/dfu. It shares no code with the mcumgr/MCUboot DFU path that CI-dfu-test exercises, so mesh changes cannot regress those tests.