### PR TITLE
[nrf noup] manifest: switch hal_nordic revision to v3.4 branch

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -203,7 +203,8 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 18da0cc9726f8759c627dba3180b3ba9294e433c
+      url: https://github.com/nrfconnect/sdk-hal_nordic
+      revision: ncs-v3.4-branch
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Dedicated branch in sdk-hal_nordic is needed for release of nrfx 4.3.1.

The branch is a checkout of hal_nordic revision already present in v3.4 branch, there should be no change in code.