### PR TITLE
drivers: pinctrl: nRF Add generic VPR VIO support

### DIFF
--- a/drivers/misc/nordic_vpr_launcher/Kconfig
+++ b/drivers/misc/nordic_vpr_launcher/Kconfig
@@ -6,6 +6,8 @@ config NORDIC_VPR_LAUNCHER
 	default y
 	depends on DT_HAS_NORDIC_NRF_VPR_COPROCESSOR_ENABLED && \
 		   $(dt_compat_any_has_prop,$(DT_COMPAT_NORDIC_NRF_VPR_COPROCESSOR),execution-memory)
+	select PINCTRL if \
+		$(dt_compat_any_has_prop,$(DT_COMPAT_NORDIC_NRF_VPR_COPROCESSOR),pinctrl-0)
 	help
 	  When enabled, the VPR coprocessors will be automatically launched
 	  during system initialization.

--- a/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
+++ b/drivers/misc/nordic_vpr_launcher/nordic_vpr_launcher.c
@@ -13,6 +13,9 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/toolchain.h>
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+#include <zephyr/drivers/pinctrl.h>
+#endif
 
 #include <hal/nrf_vpr.h>
 #if (DT_ANY_INST_HAS_BOOL_STATUS_OKAY(enable_secure) || \
@@ -38,6 +41,9 @@ struct nordic_vpr_launcher_config {
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block)
 	int32_t ram_block_id;
 #endif
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+	const struct pinctrl_dev_config *pcfg;
+#endif
 };
 
 /* Determine if all code that will be copied is 8 byte aligned. If yes then optimized
@@ -58,6 +64,18 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 	if (config->exec_addr == 0) {
 		return 0;
 	}
+
+#if DT_ANY_INST_HAS_PROP_STATUS_OKAY(pinctrl_0)
+	/* Apply the pin configuration (routing, drive, pull) for VPR-owned pins. */
+	if (config->pcfg != NULL) {
+		int ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+
+		if (ret < 0) {
+			LOG_ERR("Failed to apply pinctrl state (%d)", ret);
+			return ret;
+		}
+	}
+#endif
 
 #if DT_ANY_INST_HAS_PROP_STATUS_OKAY(source_memory)
 	if (config->size > 0U) {
@@ -123,6 +141,8 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 				  DT_REG_SIZE(DT_INST_PHANDLE(inst, source_memory))),              \
 				 "Execution memory exceeds source memory size");))                 \
                                                                                                    \
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pinctrl_0), (PINCTRL_DT_INST_DEFINE(inst);))        \
+                                                                                                   \
 	static const struct nordic_vpr_launcher_config config##inst = {                            \
 		.vpr = (NRF_VPR_Type *)DT_INST_REG_ADDR(inst),                                     \
 		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, execution_memory),                          \
@@ -134,6 +154,8 @@ static int nordic_vpr_launcher_init(const struct device *dev)
 			    .size = DT_REG_SIZE(DT_INST_PHANDLE(inst, execution_memory)),))        \
 		IF_ENABLED(DT_ANY_INST_HAS_PROP_STATUS_OKAY(hibernation_ram_block),                \
 			   (.ram_block_id = DT_INST_PROP_OR(inst, hibernation_ram_block, -1),))    \
+		IF_ENABLED(DT_INST_NODE_HAS_PROP(inst, pinctrl_0),                                 \
+			   (.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),))                        \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(inst, nordic_vpr_launcher_init, NULL, NULL, &config##inst,           \

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -110,18 +110,6 @@ static const nrf_gpio_pin_drive_t drive_modes[NRF_DRIVE_COUNT] = {
 #define NRF_PSEL_TDM(reg, line) ((NRF_TDM_Type *)reg)->PSEL.line
 #endif
 
-#if DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || \
-	defined(CONFIG_MSPI_HPF) || \
-	DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0)
-#if defined(CONFIG_SOC_SERIES_NRF54L)
-#define NRF_PSEL_SDP_MSPI(psel) \
-	nrf_gpio_pin_control_select(psel, NRF_GPIO_PIN_SEL_VPR);
-#elif defined(CONFIG_SOC_SERIES_NRF54H)
-/* On nRF54H, pin routing is controlled by secure domain, via UICR. */
-#define NRF_PSEL_SDP_MSPI(psel)
-#endif
-#endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || ... */
-
 #if NRF_GPIO_HAS_RETENTION_SETCLEAR
 
 static void port_pin_retain_set(uint16_t pin_number, bool enable)
@@ -511,26 +499,6 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_mspi) */
-#if defined(NRF_PSEL_SDP_MSPI)
-		case NRF_FUN_SDP_MSPI_CS0:
-		case NRF_FUN_SDP_MSPI_CS1:
-		case NRF_FUN_SDP_MSPI_CS2:
-		case NRF_FUN_SDP_MSPI_CS3:
-		case NRF_FUN_SDP_MSPI_CS4:
-		case NRF_FUN_SDP_MSPI_SCK:
-		case NRF_FUN_SDP_MSPI_DQ0:
-		case NRF_FUN_SDP_MSPI_DQ1:
-		case NRF_FUN_SDP_MSPI_DQ2:
-		case NRF_FUN_SDP_MSPI_DQ3:
-		case NRF_FUN_SDP_MSPI_DQ4:
-		case NRF_FUN_SDP_MSPI_DQ5:
-		case NRF_FUN_SDP_MSPI_DQ6:
-		case NRF_FUN_SDP_MSPI_DQ7:
-			NRF_PSEL_SDP_MSPI(psel);
-			dir = NRF_GPIO_PIN_DIR_OUTPUT;
-			input = NRF_GPIO_PIN_INPUT_CONNECT;
-			break;
-#endif /* defined(NRF_PSEL_SDP_MSPI) */
 #if defined(NRF_PSEL_TWIS)
 		case NRF_FUN_TWIS_SCL:
 			NRF_PSEL_TWIS(reg, SCL) = psel;

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -110,7 +110,9 @@ static const nrf_gpio_pin_drive_t drive_modes[NRF_DRIVE_COUNT] = {
 #define NRF_PSEL_TDM(reg, line) ((NRF_TDM_Type *)reg)->PSEL.line
 #endif
 
-#if DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0)
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || \
+	defined(CONFIG_MSPI_HPF) || \
+	DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0)
 #if NRF_GPIO_HAS_SEL
 #define NRF_PSEL_VPR_VIO(psel) \
 	nrf_gpio_pin_control_select(psel, NRF_GPIO_PIN_SEL_VPR);
@@ -118,7 +120,7 @@ static const nrf_gpio_pin_drive_t drive_modes[NRF_DRIVE_COUNT] = {
 /* Pin routing is controlled by the secure domain, via UICR. */
 #define NRF_PSEL_VPR_VIO(psel)
 #endif
-#endif /* DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0) */
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_hpf_mspi_controller) || ... */
 
 #if NRF_GPIO_HAS_RETENTION_SETCLEAR
 
@@ -510,6 +512,20 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			break;
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_mspi) */
 #if defined(NRF_PSEL_VPR_VIO)
+		case NRF_FUN_SDP_MSPI_CS0:
+		case NRF_FUN_SDP_MSPI_CS1:
+		case NRF_FUN_SDP_MSPI_CS2:
+		case NRF_FUN_SDP_MSPI_CS3:
+		case NRF_FUN_SDP_MSPI_CS4:
+		case NRF_FUN_SDP_MSPI_SCK:
+		case NRF_FUN_SDP_MSPI_DQ0:
+		case NRF_FUN_SDP_MSPI_DQ1:
+		case NRF_FUN_SDP_MSPI_DQ2:
+		case NRF_FUN_SDP_MSPI_DQ3:
+		case NRF_FUN_SDP_MSPI_DQ4:
+		case NRF_FUN_SDP_MSPI_DQ5:
+		case NRF_FUN_SDP_MSPI_DQ6:
+		case NRF_FUN_SDP_MSPI_DQ7:
 		case NRF_FUN_VPR_VIO:
 			NRF_PSEL_VPR_VIO(psel);
 			dir = NRF_GPIO_PIN_DIR_OUTPUT;

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -110,6 +110,16 @@ static const nrf_gpio_pin_drive_t drive_modes[NRF_DRIVE_COUNT] = {
 #define NRF_PSEL_TDM(reg, line) ((NRF_TDM_Type *)reg)->PSEL.line
 #endif
 
+#if DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0)
+#if NRF_GPIO_HAS_SEL
+#define NRF_PSEL_VPR_VIO(psel) \
+	nrf_gpio_pin_control_select(psel, NRF_GPIO_PIN_SEL_VPR);
+#else
+/* Pin routing is controlled by the secure domain, via UICR. */
+#define NRF_PSEL_VPR_VIO(psel)
+#endif
+#endif /* DT_ANY_COMPAT_HAS_PROP_STATUS_OKAY(nordic_nrf_vpr_coprocessor, pinctrl_0) */
+
 #if NRF_GPIO_HAS_RETENTION_SETCLEAR
 
 static void port_pin_retain_set(uint16_t pin_number, bool enable)
@@ -499,6 +509,13 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 #endif /* DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_mspi) */
+#if defined(NRF_PSEL_VPR_VIO)
+		case NRF_FUN_VPR_VIO:
+			NRF_PSEL_VPR_VIO(psel);
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
+			break;
+#endif /* defined(NRF_PSEL_VPR_VIO) */
 #if defined(NRF_PSEL_TWIS)
 		case NRF_FUN_TWIS_SCL:
 			NRF_PSEL_TWIS(reg, SCL) = psel;

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -184,64 +184,6 @@
 #define NRF_FUN_GRTC_CLKOUT_FAST 55U
 /** GRTC slow clock output */
 #define NRF_FUN_GRTC_CLKOUT_32K  56U
-/** SDP_MSPI clock pin */
-#define NRF_FUN_SDP_MSPI_SCK 57U
-/** SDP_MSPI data pin 0 */
-#define NRF_FUN_SDP_MSPI_DQ0 58U
-/** SDP_MSPI data pin 1 */
-#define NRF_FUN_SDP_MSPI_DQ1 59U
-/** SDP_MSPI data pin 2 */
-#define NRF_FUN_SDP_MSPI_DQ2 60U
-/** SDP_MSPI data pin 3 */
-#define NRF_FUN_SDP_MSPI_DQ3 61U
-/** SDP_MSPI data pin 4 */
-#define NRF_FUN_SDP_MSPI_DQ4 62U
-/** SDP_MSPI data pin 5 */
-#define NRF_FUN_SDP_MSPI_DQ5 63U
-/** SDP_MSPI data pin 6 */
-#define NRF_FUN_SDP_MSPI_DQ6 64U
-/** SDP_MSPI data pin 7 */
-#define NRF_FUN_SDP_MSPI_DQ7 65U
-/** SDP_MSPI chip select 0 */
-#define NRF_FUN_SDP_MSPI_CS0 66U
-/** SDP_MSPI chip select 1 */
-#define NRF_FUN_SDP_MSPI_CS1 67U
-/** SDP_MSPI chip select 2 */
-#define NRF_FUN_SDP_MSPI_CS2 68U
-/** SDP_MSPI chip select 3 */
-#define NRF_FUN_SDP_MSPI_CS3 69U
-/** SDP_MSPI chip select 4 */
-#define NRF_FUN_SDP_MSPI_CS4 70U
-/** Generic soft peripheral pin */
-#define NRF_FUN_SP_PIN       NRF_FUN_SDP_MSPI_SCK
-/** High-Performance Framework MSPI clock pin */
-#define NRF_FUN_HPF_MSPI_SCK NRF_FUN_SDP_MSPI_SCK
-/** High-Performance Framework MSPI data pin 0 */
-#define NRF_FUN_HPF_MSPI_DQ0 NRF_FUN_SDP_MSPI_DQ0
-/** High-Performance Framework MSPI data pin 1 */
-#define NRF_FUN_HPF_MSPI_DQ1 NRF_FUN_SDP_MSPI_DQ1
-/** High-Performance Framework MSPI data pin 2 */
-#define NRF_FUN_HPF_MSPI_DQ2 NRF_FUN_SDP_MSPI_DQ2
-/** High-Performance Framework MSPI data pin 3 */
-#define NRF_FUN_HPF_MSPI_DQ3 NRF_FUN_SDP_MSPI_DQ3
-/** High-Performance Framework MSPI data pin 4 */
-#define NRF_FUN_HPF_MSPI_DQ4 NRF_FUN_SDP_MSPI_DQ4
-/** High-Performance Framework MSPI data pin 5 */
-#define NRF_FUN_HPF_MSPI_DQ5 NRF_FUN_SDP_MSPI_DQ5
-/** High-Performance Framework MSPI data pin 6 */
-#define NRF_FUN_HPF_MSPI_DQ6 NRF_FUN_SDP_MSPI_DQ6
-/** High-Performance Framework MSPI data pin 7 */
-#define NRF_FUN_HPF_MSPI_DQ7 NRF_FUN_SDP_MSPI_DQ7
-/** High-Performance Framework MSPI chip select pin 0 */
-#define NRF_FUN_HPF_MSPI_CS0 NRF_FUN_SDP_MSPI_CS0
-/** High-Performance Framework MSPI chip select pin 1 */
-#define NRF_FUN_HPF_MSPI_CS1 NRF_FUN_SDP_MSPI_CS1
-/** High-Performance Framework MSPI chip select pin 2 */
-#define NRF_FUN_HPF_MSPI_CS2 NRF_FUN_SDP_MSPI_CS2
-/** High-Performance Framework MSPI chip select pin 3 */
-#define NRF_FUN_HPF_MSPI_CS3 NRF_FUN_SDP_MSPI_CS3
-/** High-Performance Framework MSPI chip select pin 4 */
-#define NRF_FUN_HPF_MSPI_CS4 NRF_FUN_SDP_MSPI_CS4
 /** TDM SCK in master mode */
 #define NRF_FUN_TDM_SCK_M        71U
 /** TDM SCK in slave mode */

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -184,6 +184,8 @@
 #define NRF_FUN_GRTC_CLKOUT_FAST 55U
 /** GRTC slow clock output */
 #define NRF_FUN_GRTC_CLKOUT_32K  56U
+/** VPR VIO (pin controlled by a VPR through its VIO interface) */
+#define NRF_FUN_VPR_VIO          57U
 /** TDM SCK in master mode */
 #define NRF_FUN_TDM_SCK_M        71U
 /** TDM SCK in slave mode */

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -186,6 +186,64 @@
 #define NRF_FUN_GRTC_CLKOUT_32K  56U
 /** VPR VIO (pin controlled by a VPR through its VIO interface) */
 #define NRF_FUN_VPR_VIO          57U
+/** SDP_MSPI clock pin */
+#define NRF_FUN_SDP_MSPI_SCK NRF_FUN_VPR_VIO
+/** SDP_MSPI data pin 0 */
+#define NRF_FUN_SDP_MSPI_DQ0 58U
+/** SDP_MSPI data pin 1 */
+#define NRF_FUN_SDP_MSPI_DQ1 59U
+/** SDP_MSPI data pin 2 */
+#define NRF_FUN_SDP_MSPI_DQ2 60U
+/** SDP_MSPI data pin 3 */
+#define NRF_FUN_SDP_MSPI_DQ3 61U
+/** SDP_MSPI data pin 4 */
+#define NRF_FUN_SDP_MSPI_DQ4 62U
+/** SDP_MSPI data pin 5 */
+#define NRF_FUN_SDP_MSPI_DQ5 63U
+/** SDP_MSPI data pin 6 */
+#define NRF_FUN_SDP_MSPI_DQ6 64U
+/** SDP_MSPI data pin 7 */
+#define NRF_FUN_SDP_MSPI_DQ7 65U
+/** SDP_MSPI chip select 0 */
+#define NRF_FUN_SDP_MSPI_CS0 66U
+/** SDP_MSPI chip select 1 */
+#define NRF_FUN_SDP_MSPI_CS1 67U
+/** SDP_MSPI chip select 2 */
+#define NRF_FUN_SDP_MSPI_CS2 68U
+/** SDP_MSPI chip select 3 */
+#define NRF_FUN_SDP_MSPI_CS3 69U
+/** SDP_MSPI chip select 4 */
+#define NRF_FUN_SDP_MSPI_CS4 70U
+/** Generic soft peripheral pin */
+#define NRF_FUN_SP_PIN       NRF_FUN_VPR_VIO
+/** High-Performance Framework MSPI clock pin */
+#define NRF_FUN_HPF_MSPI_SCK NRF_FUN_SDP_MSPI_SCK
+/** High-Performance Framework MSPI data pin 0 */
+#define NRF_FUN_HPF_MSPI_DQ0 NRF_FUN_SDP_MSPI_DQ0
+/** High-Performance Framework MSPI data pin 1 */
+#define NRF_FUN_HPF_MSPI_DQ1 NRF_FUN_SDP_MSPI_DQ1
+/** High-Performance Framework MSPI data pin 2 */
+#define NRF_FUN_HPF_MSPI_DQ2 NRF_FUN_SDP_MSPI_DQ2
+/** High-Performance Framework MSPI data pin 3 */
+#define NRF_FUN_HPF_MSPI_DQ3 NRF_FUN_SDP_MSPI_DQ3
+/** High-Performance Framework MSPI data pin 4 */
+#define NRF_FUN_HPF_MSPI_DQ4 NRF_FUN_SDP_MSPI_DQ4
+/** High-Performance Framework MSPI data pin 5 */
+#define NRF_FUN_HPF_MSPI_DQ5 NRF_FUN_SDP_MSPI_DQ5
+/** High-Performance Framework MSPI data pin 6 */
+#define NRF_FUN_HPF_MSPI_DQ6 NRF_FUN_SDP_MSPI_DQ6
+/** High-Performance Framework MSPI data pin 7 */
+#define NRF_FUN_HPF_MSPI_DQ7 NRF_FUN_SDP_MSPI_DQ7
+/** High-Performance Framework MSPI chip select pin 0 */
+#define NRF_FUN_HPF_MSPI_CS0 NRF_FUN_SDP_MSPI_CS0
+/** High-Performance Framework MSPI chip select pin 1 */
+#define NRF_FUN_HPF_MSPI_CS1 NRF_FUN_SDP_MSPI_CS1
+/** High-Performance Framework MSPI chip select pin 2 */
+#define NRF_FUN_HPF_MSPI_CS2 NRF_FUN_SDP_MSPI_CS2
+/** High-Performance Framework MSPI chip select pin 3 */
+#define NRF_FUN_HPF_MSPI_CS3 NRF_FUN_SDP_MSPI_CS3
+/** High-Performance Framework MSPI chip select pin 4 */
+#define NRF_FUN_HPF_MSPI_CS4 NRF_FUN_SDP_MSPI_CS4
 /** TDM SCK in master mode */
 #define NRF_FUN_TDM_SCK_M        71U
 /** TDM SCK in slave mode */


### PR DESCRIPTION
- Revert old NOUP MSPI specific implementation.
- Cherry pick generic VPR VIO pin support from upstream PR.
- RE-apply MSPI specific pins
- Add support to configure drivestrength from devicetree.