### PR TITLE
[nrf fromtree] net: ipv6: route: avoid net_nbr_get_lladdr() when neighbor LL is unknown

### DIFF
--- a/subsys/net/ip/route_ipv6.c
+++ b/subsys/net/ip/route_ipv6.c
@@ -514,6 +514,12 @@ int net_route_ipv6_packet(struct net_pkt *pkt, const struct net_in6_addr *nextho
 	    net_route_ll_addr_supported(out_iface) &&
 	    net_route_ll_addr_supported(net_pkt_iface(pkt)) &&
 	    net_route_ll_addr_supported(net_pkt_orig_iface(pkt))) {
+		if (nbr->idx == NET_NBR_LLADDR_UNKNOWN) {
+			NET_DBG("Neighbor %s has no link-layer (idx unknown)",
+				net_sprint_ipv6_addr(nexthop));
+			return -ESRCH;
+		}
+
 		lladdr = net_nbr_get_lladdr(nbr->idx);
 		if (lladdr == NULL) {
 			NET_DBG("Cannot find %s neighbor link layer address.",


### PR DESCRIPTION
Neighbors can exist with NET_NBR_LLADDR_UNKNOWN. Passing that idx to net_nbr_get_lladdr() trips the bounds assert in nbr.c. Return -ESRCH from net_route_ipv6_packet() before resolving LL when idx is unknown inside the net_route_ll_addr_supported() path. Fixes assert-driven failures when forwarding via nexthops without a linked link-layer address.

Signed-off-by: Jani Hirsimäki <jani.hirsimaki@nordicsemi.no>
(cherry picked from commit b0b0e8973d1967114adbb9ed1611d448b5a46519)