### PR TITLE
[nrf fromtree] boards: nrf54l15tag: correct xtal load capacitance

### DIFF
--- a/boards/nordic/nrf54l15tag/nrf54l15tag_cpuapp_common.dtsi
+++ b/boards/nordic/nrf54l15tag/nrf54l15tag_cpuapp_common.dtsi
@@ -30,13 +30,13 @@
 &lfxo {
 	status = "okay";
 	load-capacitors = "internal";
-	load-capacitance-femtofarad = <9000>;
+	load-capacitance-femtofarad = <17000>;
 };
 
 &hfxo {
 	status = "okay";
 	load-capacitors = "internal";
-	load-capacitance-femtofarad = <8000>;
+	load-capacitance-femtofarad = <15000>;
 };
 
 &radio {


### PR DESCRIPTION
The load capacitance of the lfxo and hfxo where incorrectly set to the load capacitance of the crystals, rather than the required external load capacitance to match the load capacitance of the crystals.

This commit updates the load capacitance configuration to match the crystals.

Signed-off-by: Bjarki Arge Andreasen <bjarki.andreasen@nordicsemi.no>