### PR TITLE
[nrf fromlist] arch: arm: cortex-m: exception: add system control reg…

### DIFF
--- a/arch/arm/core/cortex_m/fault.c
+++ b/arch/arm/core/cortex_m/fault.c
@@ -1136,6 +1136,30 @@ void z_arm_fault(uint32_t msp, uint32_t psp, uint32_t exc_return, _callee_saved_
 		return;
 	}
 
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO) && defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	SCB_Type *scb_ptr;
+
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+	scb_ptr = context.non_secure_esf ? SCB_NS : SCB;
+#else /* !CONFIG_ARM_SECURE_FIRMWARE */
+	scb_ptr = SCB;
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
+
+	/* Snapshot system control registers inspected and/or modified
+	 * during fault handling before fault handling is performed.
+	 */
+	esf_copy.extra_info.cfsr = scb_ptr->CFSR;
+	esf_copy.extra_info.hfsr = scb_ptr->HFSR;
+	esf_copy.extra_info.dfsr = scb_ptr->DFSR;
+	esf_copy.extra_info.mmfar = scb_ptr->MMFAR;
+	esf_copy.extra_info.bfar = scb_ptr->BFAR;
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+	esf_copy.extra_info.sfsr = SAU->SFSR;
+	esf_copy.extra_info.sfar = SAU->SFAR;
+	esf_copy.extra_info.non_secure = context.non_secure_esf;
+#endif /* CONFIG_ARM_SECURE_FIRMWARE */
+#endif /* CONFIG_EXTRA_EXCEPTION_INFO && CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
+
 	z_arm_set_fault_sp(esf, exc_return);
 
 	reason = fault_handle(esf, fault, &recoverable, context.non_secure_esf);
@@ -1178,8 +1202,9 @@ void z_arm_fault(uint32_t msp, uint32_t psp, uint32_t exc_return, _callee_saved_
 	 * so we only copy the fields before those.
 	 */
 	memcpy(&esf_copy, esf, offsetof(struct arch_esf, extra_info));
-	esf_copy.extra_info = (struct __extra_esf_info){
-		.callee = fault_callee_regs, .exc_return = exc_return, .msp = msp};
+	esf_copy.extra_info.callee = fault_callee_regs;
+	esf_copy.extra_info.exc_return = exc_return;
+	esf_copy.extra_info.msp = msp;
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
 
 	/* Overwrite stacked IPSR to mark a nested exception,

--- a/arch/arm/core/fatal.c
+++ b/arch/arm/core/fatal.c
@@ -74,6 +74,18 @@ static void esf_dump(const struct arch_esf *esf)
 
 	EXCEPTION_DUMP("EXC_RETURN: 0x%0x", esf->extra_info.exc_return);
 
+#if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+	EXCEPTION_DUMP("Non-Secure: %s", esf->extra_info.non_secure ? "true" : "false");
+	EXCEPTION_DUMP("%s: 0x%08x", "SFSR", esf->extra_info.sfsr);
+	EXCEPTION_DUMP("%s: 0x%08x", "SFAR", esf->extra_info.sfar);
+#endif /* CONFIG_ARM_SECURE_FIRMWARE*/
+	EXCEPTION_DUMP("%s: 0x%08x", "CFSR", esf->extra_info.cfsr);
+	EXCEPTION_DUMP("%s: 0x%08x", "HFSR", esf->extra_info.hfsr);
+	EXCEPTION_DUMP("%s: 0x%08x", "DFSR", esf->extra_info.dfsr);
+	EXCEPTION_DUMP("%s: 0x%08x", "MMFAR", esf->extra_info.mmfar);
+	EXCEPTION_DUMP("%s: 0x%08x", "BFAR", esf->extra_info.bfar);
+#endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
 	EXCEPTION_DUMP("Faulting instruction address (r15/pc): 0x%08x",
 		esf->basic.pc);

--- a/include/zephyr/arch/arm/cortex_m/exception.h
+++ b/include/zephyr/arch/arm/cortex_m/exception.h
@@ -98,6 +98,20 @@ struct __extra_esf_info {
 	_callee_saved_t *callee;
 	uint32_t msp;
 	uint32_t exc_return;
+#if defined(CONFIG_ARMV7_M_ARMV8_M_MAINLINE)
+	/* System control registers inspected and/or modified during fault handling */
+	uint32_t cfsr;
+	uint32_t hfsr;
+	uint32_t dfsr;
+	uint32_t mmfar;
+	uint32_t bfar;
+#if defined(CONFIG_ARM_SECURE_FIRMWARE)
+	uint32_t sfsr;
+	uint32_t sfar;
+	/* Exception entry occurred in Non-Secure stack */
+	bool non_secure;
+#endif /* CONFIG_ARM_SECURE_FIRMWARE*/
+#endif /* CONFIG_ARMV7_M_ARMV8_M_MAINLINE */
 };
 #endif /* CONFIG_EXTRA_EXCEPTION_INFO */
 


### PR DESCRIPTION
…s to extra_info

During fault handling on the cortex-m, namely ARMV7_M_ARMV8_M_MAINLINE, some system control registers are modified before reaching z_fatal_error(). Applications may want to inspect the state of these registers at time of fault from within k_sys_fatal_error_handler().

- Extend struct __extra_esf_info with the following relevant system control registers:

    - CFSR
    - HFSR
    - DFSR
    - MMFAR
    - BFAR

  and extend it with the following SAU registers if
  CONFIG_ARM_SECURE_FIRMWARE=y

    - SFSR
    - SFAR

  and the following field indicating whether the ESF is from the
  non-secure stack

    - bool non_secure

- Update z_arm_fault() to snapshot these registers into the esf copy extra_info before fault handling touches any of them.

- Extend esf_dump() to include these registers in case they are present. If CONFIG_ARM_SECURE_FIRMWARE=y, the value of the non_secure member is dumped, preceeding the system registers, to indicate whether the SCB registers are from the SCB or SCB_NS instance.

Signed-off-by: Bjarki Arge Andreasen <bjarki.andreasen@nordicsemi.no>

Upstream PR #: 112100