### PR TITLE
[nrf fromtree] Revert "Bluetooth: Host: Fix RPA expire issues for adv"

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -247,7 +247,11 @@ static void adv_rpa_expired(struct bt_le_ext_adv *adv, void *data)
 
 static void adv_rpa_invalidate(struct bt_le_ext_adv *adv, void *data)
 {
-	if (atomic_test_bit(adv->flags, BT_ADV_RPA_UPDATE)) {
+	/* RPA of Advertisers limited by timeout or number of packets only expire
+	 * when they are stopped.
+	 */
+	if (!atomic_test_bit(adv->flags, BT_ADV_LIMITED) &&
+	    !atomic_test_bit(adv->flags, BT_ADV_USE_IDENTITY)) {
 		adv_rpa_expired(adv, data);
 	}
 }
@@ -699,12 +703,15 @@ static void rpa_timeout(struct k_work *work)
 	adv_enabled = le_adv_rpa_timeout();
 	le_rpa_invalidate();
 
-	/* Update the RPA if we have any active procedures that use it */
-	if ((IS_ENABLED(CONFIG_BT_BROADCASTER) && adv_enabled) ||
-	    (IS_ENABLED(CONFIG_BT_CENTRAL) && atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING)) ||
-	    (IS_ENABLED(CONFIG_BT_OBSERVER) && bt_le_scan_active_scanner_running())) {
-		le_update_private_addr();
+	/* IF no roles using the RPA is running we can stop the RPA timer */
+	if (IS_ENABLED(CONFIG_BT_CENTRAL)) {
+		if (!(adv_enabled || atomic_test_bit(bt_dev.flags, BT_DEV_INITIATING) ||
+		      bt_le_scan_active_scanner_running())) {
+			return;
+		}
 	}
+
+	le_update_private_addr();
 }
 #endif /* CONFIG_BT_PRIVACY */
 


### PR DESCRIPTION
Cherry-pick of the upstream revert of e55eaf1312ea55f1ad702f35e15a9935814482d0 ("Bluetooth: Host: Fix RPA expire issues for adv"), merged upstream in https://github.com/zephyrproject-rtos/zephyr/pull/118322.

This replaces the previous `[nrf noup]` partial revert that was in this PR, now that the full revert has landed upstream. Pulling it in ahead of the next upmerge to unblock NCS.

## Background

The reverted commit gated the `rpa_expired` callback on `BT_ADV_RPA_UPDATE`, which `adv_pause_rpa()` only sets for advertising sets that are enabled at the time of the RPA timeout. Stopped sets therefore no longer received the callback and no longer had `BT_ADV_RPA_VALID` cleared, so `bt_id_set_adv_private_addr()` took its early return on the next `bt_le_ext_adv_start()` and the set resumed on the address it stopped on.

This broke the Fast Pair Find Hub Network locator tag in sdk-nrf, which refreshes its advertising payload and its RPA together from the `rpa_expired` callback before starting the advertising set. The set was enabled with an empty advertising payload, and a set that is stopped and restarted kept a stale RPA, which violates the FHN and DULT address rotation requirements.

## Note on scope

This cherry-pick reverts the commit in full, including the `rpa_timeout()` hunk, matching upstream. The previous `[nrf noup]` version in this PR reverted only the `adv_rpa_invalidate()` hunk and kept the `rpa_timeout()` change.

Upstream commit: 00e55c5c756affe97f51c08d5d40a3c6aef6e5d9

Ref: NCSDK-40951