### PR TITLE
[nrf fromtree] kernel: add kobj NULL check in k_thread_name_copy()

### DIFF
--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -291,7 +291,7 @@ static inline int z_vrfy_k_thread_name_copy(k_tid_t thread,
 	/* Special case: we allow reading the names of initialized threads
 	 * even if we don't have permission on them
 	 */
-	if ((thread == NULL) || (ko->type != K_OBJ_THREAD) ||
+	if ((ko == NULL) || (ko->type != K_OBJ_THREAD) ||
 		((ko->flags & K_OBJ_FLAG_INITIALIZED) == 0)) {
 		return -EINVAL;
 	}


### PR DESCRIPTION
Inside k_thread_name_copy(), we call k_object_find() to find the associated thread object of the incoming thread. However, the finder can return NULL if incoming pointer address has no kobj associated. So we need to check for NULL before dereferencing k_object to look inside. Since k_object_find() returns NULL if input object is NULL, there is no need to specifically test thread pointer for NULL, and only need to check for the return of k_object_find().
