### PR TITLE
[Backport ncs-v3.4-branch] bluetooth: mesh: fix iv idx test mode and dividers

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -260,6 +260,11 @@ void bt_mesh_iv_update_test(bool enable)
 	atomic_set_bit_to(bt_mesh.flags, BT_MESH_IVU_TEST, enable);
 	/* Reset the duration variable - needed for some PTS tests */
 	bt_mesh.ivu_duration = 0U;
+	/* ivu_refresh() drops the beacon cache when the 96-hour limit expires. Test mode
+	 * lifts that limit without the timer running, so drop it here too, or a beacon
+	 * cached while the limit was in force would keep being filtered as a duplicate.
+	 */
+	bt_mesh_subnet_foreach(bt_mesh_beacon_cache_clear);
 }
 
 bool bt_mesh_iv_update(void)

--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -968,10 +968,13 @@ void bt_mesh_net_recv(struct net_buf_simple *data, int8_t rssi,
 
 static void ivu_refresh(struct k_work *work)
 {
+	uint8_t prev_duration;
+
 	if (!bt_mesh_is_provisioned()) {
 		return;
 	}
 
+	prev_duration = bt_mesh.ivu_duration;
 	bt_mesh.ivu_duration = MIN(UINT8_MAX,
 	       bt_mesh.ivu_duration + BT_MESH_IVU_HOURS);
 
@@ -991,8 +994,10 @@ static void ivu_refresh(struct k_work *work)
 	/* Because the beacon may be cached, iv update or iv recovery
 	 * cannot be performed after 96 hours or 192 hours.
 	 * So we need clear beacon cache.
+	 * BT_MESH_IVU_HOURS need not divide the limit, so test for crossing it.
 	 */
-	if (!(bt_mesh.ivu_duration % BT_MESH_IVU_MIN_HOURS)) {
+	if (prev_duration / BT_MESH_IVU_MIN_HOURS !=
+	    bt_mesh.ivu_duration / BT_MESH_IVU_MIN_HOURS) {
 		bt_mesh_subnet_foreach(bt_mesh_beacon_cache_clear);
 	}
 


### PR DESCRIPTION
Backport 14187fcf0b8e19f4b4d3928caeb6a192f57a72cc~2..14187fcf0b8e19f4b4d3928caeb6a192f57a72cc from #4419.

_Original PR description:_

---

Latest mesh fixes for IV index test mode