### PR TITLE
[nrf fromtree] twister: runner: Relax platform filter

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -1511,7 +1511,7 @@ class ProjectBuilder(FilterBuilder):
                 if self.instance.platform.arch == cond_args[1]:
                     args.append(cond_args[2])
             elif cond_args[0] == "platform" and len(cond_args) == 3:
-                if self.instance.platform.name == cond_args[1]:
+                if cond_args[1] in self.instance.platform.name:
                     args.append(cond_args[2])
             elif cond_args[0] == "simulation" and len(cond_args) == 3:
                 if self.instance.platform.simulation == cond_args[1]:


### PR DESCRIPTION
Expect that string provided in platform argument is part of the target platform instead of an exact name match. This relaxed setting allows to handle cases like:
- unify argument for multiple boards with the same SoC
- handle multiple versions of the same board

It also matches handling in the west build command implementation.

Signed-off-by: Krzysztof Chruściński <krzysztof.chruscinski@nordicsemi.no>

(cherry picked from commit 5e34e0a3b89d508c9830d944f05afd1490efbeab)