### PR TITLE
[nrf fromtree] tests: kernel: usage: bound peak growth by measured bu…

### DIFF
--- a/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
+++ b/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
@@ -162,13 +162,24 @@ ZTEST(usage_api, test_all_stats_usage)
 	zassert_true(stats4.current_cycles <= stats1.current_cycles);
 	zassert_true(stats5.current_cycles > stats4.current_cycles);
 
-	/* The peak busy stretch is the same one before and after it closed; it
-	 * only grew by the sub-tick measurement tail between the stats3 sample
-	 * and the idle event. Scheduling here is tick aligned, so comparing in
-	 * the tick domain makes that tail vanish, no percentage tolerance needed.
+	/* stats3 sampled this busy stretch mid-way and stats4 after the idle
+	 * event closed it, so peak grew only by the CPU-busy time that elapsed
+	 * between the two samples. That busy time is exactly the growth in
+	 * total_cycles: peak (longest) and total are advanced from the same cycle
+	 * deltas, so peak can never grow by more than total. Bounding peak growth
+	 * by it needs no tolerance and no per-platform value, self-scales with the
+	 * clock, and still catches a spurious jump at the idle event.
 	 */
-	zassert_equal(k_cyc_to_ticks_near64(stats4.peak_cycles),
-		      k_cyc_to_ticks_near64(stats3.peak_cycles), NULL);
+	zassert_true(stats4.peak_cycles >= stats3.peak_cycles,
+		     "peak_cycles shrank across the idle event: %llu -> %llu",
+		     (unsigned long long)stats3.peak_cycles,
+		     (unsigned long long)stats4.peak_cycles);
+	zassert_true((stats4.peak_cycles - stats3.peak_cycles) <=
+		     (stats4.total_cycles - stats3.total_cycles),
+		     "peak grew by %llu cycles but only %llu busy cycles elapsed "
+		     "between the samples",
+		     (unsigned long long)(stats4.peak_cycles - stats3.peak_cycles),
+		     (unsigned long long)(stats4.total_cycles - stats3.total_cycles));
 	zassert_true(stats4.peak_cycles == stats5.peak_cycles);
 
 	zassert_true(stats4.average_cycles > 0);


### PR DESCRIPTION
…sy time

(stats3 and stats4) rounded to the nearest tick, expecting the short tail of processing between them to round away. That does not hold when the tick rate is high relative to the CPU speed: the tail (the stats-get and abort between the samples) becomes comparable to a tick, so the two samples round to different ticks and the equality trips. It regressed kernel.usage on nRF, ITE and several NXP boards (#113404, #113527, #113576); it passed in CI only because the emulated boards run a 100 Hz tick where the tail is negligible.

The two samples are the same busy stretch, sampled mid-way and again after the idle event closed it, so peak can only have grown by the CPU-busy time that elapsed between them. That is exactly the growth in total_cycles, so assert that instead: peak did not shrink and grew by no more than the busy cycles that elapsed. No tolerance, no per-platform value, and it still catches a spurious jump at the idle event.

Fixes #113404
Fixes #113527
Fixes #113576


(cherry picked from commit bde6374f13f1b5ad19781eac2b9f44d158888d98)