### PR TITLE
Riscv irq vector table switch

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -559,7 +559,7 @@ config DYNAMIC_INTERRUPTS
 
 config SHARED_INTERRUPTS
 	bool "Set this to enable support for shared interrupts"
-	depends on GEN_SW_ISR_TABLE
+	depends on GEN_SW_ISR_TABLE_ARRAY
 	select EXPERIMENTAL
 	help
 	  Set this to enable support for shared interrupts. Use this with
@@ -657,6 +657,7 @@ config GEN_SW_ISR_TABLE_ARRAY
 
 config GEN_SW_ISR_TABLE_SWITCH
 	bool "Generate a function with a switch-case"
+	depends on !DYNAMIC_INTERRUPTS
 	help
 	  Use a switch-case instead of an array.
 	  This helps to limit binary size when most of the IRQs are not used.

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -641,6 +641,7 @@ config GEN_SW_ISR_TABLE
 choice GEN_SW_ISR_TABLE_TYPE
 	prompt "Allows to chose how ISR table is implemented"
 	depends on GEN_SW_ISR_TABLE
+	default GEN_SW_ISR_TABLE_SWITCH if NRFX_CLIC
 	default GEN_SW_ISR_TABLE_ARRAY
 	help
 	  CONFIG_GEN_SW_ISR_TABLE_ARRAY is a default option.

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -140,6 +140,10 @@ GTEXT(z_riscv_custom_stack_guard_enable)
 GTEXT(z_riscv_custom_stack_guard_disable)
 #endif /* CONFIG_CUSTOM_STACK_GUARD */
 
+#ifdef CONFIG_GEN_SW_ISR_TABLE_SWITCH
+GTEXT(get_isr_entry)
+#endif /* CONFIG_GEN_SW_ISR_TABLE_SWITCH */
+
 /* exports */
 GTEXT(_isr_wrapper)
 
@@ -735,7 +739,36 @@ on_irq_stack:
 	 */
 	jal ra, __soc_handle_irq
 
-#if defined CONFIG_GEN_SW_ISR_TABLE
+#if defined CONFIG_GEN_SW_ISR_TABLE_SWITCH
+	/*
+	 * Retrieve the corresponding ISR entry and argument for the given IRQ index.
+	 * get_isr_entry(int irq_index, struct _isr_table_entry *entry)
+	 * a0 already contains the IRQ index.
+	 * a1 will contain the pointer to a local struct _isr_table_entry on the stack.
+	 * struct _isr_table_entry layout:
+	 * +0          : arg
+	 * +RV_REGSIZE : isr
+	 */
+
+	/* space for struct _isr_table_entry on the stack, keep stack 16-byte aligned */
+	addi sp, sp, -__isr_table_entry_STACK_SIZEOF
+
+	/* a1 will point to struct _isr_table_entry on the stack */
+	mv a1, sp
+	/*
+	 * Call to get_isr_entry will fill the struct _isr_table_entry
+	 * with the ISR address and argument for the given IRQ index
+	 */
+	call get_isr_entry
+
+	/* Load argument in a0 register */
+	lr a0, __isr_table_entry_arg_OFFSET(sp)
+	/* Load ISR function address in register t1 */
+	lr t1, __isr_table_entry_isr_OFFSET(sp)
+	addi sp, sp, __isr_table_entry_STACK_SIZEOF
+
+#elif defined CONFIG_GEN_SW_ISR_TABLE
+
 	/*
 	 * Call corresponding registered function in _sw_isr_table.
 	 * (table is 2-word wide, we should shift index accordingly)

--- a/arch/riscv/core/offsets/offsets.c
+++ b/arch/riscv/core/offsets/offsets.c
@@ -156,4 +156,11 @@ GEN_OFFSET_SYM(_cpu_context_t, mie);
 GEN_OFFSET_SYM(_cpu_context_t, sp);
 #endif /* CONFIG_PM_S2RAM */
 
+#ifdef CONFIG_GEN_SW_ISR_TABLE_SWITCH
+GEN_ABSOLUTE_SYM(__isr_table_entry_arg_OFFSET, offsetof(struct _isr_table_entry, arg));
+GEN_ABSOLUTE_SYM(__isr_table_entry_isr_OFFSET, offsetof(struct _isr_table_entry, isr));
+GEN_ABSOLUTE_SYM(__isr_table_entry_STACK_SIZEOF,
+	ROUND_UP(sizeof(struct _isr_table_entry), ARCH_STACK_PTR_ALIGN));
+#endif /* CONFIG_GEN_SW_ISR_TABLE_SWITCH */
+
 GEN_ABS_SYM_END


### PR DESCRIPTION
CONFIG_GEN_SW_ISR_TABLE_SWITCH was not supported
    for RISCV platform. This commit adds procedure in
    isr handling that will retrive isr_table_entry data
    using get_isr_entry function.
    Depending on platform this can provide large CODE
    memory savings.
    ISR_TABLE_SWITCH is incompatibilie with dynamic
    and shared interrupts in current implementation.