### PR TITLE
[nrf fromlist] tests: arch: derive Nordic VPR test IRQ lines from dev…

### DIFF
--- a/tests/arch/common/gen_isr_table/src/main.c
+++ b/tests/arch/common/gen_isr_table/src/main.c
@@ -31,23 +31,21 @@ extern const uintptr_t _irq_vector_table[];
 
 #if defined(CONFIG_NRFX_CLIC)
 
-#if (defined(CONFIG_SOC_SERIES_NRF54L) || defined(CONFIG_SOC_NRF54H20_CPUFLPR)) && \
-	defined(CONFIG_RISCV_CORE_NORDIC_VPR)
-#define ISR1_OFFSET	16
-#define ISR3_OFFSET	17
-#define ISR5_OFFSET	18
-#define TRIG_CHECK_SIZE	19
-#elif (defined(CONFIG_SOC_SERIES_NRF54H) || defined(CONFIG_SOC_SERIES_NRF92)) && \
-	defined(CONFIG_RISCV_CORE_NORDIC_VPR)
-#define ISR1_OFFSET	14
-#define ISR3_OFFSET	15
-#define ISR5_OFFSET	16
-#define TRIG_CHECK_SIZE	17
-#elif defined(CONFIG_SOC_SERIES_NRF71) && defined(CONFIG_RISCV_CORE_NORDIC_VPR)
-#define ISR1_OFFSET	16
-#define ISR3_OFFSET	21
-#define ISR5_OFFSET	22
-#define TRIG_CHECK_SIZE	23
+/* Software-triggerable VEVIF task lines of a Nordic VPR core. */
+#define VPR_VEVIF_NODE		DT_INST(0, nordic_nrf_vevif_task_rx)
+#define VPR_VEVIF_IRQ(idx)	DT_IRQ_BY_IDX(VPR_VEVIF_NODE, idx, irq)
+#define VPR_VEVIF_LAST_IDX	UTIL_DEC(DT_NUM_IRQS(VPR_VEVIF_NODE))
+
+#if defined(CONFIG_RISCV_CORE_NORDIC_VPR) && DT_NODE_EXISTS(VPR_VEVIF_NODE)
+/*
+ * On Nordic VPR cores, the VEVIF task lines are the only CLIC lines that are not
+ * wired to a peripheral, so use the three highest ones.  The VEVIF mailbox is not
+ * enabled in this test, meaning its driver does not claim these lines.
+ */
+#define ISR1_OFFSET	VPR_VEVIF_IRQ(UTIL_DEC(UTIL_DEC(VPR_VEVIF_LAST_IDX)))
+#define ISR3_OFFSET	VPR_VEVIF_IRQ(UTIL_DEC(VPR_VEVIF_LAST_IDX))
+#define ISR5_OFFSET	VPR_VEVIF_IRQ(VPR_VEVIF_LAST_IDX)
+#define TRIG_CHECK_SIZE	(ISR5_OFFSET + 1)
 #else
 #error "Target not supported"
 #endif

--- a/tests/arch/common/interrupt/src/nested_irq.c
+++ b/tests/arch/common/interrupt/src/nested_irq.c
@@ -21,6 +21,13 @@
 #define ISR0_TOKEN	0xDEADBEEF
 #define ISR1_TOKEN	0xCAFEBABE
 
+#if defined(CONFIG_RISCV_CORE_NORDIC_VPR)
+/* Software-triggerable VEVIF task lines of a Nordic VPR core, see below. */
+#define VPR_VEVIF_NODE		DT_INST(0, nordic_nrf_vevif_task_rx)
+#define VPR_VEVIF_IRQ(idx)	DT_IRQ_BY_IDX(VPR_VEVIF_NODE, idx, irq)
+#define VPR_VEVIF_LAST_IDX	UTIL_DEC(DT_NUM_IRQS(VPR_VEVIF_NODE))
+#endif
+
 /*
  * This test uses two IRQ lines selected within the range of available IRQs on
  * the target SoC.  These IRQs are platform and interrupt controller-specific,
@@ -62,23 +69,14 @@
  */
 #define IRQ0_PRIO	IRQ_DEFAULT_PRIORITY
 #define IRQ1_PRIO	0x0
-#elif (defined(CONFIG_SOC_SERIES_NRF54L) || defined(CONFIG_SOC_NRF54H20_CPUFLPR)) && \
-	defined(CONFIG_RISCV_CORE_NORDIC_VPR)
-#define IRQ0_LINE	16
-#define IRQ1_LINE	17
-
-#define IRQ0_PRIO	1
-#define IRQ1_PRIO	2
-#elif (defined(CONFIG_SOC_SERIES_NRF54H) || defined(CONFIG_SOC_SERIES_NRF92)) && \
-	defined(CONFIG_RISCV_CORE_NORDIC_VPR)
-#define IRQ0_LINE	14
-#define IRQ1_LINE	15
-
-#define IRQ0_PRIO	1
-#define IRQ1_PRIO	2
-#elif defined(CONFIG_SOC_SERIES_NRF71) && defined(CONFIG_RISCV_CORE_NORDIC_VPR)
-#define IRQ0_LINE	19
-#define IRQ1_LINE	20
+#elif defined(CONFIG_RISCV_CORE_NORDIC_VPR) && DT_NODE_EXISTS(VPR_VEVIF_NODE)
+/*
+ * On Nordic VPR cores, the VEVIF task lines are the only CLIC lines that are not
+ * wired to a peripheral, so use the two highest ones.  The VEVIF mailbox is not
+ * enabled in this test, meaning its driver does not claim these lines.
+ */
+#define IRQ0_LINE	VPR_VEVIF_IRQ(VPR_VEVIF_LAST_IDX)
+#define IRQ1_LINE	VPR_VEVIF_IRQ(UTIL_DEC(VPR_VEVIF_LAST_IDX))
 
 #define IRQ0_PRIO	1
 #define IRQ1_PRIO	2


### PR DESCRIPTION
…icetree

The gen_isr_table and interrupt tests both select their test IRQ lines on Nordic VPR cores from a hardcoded ladder of SOC_SERIES conditionals. The values in that ladder are VEVIF task lines, which devicetree already describes: every VPR core has a nordic,nrf-vevif-task-rx mailbox node whose interrupts property enumerates the CLIC lines that are not wired to a peripheral and can therefore be triggered from software. The node is disabled in both tests, so the VEVIF mailbox driver does not claim those lines.

Read the lines from that node instead, taking the highest ones: the two highest for the nested interrupt test and the three highest for gen_isr_table. Selecting from the top rather than the bottom keeps the choice inside nordic,tasks-mask on every target, as the nRF54H20 reserves the low tasks for other domains (0-3 on the PPR, 0-15 on the FLPR).

The lines picked on the already-listed targets change, and all remain within the VEVIF range and the task mask. The nested interrupt test moves from 16/17 to 21/22 on the nRF54L and nRF71 FLPR, from 19/20 to 21/22 on the nRF71 FLPR, from 16/17 to 30/31 on the nRF54H20 FLPR, and is unchanged at 14/15 on the nRF54H20 and nRF92 PPR. gen_isr_table moves to 20/21/22 on the nRF54L and nRF71 FLPR, 29/30/31 on the nRF54H20 FLPR, and 13/14/15 on the nRF54H20 and nRF92 PPR.

Assisted-by: Claude:claude-opus-5
Signed-off-by: Łukasz Stępnicki <lukasz.stepnicki@nordicsemi.no>

Upstream PR #: 118596